### PR TITLE
Set the buildkit env var so compose can use existing cache

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -595,6 +595,7 @@ jobs:
 
     env:
       COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
+      DOCKER_BUILDKIT: "1"
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>