### PR TITLE
Only allow tag events if versioning is disabled

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -138,7 +138,7 @@ jobs:
     # all jobs depend on this one in some way so add global trigger rules here
     if: |
       (github.event_name == 'pull_request' && github.base_ref == github.event.repository.default_branch) ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && inputs.disable_versioning == true)
 
     outputs:
       pr_opened: ${{ steps.pr_opened.outcome == 'success' }}


### PR DESCRIPTION
Manual tagging of the main branch is effectively manual versioning, and would conflict with automatic Flowzone versioning.

This way Flowzone cannot be triggered by previous Flowzone versioned commits.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>