### PR TITLE
Cancel in progress jobs of the same ref

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -66,6 +66,11 @@ on:
         required: false
         default: "1"
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency: 
+  group: flowzone-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GHCR_USER: "flowzone" # does not seem to matter what is used here
   GHCR_TOKEN: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}


### PR DESCRIPTION
Cancel parallel flowzone runs from the same ref that may
cause conflicts.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/product-os/flowzone/issues/179