### PR TITLE
Allow PRs without a change type to publish draft releases

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -329,7 +329,7 @@ jobs:
         shell: ${{ needs.context_check.outputs.shell }}
 
     outputs:
-      tag: ${{ steps.versionist.outputs.tag }}
+      new_tag: ${{ steps.versionist.outputs.new_tag }}
       version: ${{ steps.versionist.outputs.version }}
 
     steps:
@@ -350,40 +350,49 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
+      # call balena-versionist with a default repo type for now
+      # (TODO: call versionist directly with sane configuration defaults)
+      # set the version output only if it could be extracted from the changelog
+      # set the new_tag output only if versionist modified some files (version has changed)
+      # this allows PRs with no change type to proceed with draft releases
       - name: Run versionist
         id: versionist
         if: inputs.skip_versioning == false
         run: |
-          test -f repo.yml || echo 'type: node' > repo.yml
+          test -f repo.yml || echo 'type: generic' > repo.yml
           npm install -g balena-versionist versionist
           balena-versionist
-          git status --porcelain
-          if [ -n "$(git status --porcelain)" ]
+
+          version="$(grep '^## ' CHANGELOG.md | head -n1 | awk '{print $2}')"
+          if [ -n "${version}" ]
           then
-            version="$(grep '^## ' CHANGELOG.md | head -n1 | awk '{print $2}')"
-            if [ -n "${version}" ]
+            echo "::set-output name=version::${version}"
+
+            git status --porcelain
+            if [ -n "$(git status --porcelain)" ]
             then
-              echo "::set-output name=tag::v${version}"
-              echo "::set-output name=version::${version}"
+              echo "::set-output name=new_tag::v${version}"
             fi
           fi
 
+      # create a versioned commit only if the the version has changed
       - name: Create versioned commit
-        if: steps.versionist.outputs.tag != ''
+        if: steps.versionist.outputs.new_tag != ''
         env:
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
           GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          TAG: ${{ steps.versionist.outputs.tag }}
+          TAG: ${{ steps.versionist.outputs.new_tag }}
         run: |
           git add --all
           git commit -m "${TAG}" --allow-empty
           git tag -a "${TAG}" -m "${TAG}"
           git log -n 2
 
+      # push the versioned commit only if the PR is merged
       - name: Push versioned commit
-        if: github.event.pull_request.merged == true && steps.versionist.outputs.tag != ''
+        if: github.event.pull_request.merged == true && steps.versionist.outputs.new_tag != ''
         run: |
           git push origin HEAD:${{ github.base_ref }} --follow-tags
 


### PR DESCRIPTION
Failures are still expected on merge as npm cannot overwrite a release.

Signed-off-by: Kyle Harding <kyle@balena.io>