### PR TITLE
Support multiple Docker bake targets

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -53,7 +53,7 @@ on:
         description: "GitHub Actions runner type."
         type: string
         required: false
-        default: "[\"ubuntu-latest\"]"
+        default: '["ubuntu-latest"]'
       jobs_timeout_minutes:
         description: "Timeout for the job(s)."
         type: number
@@ -69,6 +69,11 @@ on:
         type: string
         required: false
         default: ""
+      bake_targets:
+        description: "Comma-delimited string of Docker buildx bake targets to publish (skipped if empty)"
+        type: string
+        required: false
+        default: "default"
       balena_environment:
         description: "balenaCloud environment"
         type: string
@@ -114,7 +119,6 @@ on:
         type: string
         required: false
         default: ""
-
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -207,15 +211,15 @@ jobs:
     outputs:
       balena_slugs: ${{ steps.balena_slugs.outputs.build }}
       docker_images: ${{ steps.docker_images.outputs.build }}
+      bake_targets: ${{ steps.bake_targets.outputs.build }}
 
       npm: ${{ steps.npm.outputs.enabled }}
       npm_private: ${{ steps.npm.outputs.private }} # can be null or unset
       npm_docs: ${{ steps.npm.outputs.docs }} # can be null or unset
-      docker_compose: ${{ steps.docker_compose.outputs.enabled }}
-      dockerfile: ${{ steps.dockerfile.outputs.enabled }}
+      docker_compose: ${{ steps.docker_compose.outputs.file }} # can be null or unset
+      docker_compose_test: ${{ steps.docker_compose_test.outputs.file }} # can be null or unset
+      docker_bake: ${{ steps.docker_bake.outputs.build }}
       balena: ${{ steps.balena.outputs.enabled }}
-      docker_bake: ${{ steps.docker_bake.outputs.enabled }}
-      docker_platforms: ${{ steps.docker_bake.outputs.platforms }}
       node_versions: ${{ steps.node_versions.outputs.json }}
 
       custom_test: ${{ steps.custom.outputs.test }}
@@ -232,7 +236,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-          submodules: 'recursive'
+          submodules: "recursive"
           token: ${{ secrets.FLOWZONE_TOKEN }}
 
       - name: Convert balena_slugs to a JSON array
@@ -249,6 +253,15 @@ jobs:
         uses: kanga333/json-array-builder@v0.1.0
         env:
           INPUT: ${{ inputs.docker_images }}
+        with:
+          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
+          separator: ","
+
+      - name: Convert bake_targets to a JSON array
+        id: bake_targets
+        uses: kanga333/json-array-builder@v0.1.0
+        env:
+          INPUT: ${{ inputs.bake_targets }}
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
@@ -334,25 +347,34 @@ jobs:
             echo "json=${NODE_VERSIONS}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Check for docker-compose.test.yml
+      - name: Check for Docker compose files
         id: docker_compose
         run: |
-          if [ -f docker-compose.test.yml ]; then
-            echo "found docker-compose.test.yml"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
+          if [ -f docker-compose.yml ]
+          then
+            echo "file=docker-compose.yml" >> $GITHUB_OUTPUT
+          elif [ -f docker-compose.yaml ]
+          then
+            echo "file=docker-compose.yaml" >> $GITHUB_OUTPUT
           fi
 
-      - name: Check for Dockerfile
-        id: dockerfile
+      - name: Check for Docker compose test files
+        id: docker_compose_test
         run: |
-          if [ -f Dockerfile ]; then
-            echo "found Dockerfile"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
+          if [ -f docker-compose.test.yml ]
+          then
+            echo "file=docker-compose.test.yml" >> $GITHUB_OUTPUT
+          elif [ -f docker-compose.test.yaml ]
+          then
+            echo "file=docker-compose.test.yaml" >> $GITHUB_OUTPUT
           fi
+
+      - name: Check for Docker bake files
+        id: docker_bake
+        uses: kanga333/json-array-builder@v0.1.0
+        with:
+          cmd: bash -c "find ${{ github.workspace }}/${{ inputs.working_directory }} -name 'docker-bake*' -o -name 'docker-compose.yml' -o -name 'docker-compose.yaml'" || true
+          separator: newline
 
       - name: Check for balena.yml
         id: balena
