### PR TITLE
Fix typo when referencing new tag for Docker labels

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -899,7 +899,7 @@ jobs:
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
             type=raw,value=${{ github.event.pull_request.head.ref }}
-          labels: org.opencontainers.image.version=${{ needs.versioned_source.outputs.tag }}
+          labels: org.opencontainers.image.version=${{ needs.versioned_source.outputs.new_tag }}
           flavor: |
             latest=false
             prefix=${{ env.PREFIX }}


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>