### PR TITLE
Append git sha to versioned source artifact name

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -148,57 +148,6 @@ jobs:
 
           echo ::set-output name=result::"${result}"
 
-  versioned_merge:
-    name: Versioned merge
-    runs-on: ubuntu-latest
-    # only run on PR merge events
-    if: github.event_name == 'pull_request' && github.base_ref == github.event.repository.default_branch && github.event.action == 'closed' && github.event.pull_request.merged == true
-
-    defaults:
-      run:
-        working-directory: .
-        shell: bash
-
-    steps:
-      - name: Download artifact
-        id: download
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.FLOWZONE_TOKEN }}
-          workflow_conclusion: success
-          pr: ${{ github.event.pull_request.number }}
-          name: versioned-source
-
-      - name: Extract source
-        run: tar -xvf versioned-source.tar
-
-      - name: Import GPG key for signing commits
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@v4
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      # TODO: how can we check that master hasn't changed since this PR was merged?
-      - name: Push versioned commit
-        env:
-          BRANCH: ${{ github.base_ref }}
-          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
-        run: |
-          REV="$(git rev-parse HEAD)"
-          VERSION="v$(head -n1 VERSION || jq -r '.version' package.json)"
-          git fetch origin ${BRANCH}:${BRANCH}
-          git checkout ${BRANCH}
-          git cherry-pick ${REV}
-          git tag -a "${VERSION}" -m "${VERSION}"
-          git push origin HEAD:${BRANCH} --follow-tags
-
   versioned_source:
     name: Versioned source
     runs-on: ubuntu-latest
@@ -221,7 +170,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: versionbot/pr/${{ github.event.pull_request.number }}
-          fetch-depth: 2
+          fetch-depth: 1
           token: ${{ secrets.FLOWZONE_TOKEN }}
 
       # Fallback to unversioned source if versionbot branch does not exist
@@ -239,7 +188,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: versioned-source
+          name: versioned-source-${{ github.sha }}
           path: /tmp/versioned-source.tar
 
   eval_source:
@@ -262,7 +211,7 @@ jobs:
       - name: Download versioned source
         uses: actions/download-artifact@v3
         with:
-          name: versioned-source
+          name: versioned-source-${{ github.sha }}
 
       - name: Extract versioned source
         working-directory: .
@@ -403,7 +352,7 @@ jobs:
       - name: Download versioned source
         uses: actions/download-artifact@v3
         with:
-          name: versioned-source
+          name: versioned-source-${{ github.sha }}
 
       - name: Extract versioned source
         working-directory: .
@@ -484,7 +433,7 @@ jobs:
       - name: Download versioned source
         uses: actions/download-artifact@v3
         with:
-          name: versioned-source
+          name: versioned-source-${{ github.sha }}
 
       - name: Extract versioned source
         working-directory: .
@@ -628,7 +577,7 @@ jobs:
       - name: Download versioned source
         uses: actions/download-artifact@v3
         with:
-          name: versioned-source
+          name: versioned-source-${{ github.sha }}
 
       - name: Extract versioned source
         working-directory: .
@@ -649,3 +598,58 @@ jobs:
     steps:
       - shell: bash
         run: echo "balena jobs completed!"
+
+###################################################
+## PR MERGE
+###################################################
+
+  versioned_merge:
+    name: Versioned merge
+    runs-on: ubuntu-latest
+    # only run on PR merge events
+    if: github.event_name == 'pull_request' && github.base_ref == github.event.repository.default_branch && github.event.action == 'closed' && github.event.pull_request.merged == true
+
+    defaults:
+      run:
+        working-directory: .
+        shell: bash
+
+    steps:
+      - name: Download artifact
+        id: download
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.FLOWZONE_TOKEN }}
+          workflow_conclusion: success
+          pr: ${{ github.event.pull_request.number }}
+          name: versioned-source-${{ github.sha }}
+
+      - name: Extract source
+        run: tar -xvf versioned-source.tar
+
+      - name: Import GPG key for signing commits
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      # TODO: how can we check that master hasn't changed since this PR was merged?
+      - name: Push versioned commit
+        env:
+          BRANCH: ${{ github.base_ref }}
+          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
+        run: |
+          REV="$(git rev-parse HEAD)"
+          VERSION="v$(head -n1 VERSION || jq -r '.version' package.json)"
+          git fetch origin ${BRANCH}:${BRANCH}
+          git checkout ${BRANCH}
+          git cherry-pick ${REV}
+          git tag -a "${VERSION}" -m "${VERSION}"
+          git push origin HEAD:${BRANCH} --follow-tags

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -627,6 +627,12 @@ jobs:
       - name: Extract source
         run: tar -xvf versioned-source.tar
 
+      - name: Parse version
+        id: version
+        run: |
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "::set-output name=value::v$(head -n1 VERSION || jq -r '.version' package.json)"
+
       - name: Import GPG key for signing commits
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v4
@@ -645,9 +651,9 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
           GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          VERSION: ${{ steps.version.outputs.value }}
+          REV: ${{ steps.version.outputs.sha }}
         run: |
-          REV="$(git rev-parse HEAD)"
-          VERSION="v$(head -n1 VERSION || jq -r '.version' package.json)"
           git fetch origin ${BRANCH}:${BRANCH}
           git checkout ${BRANCH}
           git cherry-pick ${REV}


### PR DESCRIPTION
This should ensure that related jobs always download the
correct artifact.

CHange-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>