### PR TITLE
Add support for a `flowzone-preinstall` npm script

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -573,6 +573,10 @@ jobs:
           echo "::set-output name=sha_tag::${sha_tag}"
           echo "::set-output name=version_tag::${version_tag}"
 
+      - name: Install native dependencies (if necessary)
+        run: |
+          npm run flowzone-preinstall --if-present
+
       - name: Install dependencies
         run: |
           if [ -e package-lock.json ]; then


### PR DESCRIPTION
This can be used for installing native dependencies that are required for installing npm dependencies

Change-type: minor