### PR TITLE
Remove default value for balena_slugs input

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -78,7 +78,7 @@ on:
         description: "Comma-delimited string of balenaCloud apps, fleets, or blocks to deploy (skipped if empty)"
         type: string
         required: false
-        default: ${{ github.repository }}
+        default: ""
       protect_branch:
         description: "Set to false to disable updating branch protection rules after a successful run"
         type: boolean

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Comma-delimited string of balenaCloud apps, fleets, or blocks to deploy (skipped
 
 Type: _string_
 
-Default: `${{ github.repository }}`
+Default: `''`
 
 #### `protect_branch`
 


### PR DESCRIPTION
It's rare that GH repo slugs align with balenaCloud application slugs so default to an empty list.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>