@@ -417,26 +439,6 @@ jobs:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
 
-      - name: Check for docker-bake.hcl
-        id: docker_bake
-        run: |
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          echo "platforms=[\"linux/amd64\"]" >> $GITHUB_OUTPUT
-          if [ -f docker-bake.hcl ]
-          then
-            echo "enabled=true" >> $GITHUB_OUTPUT
-            curl -fsSL https://github.com/teamon/hclq/releases/download/v0.1.1/hclq_0.1.1_Linux_x86_64.gz -O
-            echo "cc05154fd66e5a0c4185a95712980a5f  hclq_0.1.1_Linux_x86_64.gz" | md5sum -c -
-            gzip -d hclq_0.1.1_Linux_x86_64.gz
-            chmod +x ./hclq_0.1.1_Linux_x86_64
-            platforms_json="$(./hclq_0.1.1_Linux_x86_64 < docker-bake.hcl | jq -rc .target.build.platforms)"
-            if [ -n "${platforms_json}" ] && [ "${platforms_json}" != "null" ] && [ "${platforms_json}" != "[]" ]
-            then
-              echo "platforms=${platforms_json}" >> $GITHUB_OUTPUT
-            fi
-            rm hclq_0.1.1_Linux_x86_64
-          fi
-
   ###################################################
   ## versioned source
   ###################################################
@@ -461,7 +463,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: 'recursive'
+          submodules: "recursive"
           token: ${{ secrets.FLOWZONE_TOKEN }}
 
       - name: Import GPG key for signing commits
@@ -686,7 +688,6 @@ jobs:
           path: /tmp/docs.tgz
           retention-days: 90
 
-
   npm_publish:
     name: Publish npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -812,23 +813,46 @@ jobs:
     needs: [event_types, project_types, versioned_source]
     if: |
       needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.dockerfile == 'true'
+      needs.project_types.outputs.docker_compose_test != ''
 
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
-    env:
-      COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
-      DOCKER_BUILDKIT: "1"
-
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(needs.project_types.outputs.docker_platforms) }}
+        target: ["default"]
+        # platform is limited to one for now to avoid parsing all target/platform pairs from the bake files for testing
+        platform: ["linux/amd64"]
+
+    env:
+      COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
+      DOCKER_BUILDKIT: "1"
+      COMPOSE_FILE: "${{ needs.project_types.outputs.docker_compose }}:${{ needs.project_types.outputs.docker_compose_test }}"
+      BAKE_OVERRIDE: /tmp/docker-bake.override.json
+      BAKE_EMPTY: /tmp/docker-bake.empty.json
 
     steps:
+      # attempt login for to pull private images for caching
+      - name: Login to GitHub Container Registry
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ env.GHCR_TOKEN }}
+
+      # attempt login for to pull private images for caching
+      - name: Login to Docker Hub
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
+
       - name: Download source artifact
         uses: actions/download-artifact@v3
         with:
@@ -848,88 +872,44 @@ jobs:
           driver-opts: network=host
           install: true
 
-      - name: Set ARCHVARIANT
+      # this override file will add additional cache sources
+      # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
+      - name: Create bake override
         run: |
-          echo "ARCHVARIANT=$(echo "${{ matrix.platform }}" | sed -e 's|linux/||' -e 's|/||')" >> $GITHUB_ENV
+          jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
+          docker buildx bake --print ${{ matrix.target }} \
+            -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
+            -f ${{ needs.project_types.outputs.docker_compose_test }} \
+            | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
+            | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
+            > "${BAKE_OVERRIDE}"
+            jq . "${BAKE_OVERRIDE}"
 
