### PR TITLE
Set artifact retention days to 1

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -473,6 +473,7 @@ jobs:
         with:
           name: source-${{ github.event.pull_request.head.sha }}
           path: /tmp/source.tar
+          retention-days: 1
 
   ###################################################
   ## npm


### PR DESCRIPTION
We only need artifacts for the lifetime of this workflow
so there is no need for them to live longer than a few minutes.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>