### PR TITLE
Force tagging because the previous commit must not have merged

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -390,7 +390,7 @@ jobs:
         run: |
           git add --all
           git commit -m "${TAG}" --allow-empty
-          git tag -a "${TAG}" -m "${TAG}"
+          git tag -a "${TAG}" -m "${TAG}" -f
           git log -n 2
 
       # push the versioned commit only if the PR is merged


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>