### PR TITLE
Use the `FLOWZONE_TOKEN` not `GITHUB_TOKEN` for publish docs

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -783,7 +783,7 @@ jobs:
       - name: Publish generated docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.FLOWZONE_TOKEN }}
           publish_dir: docs
           publish_branch: docs
 


### PR DESCRIPTION
Change-type: patch