-      - name: Image metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          # add extra image names here that could be referenced from docker-compose.test.yml
-          images: |
-            ${{ github.repository }}
-            sut
-          tags: |
-            type=raw,value=${{ needs.versioned_source.outputs.new_tag }}
-            type=raw,value=${{ needs.versioned_source.outputs.version }}
-            type=raw,value=${{ env.ARCHVARIANT }}
-            type=raw,value=edge
-          flavor: |
-            latest=true
-
+      # build all docker compose test targets with buildx bake and use the same cache scope as the publish job
+      # these images are not pushed and are only used for testing, but can save build time of the publish job
       # https://github.com/docker/bake-action
       - name: Docker bake and load
-        if: needs.project_types.outputs.docker_bake == 'true'
         uses: docker/bake-action@v2
         with:
           workdir: ${{ inputs.working_directory }}
           files: |
-            ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: build
+            ${{ env.BAKE_OVERRIDE }}
+          # force a single platform as multi-platform images cannot be loaded to local context
           set: |
             *.platform=${{ matrix.platform }}
-            *.cache-to=type=gha,scope=test-${{ env.ARCHVARIANT }},mode=max
-            *.cache-from=type=gha,scope=test-${{ env.ARCHVARIANT }}
           load: true
           push: false
 
-      # https://github.com/docker/build-push-action
-      - name: Docker build and load
-        if: needs.project_types.outputs.docker_bake != 'true'
-        uses: docker/build-push-action@v3
-        with:
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-to: type=gha,scope=test-${{ env.ARCHVARIANT }},mode=max
-          cache-from: type=gha,scope=test-${{ env.ARCHVARIANT }}
-          context: ${{ inputs.working_directory }}
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-          load: true
-          push: false
-
-      - name: Save image to file
-        run: |
-          # (e.g.) Error response from daemon: invalid reference format: repository name must be lowercase
-          github_repository='${{ github.repository }}'
-          docker save ${github_repository,,}:${{ env.ARCHVARIANT }} | gzip > /tmp/docker.tgz
-
+      # run docker compose tests and print the logs from all services
       - name: Run docker compose tests
         run: |
-          if [[ '${{ needs.project_types.outputs.docker_compose }}' != 'true' ]]; then
-            echo "::warning::Missing docker-compose tests whilst using docker building/publishing"
-            exit 0
-          fi
-          if [[ ! -z "${COMPOSE_VARS}" ]]; then
-            echo ${COMPOSE_VARS} | base64 --decode > .env
+          if [ -n "${COMPOSE_VARS}" ]
+          then
+            echo "${COMPOSE_VARS}" | base64 --decode > .env
           fi
 
-          if [ -f docker-compose.test.yml ] && [ -f docker-compose.yml ]; then
-            docker compose -f docker-compose.yml -f docker-compose.test.yml up sut --exit-code-from sut
-          else
-            docker compose -f docker-compose.test.yml up sut --exit-code-from sut
-          fi
-
-      # give the artifact a unique name that includes the ARCHVARIANT since the docker_publish job
-      # will download all docker artifacts and combine them into a multiarch manifest
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker-${{ github.event.pull_request.head.sha }}-${{ env.ARCHVARIANT }}
-          path: /tmp/docker.tgz
-          retention-days: 1
+          docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
+          docker compose logs
 
   docker_publish:
     name: Publish docker
@@ -938,7 +918,6 @@ jobs:
     needs: [project_types, versioned_source, npm_test, docker_test, custom_test]
     if: |
       !failure() && !cancelled() &&
-      needs.docker_test.result == 'success' &&
       needs.event_types.outputs.do_draft == 'true' &&
       join(fromJSON(needs.project_types.outputs.docker_images)) != ''
 
@@ -950,18 +929,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ fromJSON(needs.project_types.outputs.docker_images) }}
+        target: ${{ fromJSON(needs.project_types.outputs.bake_targets) }}
 
     env:
-      LOCAL_IMAGE: localhost:5000/${{ github.repository }}
-
-    services:
-      registry:
-        image: registry:2.8.1
-        ports:
-          - 5000:5000
+      BAKE_OVERRIDE: /tmp/docker-bake.override.json
+      BAKE_EMPTY: /tmp/docker-bake.empty.json
 
     steps:
