### PR TITLE
Fix versioning race condition if others also update master directly

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -554,7 +554,11 @@ jobs:
       - name: Push versioned commit
         if: inputs.disable_versioning != true && needs.event_types.outputs.pr_merged == 'true'
         run: |
-          git push origin HEAD:${{ github.base_ref }} --follow-tags
+          git push origin HEAD:${{ github.base_ref }}
+          # We push the tag separately so that it is only pushed if the commit push succeed, this avoids
+          # issues if something else updates the main branch whilst we're running and causes us to push
+          # the tag successfully but not the main branch and breaks future versioning attempts
+          git push origin "refs/tags/${{ steps.new_version.outputs.tag }}"
 
       # https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Compress source


### PR DESCRIPTION
The race condition looks like
```
+ git push origin HEAD:master --follow-tags
warning: not sending a push certificate since the receiving end does not support --signed push
To ...
 * [new tag]         v1.4.23 -> v1.4.23
 ! [rejected]        HEAD -> master (fetch first)
error: failed to push some refs to 'https://github.com/product-os/environment-production'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```
and causes future versioning to fail because the tag already exists

Change-type: patch