### PR TITLE
Remove node versions input and limit to 16.x for now

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -55,14 +55,6 @@ on:
         type: string
         required: false
         default: ${{ github.repository }}
-      docker_platforms:
-        description: "Comma-delimited string of Docker target platforms"
-        type: string
-        required: false
-        default: |
-          linux/amd64,
-          linux/arm64,
-          linux/arm/v7
       protect_branch:
         description: "Set to false to disable updating branch protection rules after a successful run"
         type: boolean
@@ -86,6 +78,9 @@ env:
   # TODO: Use engines field of package.json to limit LTS node versions for testing
   # https://github.com/product-os/flowzone/issues/149
   NODE_VERSIONS: 16.x
+  # TODO: Support advanced docker build configuration via docker-compose or bake files
+  # https://github.com/product-os/flowzone/issues/146
+  DOCKER_PLATFORMS: linux/amd64
 
 jobs:
   ###################################################
@@ -128,7 +123,7 @@ jobs:
         id: docker_platforms
         uses: kanga333/json-array-builder@v0.1.0
         env:
-          INPUT: ${{ inputs.docker_platforms }}
+          INPUT: ${{ env.DOCKER_PLATFORMS }}
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -63,14 +63,6 @@ on:
           linux/amd64,
           linux/arm64,
           linux/arm/v7
-      node_versions:
-        description: "Comma-delimited string of Node.js versions to test"
-        type: string
-        required: false
-        default: |
-          14.x,
-          16.x,
-          18.x
       protect_branch:
         description: "Set to false to disable updating branch protection rules after a successful run"
         type: boolean
@@ -91,6 +83,9 @@ env:
   GHCR_USER: "flowzone" # does not seem to matter what is used here
   GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
   NPM_REGISTRY: registry.npmjs.org
+  # TODO: Use engines field of package.json to limit LTS node versions for testing
+  # https://github.com/product-os/flowzone/issues/149
+  NODE_VERSIONS: 16.x
 
 jobs:
   ###################################################
@@ -142,7 +137,7 @@ jobs:
         id: node_versions
         uses: kanga333/json-array-builder@v0.1.0
         env:
-          INPUT: ${{ inputs.node_versions }}
+          INPUT: ${{ env.NODE_VERSIONS }}
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
@@ -174,6 +169,7 @@ jobs:
     outputs:
       npm: ${{ steps.npm.outputs.enabled }}
       npm_private: ${{ steps.npm.outputs.private }} # can be null or unset
+      npm_engines: ${{ steps.npm.outputs.engines }} # can be null or unset
       docker: ${{ steps.docker.outputs.enabled }}
       balena: ${{ steps.balena.outputs.enabled }}
       repo_type: ${{ steps.repo.outputs.type }} # can be null or unset
@@ -197,6 +193,7 @@ jobs:
             echo "found package.json"
             echo "::set-output name=enabled::true"
             echo "::set-output name=private::$(jq -r '.private' package.json)"
+            echo "::set-output name=engines::$(jq -r '.engines' package.json)"
           else
             echo ::set-output name=enabled::"false"
           fi

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`working_directory`](#working_directory)
     - [`docker_images`](#docker_images)
     - [`balena_slugs`](#balena_slugs)
-    - [`docker_platforms`](#docker_platforms)
     - [`protect_branch`](#protect_branch)
     - [`required_approving_review_count`](#required_approving_review_count)
     - [`verbose`](#-verbose-)
@@ -222,14 +221,6 @@ Comma-delimited string of balenaCloud apps, fleets, or blocks to deploy (skipped
 Type: _string_
 
 Default: `${{ github.repository }}`
-
-#### `docker_platforms`
-
-Comma-delimited string of Docker target platforms.
-
-Type: _string_
-
-Default: `linux/amd64,linux/arm64,linux/arm/v7`
 
 #### `protect_branch`
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`docker_images`](#docker_images)
     - [`balena_slugs`](#balena_slugs)
     - [`docker_platforms`](#docker_platforms)
-    - [`node_versions`](#node_versions)
     - [`protect_branch`](#protect_branch)
     - [`required_approving_review_count`](#required_approving_review_count)
     - [`verbose`](#-verbose-)
@@ -107,8 +106,6 @@ Note that these project types are _not_ mutually exclusive, and your project may
 
 These tests will be run if a `package.json` file is found in the root of the repository. If a `package-lock.json` file is found in the root of the repository, dependencies will be install with `npm ci`, otherwise `npm i` will be used.
 If a build script is present in `package.json` it will be called before the tests are run. Testing is done by calling `npm test`.
-
-The [`node_versions`](#node_versions) will determine the Node.js versions used for testing.
 
 To disable publishing of artifacts set `"private": true` in `package.json`.
 
@@ -233,14 +230,6 @@ Comma-delimited string of Docker target platforms.
 Type: _string_
 
 Default: `linux/amd64,linux/arm64,linux/arm/v7`
-
-#### `node_versions`
-
-Comma-delimited string of Node.js versions to test.
-
-Type: _string_
-
-Default: `14.x,16.x,18.x`
 
 #### `protect_branch`
 


### PR DESCRIPTION
This will be replaced by testing a range of LTS releases
defined within the engines.node section of the package.json.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>