+      - name: Check test result
+        if: needs.docker_test.result != 'success'
+        run: echo "::warning::Missing docker-compose tests whilst using docker building/publishing"
+
       - name: Login to GitHub Container Registry
         continue-on-error: true
         uses: docker/login-action@v2
@@ -978,49 +956,76 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
 
-      - name: Download all artifacts
+      - name: Download source artifact
         uses: actions/download-artifact@v3
         with:
+          name: source-${{ github.event.pull_request.head.sha }}
           path: /tmp
 
-      - name: Load images
-        run: |
-          for image in /tmp/docker-*/*.tgz
-          do
-            ARCHVARIANT="$(dirname "${image}" | awk -F- '{print $NF}')"
-            docker load -i "${image}" | tee /dev/stderr | awk '{print $NF}' |
-              xargs -i docker tag {} "${LOCAL_IMAGE,,}:${ARCHVARIANT}"
-            docker push "${LOCAL_IMAGE,,}:${ARCHVARIANT}"
-          done
+      - name: Extract source artifact
+        working-directory: .
+        run: tar -xvf /tmp/source.tgz
 
-      # see https://github.com/estesp/manifest-tool to understand template
-      - name: Create multi-arch manifest
-        id: manifest
-        run: |
-          docker run --rm --network=host mplatform/manifest-tool:alpine-v2.0.5 push from-args \
-            --platforms ${{ join(fromJSON(needs.project_types.outputs.docker_platforms)) }} \
-            --template ${LOCAL_IMAGE,,}:ARCHVARIANT \
-            --target ${LOCAL_IMAGE,,}:latest
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
 
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
+          install: true
+
+      - name: Set env vars
+        run: |
+          DOCKER_IMAGES="$(echo "${{ join(fromJSON(needs.project_types.outputs.docker_images),' ') }}" | tr " " "\n")"
+          echo "DOCKER_IMAGES<<EOF" >> $GITHUB_ENV
+          echo "${DOCKER_IMAGES}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+          if [ ${{ matrix.target }} != 'default' ]
+          then
+            echo "PREFIX=${{ matrix.target }}-" >> $GITHUB_ENV
+          fi
+
+      # https://github.com/docker/metadata-action
       - name: Generate draft labels and tags
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ matrix.image }}
+            ${{ env.DOCKER_IMAGES }}
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
             type=raw,value=${{ github.event.pull_request.head.ref }}
-            type=ref,event=pr
           flavor: |
             latest=false
+            prefix=${{ env.PREFIX }}
 
-      - name: Publish draft tags
-        uses: akhilerm/tag-push-action@v2.0.0
+      # this override file will add additional cache sources and inherit the docker-metadata-action
+      # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
+      - name: Create bake override
+        run: |
+          jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
+          docker buildx bake --print ${{ matrix.target }} \
+            -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
+            | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
+            | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
+            | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
+            | jq '.target |= map_values(."cache-from" += ${{ toJSON(fromJSON(steps.meta.outputs.json).tags) }})' \
+            > "${BAKE_OVERRIDE}"
+            jq . "${BAKE_OVERRIDE}"
+
+      # https://github.com/docker/bake-action
+      - name: Docker bake and push
+        uses: docker/bake-action@v2
         with:
-          src: ${{ env.LOCAL_IMAGE }}:latest
-          dst: |
-            ${{ steps.meta.outputs.tags }}
+          workdir: ${{ inputs.working_directory }}
+          files: |
+            ${{ env.BAKE_OVERRIDE }}
+            ${{ steps.meta.outputs.bake-file }}
+          targets: ${{ matrix.target }}
+          load: false
+          push: true
 
   docker_finalize:
     name: Finalize docker
@@ -1029,7 +1034,6 @@ jobs:
     needs: [event_types, project_types, versioned_source]
     if: |
       needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.dockerfile == 'true' &&
       join(fromJSON(needs.project_types.outputs.docker_images)) != ''
 
     defaults:
@@ -1041,6 +1045,7 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{ fromJSON(needs.project_types.outputs.docker_images) }}
+        target: ${{ fromJSON(needs.project_types.outputs.bake_targets) }}
 
     steps:
       - name: Login to GitHub Container Registry
@@ -1059,56 +1064,55 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
 
-      # merged pull requests
+      - name: Set env vars
+        run: |
+          if [ ${{ matrix.target }} != 'default' ]
+          then
+            echo "PREFIX=${{ matrix.target }}-" >> $GITHUB_ENV
+          fi
+
+      # merge events with flowzone versioning
+      # https://github.com/docker/metadata-action
       - name: Generate versioned labels and tags
-        id: versioned_meta
-        if: needs.event_types.outputs.pr_merged == 'true' && needs.versioned_source.outputs.version != ''
+        id: meta1
+        if: needs.versioned_source.outputs.version != ''
         uses: docker/metadata-action@v4
         with:
           images: |
             ${{ matrix.image }}
           tags: |
+            type=raw,value=${{ github.event.base_ref || github.event.ref_name }}
             type=raw,value=${{ needs.versioned_source.outputs.new_tag }}
             type=raw,value=${{ needs.versioned_source.outputs.version }}
           flavor: |
             latest=true
+            prefix=${{ env.PREFIX }},onlatest=true
 
-      # merged pull requests with versioning disabled
-      - name: Generate edge labels and tags
-        id: edge_meta
-        if: needs.event_types.outputs.pr_merged == 'true' && needs.versioned_source.outputs.version == ''
+      # merge or tag events with versioning disabled
+      # https://github.com/docker/metadata-action
+      - name: Generate labels and tags
+        id: meta2
+        if: needs.versioned_source.outputs.version == ''
         uses: docker/metadata-action@v4
         with:
           images: |
             ${{ matrix.image }}
           tags: |
-            type=raw,value=edge
-          flavor: |
-            latest=false
-
-      # tag pushed to main branch
-      - name: Generate tagged labels and tags
-        id: tagged_meta
-        if: github.event_name == 'push'
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ matrix.image }}
-          tags: |
+            type=raw,value=${{ github.event.base_ref || github.event.ref_name }}
             type=ref,event=tag
             type=semver,pattern={{version}}
           flavor: |
             latest=auto
+            prefix=${{ env.PREFIX }},onlatest=true
 
       # only one of the destination lines should have values based on the meta restrictions above
       - name: Publish final tags
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: ${{ matrix.image }}:${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          src: ${{ matrix.image }}:${{ env.PREFIX }}${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           dst: |
-            ${{ steps.versioned_meta.outputs.tags }}
-            ${{ steps.edge_meta.outputs.tags }}
-            ${{ steps.tagged_meta.outputs.tags }}
+            ${{ steps.meta1.outputs.tags }}
+            ${{ steps.meta2.outputs.tags }}
 
   ###################################################
   ## balena
@@ -1375,7 +1379,6 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
-
 
   ###################################################
   ## protect branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,3 +19,6 @@ jobs:
         ghcr.io/product-os/flowzone
       balena_slugs: |
         product_os/flowzone
+      bake_targets: |
+        default,
+        debug

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`jobs_timeout_minutes`](#jobs_timeout_minutes)
     - [`working_directory`](#working_directory)
     - [`docker_images`](#docker_images)
+    - [`bake_targets`](#bake_targets)
     - [`balena_environment`](#balena_environment)
     - [`balena_slugs`](#balena_slugs)
     - [`protect_branch`](#protect_branch)
@@ -161,37 +162,21 @@ To disable publishing of artifacts set `"private": true` in `package.json`.
 
 ### Docker
 
-If a `docker-compose.yml` _and_ a `docker-compose.test.yml` are found in the root of the repository, Flowzone will test your project using Docker compose.
+If `docker-compose.test.yml` is found in the root of the repository, Flowzone will test your project using Docker compose.
+If a `docker-compose.yml` is also found they will be merged.
 
-The compose script will merge the to yaml file together and wait on a container named `sut` to finish. The result of the test is determined by the exit code of the `sut` container.
+The result of the test is determined by the exit code of the `sut` service.
 Typically, the `sut` container will execute your e2e or integration tests and will exit on test completion.
 
 If you need to provide environment variables to the compose environment you can add a repository secret called [`COMPOSE_VARS`](#compose_vars) that should be a base64 encoded `.env` file.
 This will be decoded and written to a `.env` file inside the test worker at runtime.
 
-To enable publishing of Docker artifacts set [`docker_images`](#docker_images) input to correct value of docker image repositories without tags eg  - eg `ghcr.io/${{ github.repository }}`.
+To enable publishing of Docker artifacts set the [`docker_images`](#docker_images) input to correct value of docker image repositories without tags - eg `ghcr.io/product-os/flowzone`.
 
-For advanced Docker build options, including multi-arch, add a [docker-bake.hcl](https://docs.docker.com/engine/reference/commandline/buildx_bake/) file to your project.
+For advanced Docker build options, including multi-arch, add one or more [Docker bake files](https://docs.docker.com/build/customize/bake/file-definition/) to your project.
 
-```hcl
-// docker-bake.hcl
-// https://github.com/docker/metadata-action#bake-definition
-target "docker-metadata-action" {}
-
-target "build" {
-  inherits = ["docker-metadata-action"]
-  context = "./"
-  dockerfile = "Dockerfile"
-  args = {
-    foo = "bar"
-  }
-  platforms = [
-    "linux/amd64",
-    "linux/arm/v7",
-    "linux/arm64",
-  ]
-}
-```
+To publish multiple image variants, set the [`bake_targets`](#bake_targets) input to the name of each target in the Docker bake file(s).
+All targets except `default` will have the target name prefixed to the tags - eg. `v1.2.3`, `debug-v1.2.3`.
 
 ### balena
 
@@ -355,6 +340,14 @@ Comma-delimited string of Docker images (without tags) to publish (skipped if em
 Type: _string_
 
 Default: `''`
+
+#### `bake_targets`
+
+Comma-delimited string of Docker buildx bake targets to publish (skipped if empty).
+
+Type: _string_
+
+Default: `default`
 
 #### `balena_environment`
 

--- a/tests/docker-bake.hcl
+++ b/tests/docker-bake.hcl
@@ -1,8 +1,6 @@
-// docker-bake.hcl
-target "docker-metadata-action" {}
+// https://docs.docker.com/build/customize/bake/file-definition
 
-target "build" {
-  inherits = ["docker-metadata-action"]
+target "default" {
   context = "./"
   dockerfile = "Dockerfile"
   platforms = [
@@ -10,4 +8,15 @@ target "build" {
     "linux/arm/v7",
     "linux/arm64",
   ]
+  cache-from = [
+    "ghcr.io/product-os/flowzone:latest",
+    "ghcr.io/product-os/flowzone:master"
+  ]
+}
+
+target "debug" {
+  inherits = ["default"]
+  args = {
+    DEBUG = "true"
+  }
 }

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -14,3 +14,15 @@ services:
       - REPO_SECRET
     networks:
       - internal
+
+  redis:
+    image: redis:7
+    command: redis-server --appendonly yes
+    restart: always
+    networks:
+      - internal
+    ports:
+      - '6379:6379'
+
+networks:
+  internal: {}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,14 +1,7 @@
 version: '2.1'
 
 services:
-  redis:
-    image: redis:7
-    command: redis-server --appendonly yes
-    restart: always
-    networks:
-      - internal
-    ports:
-      - '6379:6379'
-
-networks:
-  internal: {}
+  main:
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
This commit replaces the Docker platform build/test matrix
with a single docker-compose test. It also allows multiple bake
targets for publishing image variants with unique tags.

Currently only the linux/amd64 platform image will be tested
with compose tests but any targets defined in the bake file(s)
will be published as defined.

The same cache scope is used for the compose tests as the publish
steps so targets with long build times should need to build once.
Additional cache sources can be added to the bake file(s).

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/product-os/flowzone/issues/230
Resolves: https://github.com/product-os/flowzone/issues/253

PRs for testing:
- https://github.com/balena-io-modules/open-balena-base/pull/178
- https://github.com/klutchell/unbound-docker/pull/100