### PR TITLE
Revert "Remove resinCI config"

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,1 @@
+disabled: true


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/product-os/balena-concourse/pull/662

This repo still requires that resinCI be disabled via config file. Normally repos [configured with Flowzone will be ignored by resinCI](https://github.com/product-os/balena-concourse/pull/662/commits/ec5bb707973f1758ca6d370de0fed14798441f4b) but this one includes a local path to the workflow and is not detected as using Flowzone.