### PR TITLE
Allow clean jobs to run when a PR is merged

### DIFF
--- a/.github/actions/clean/action.yml
+++ b/.github/actions/clean/action.yml
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
 name: "Clean custom"
-description: "Custom clean step to run after PR is closed and unmerged"
+description: "Custom clean step to run after PR is closed"
 # this inputs are always provided by flowzone, so they must always be defined on the composite action
 inputs:
   json:

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -92,7 +92,7 @@ jobs:
       tagged: ${{ steps.tagged.outcome == 'success' }}
       do_draft: ${{ steps.pr_opened.outcome == 'success' || steps.pr_synchronize.outcome == 'success' }}
       do_final: ${{ steps.pr_merged.outcome == 'success' || steps.tagged.outcome == 'success' }}
-      do_clean: ${{ steps.pr_closed.outcome == 'success' && steps.pr_merged.outcome != 'success' }}
+      do_clean: ${{ steps.pr_closed.outcome == 'success' }}
 
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ A `publish` action will run after all the supported tests have completed. See [p
 
 A `finalize` action will run after a pull request is merged. See [finalize/action.yml](.github/actions/finalize/action.yml) for an example.
 
-A `clean` action will run after a pull request is closed and unmerged. See [clean/action.yml](.github/actions/clean/action.yml) for an example.
+A `clean` action will run after a pull request is closed (including merged). See [clean/action.yml](.github/actions/clean/action.yml) for an example.
 
 More interfaces may be added in the future. Open an issue if you have a use case that is not covered!
 


### PR DESCRIPTION
Composite jobs can check additional conditions like whether
or not the PR was merged.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>