### PR TITLE
Combine docker test and publish jobs

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -849,113 +849,17 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
-      - versioned_source
-    if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.docker_compose_test != ''
-    defaults:
-      run:
-        working-directory: ${{ inputs.working_directory }}
-        shell: bash --noprofile --norc -eo pipefail -x {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - default
-        platform:
-          - linux/amd64
-    env:
-      COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
-      DOCKER_BUILDKIT: "1"
-      COMPOSE_FILE: ${{ needs.project_types.outputs.docker_compose }}:${{ needs.project_types.outputs.docker_compose_test }}
-      BAKE_OVERRIDE: /tmp/docker-bake.override.json
-      BAKE_EMPTY: /tmp/docker-bake.empty.json
-    steps:
-      - name: Login to GitHub Container Registry
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ env.GHCR_TOKEN }}
-      - name: Login to Docker Hub
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
-      - name: Download source artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: tar -xvf ${{ runner.temp }}/source.tgz
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Setup buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: network=host
-          install: true
-      - name: Setup docker-compose environment
-        run: |
-          if [[ -n "${COMPOSE_VARS}" ]]
-          then
-            echo "${COMPOSE_VARS}" | base64 --decode > .env
-          fi
-      - name: Create bake override
-        run: |
-          jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
-          docker buildx bake --print ${{ matrix.target }} \
-            -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
-            | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
-            | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
-            > "${BAKE_OVERRIDE}"
-            jq . "${BAKE_OVERRIDE}"
-      - name: Docker bake and load
-        uses: docker/bake-action@v2
-        with:
-          workdir: ${{ inputs.working_directory }}
-          files: |
-            ${{ env.BAKE_OVERRIDE }}
-          set: |
-            *.platform=${{ matrix.platform }}
-          load: true
-          push: false
-      - name: Run docker compose tests
-        run: |
-          DC_ARGS=''
-          if [ -f docker-compose.yml ]; then
-            DC_ARGS="${DC_ARGS} -f docker-compose.yml"
-          fi
-          if [ -f docker-compose.test.yml ]; then
-            DC_ARGS="${DC_ARGS} -f docker-compose.test.yml"
-          fi
-          docker compose ${DC_ARGS} up sut --exit-code-from sut || { docker compose ${DC_ARGS} logs ; exit 1 ; }
-          docker compose ${DC_ARGS} logs
-  docker_publish:
-    name: Publish docker
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
-    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs:
       - project_types
       - versioned_source
       - npm_test
-      - docker_test
       - custom_test
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_test != '')
     defaults:
       run:
-        working-directory: .
+        working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     strategy:
       fail-fast: false
@@ -964,10 +868,13 @@ jobs:
     env:
       BAKE_OVERRIDE: /tmp/docker-bake.override.json
       BAKE_EMPTY: /tmp/docker-bake.empty.json
+      SUT_IMAGE: localhost:5000/sut
+    services:
+      registry:
+        image: registry:2.8.1
+        ports:
+          - 5000:5000
     steps:
-      - name: Check test result
-        if: needs.docker_test.result != 'success'
-        run: echo "::warning::Missing docker-compose tests whilst using docker building/publishing"
       - name: Login to GitHub Container Registry
         continue-on-error: true
         uses: docker/login-action@v2
@@ -1009,30 +916,37 @@ jobs:
           then
             echo "PREFIX=${{ matrix.target }}-" >> $GITHUB_ENV
           fi
+
+          if [ -f "${{ needs.project_types.outputs.docker_compose }}" ]
+          then
+            echo "COMPOSE_FILE=${{ needs.project_types.outputs.docker_compose }}:${{ needs.project_types.outputs.docker_compose_test }}" >> $GITHUB_ENV
+          else
+            echo "COMPOSE_FILE=${{ needs.project_types.outputs.docker_compose_test }}" >> $GITHUB_ENV
+          fi
       - name: Generate draft labels and tags
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ env.DOCKER_IMAGES }}
+            ${{ env.DOCKER_IMAGES || env.SUT_IMAGE }}
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
             type=raw,value=${{ github.event.pull_request.head.ref }}
+          labels: org.opencontainers.image.version=${{ needs.versioned_source.outputs.new_tag }}
           flavor: |
             latest=false
             prefix=${{ env.PREFIX }}
       - name: Create bake override
         run: |
-          jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
+          jq -n '{target:{"${{ matrix.target }}":{}}}' > ${BAKE_EMPTY}
           docker buildx bake --print ${{ matrix.target }} \
             -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
             | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
-            | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
-            | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
-            | jq '.target |= map_values(."cache-from" += ${{ toJSON(fromJSON(steps.meta.outputs.json).tags) }})' \
+            | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
+            | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
             > "${BAKE_OVERRIDE}"
-            jq . "${BAKE_OVERRIDE}"
-      - name: Docker bake and push
+          jq . "${BAKE_OVERRIDE}"
+      - name: Docker bake and push to local registry
         uses: docker/bake-action@v2
         with:
           workdir: ${{ inputs.working_directory }}
@@ -1040,8 +954,34 @@ jobs:
             ${{ env.BAKE_OVERRIDE }}
             ${{ steps.meta.outputs.bake-file }}
           targets: ${{ matrix.target }}
+          set: |
+            *.tags=${{ env.SUT_IMAGE }}:${{ env.PREFIX }}latest
           load: false
           push: true
+      - name: Run docker compose tests
+        id: compose_test
+        if: needs.project_types.outputs.docker_compose_test != ''
+        env:
+          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
+          DOCKER_BUILDKIT: "1"
+        run: |
+          if [ -n "${COMPOSE_VARS}" ]
+          then
+            echo "${COMPOSE_VARS}" | base64 --decode > .env
+          fi
+
+          docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
+          docker compose logs
+      - name: Warn if tests skipped
+        if: join(fromJSON(needs.project_types.outputs.docker_images)) != '' && steps.compose_test.result == 'skipped'
+        run: echo "::warning::Publishing Docker images without docker compose tests!"
+      - name: Publish draft tags
+        if: join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ${{ env.SUT_IMAGE }}:${{ env.PREFIX }}latest
+          dst: |
+            ${{ steps.meta.outputs.tags }}
   docker_finalize:
     name: Finalize docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -1754,7 +1694,6 @@ jobs:
       - custom_publish
       - custom_test
       - python_test
-      - docker_publish
       - docker_test
       - event_types
       - npm_publish

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ For advanced Docker build options, including multi-arch, add one or more [Docker
 To publish multiple image variants, set the [`bake_targets`](#bake_targets) input to the name of each target in the Docker bake file(s).
 All targets except `default` will have the target name prefixed to the tags - eg. `v1.2.3`, `debug-v1.2.3`.
 
+An example of multiple bake targets can be found here: <https://github.com/balena-io-modules/open-balena-base/blob/master/docker-bake.hcl>
+
 ### balena
 
 If a `balena.yml` file is found in the root of the repository Flowzone will attempt to push draft releases to your application slug(s) and finalize on merge.

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -979,125 +979,21 @@ jobs:
   ## docker
   ###################################################
 
+  # this job combines build & test & publish with buildx bake, docker compose tests, and crane image copy
+  # if there are no compose tests AND no images to publish, this job will be skipped
   docker_test:
     name: Test docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [project_types, versioned_source, npm_test, custom_test]
     if: |
+      !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.docker_compose_test != ''
+      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_test != '')
 
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-        shell: bash --noprofile --norc -eo pipefail -x {0}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ["default"]
-        # platform is limited to one for now to avoid parsing all target/platform pairs from the bake files for testing
-        platform: ["linux/amd64"]
-
-    env:
-      COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
-      DOCKER_BUILDKIT: "1"
-      COMPOSE_FILE: "${{ needs.project_types.outputs.docker_compose }}:${{ needs.project_types.outputs.docker_compose_test }}"
-      BAKE_OVERRIDE: /tmp/docker-bake.override.json
-      BAKE_EMPTY: /tmp/docker-bake.empty.json
-
-    steps:
-      # attempt login for to pull private images for caching
-      - name: Login to GitHub Container Registry
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ env.GHCR_TOKEN }}
-
-      # attempt login for to pull private images for caching
-      - name: Login to Docker Hub
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
-
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Setup buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: network=host
-          install: true
-
-      - name: Setup docker-compose environment
-        run: |
-          if [[ -n "${COMPOSE_VARS}" ]]
-          then
-            echo "${COMPOSE_VARS}" | base64 --decode > .env
-          fi
-
-      # this override file will add additional cache sources
-      # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
-      - name: Create bake override
-        run: |
-          jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
-          docker buildx bake --print ${{ matrix.target }} \
-            -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
-            | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
-            | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
-            > "${BAKE_OVERRIDE}"
-            jq . "${BAKE_OVERRIDE}"
-
-      # build all docker compose test targets with buildx bake and use the same cache scope as the publish job
-      # these images are not pushed and are only used for testing, but can save build time of the publish job
-      # https://github.com/docker/bake-action
-      - name: Docker bake and load
-        uses: docker/bake-action@v2
-        with:
-          workdir: ${{ inputs.working_directory }}
-          files: |
-            ${{ env.BAKE_OVERRIDE }}
-          # force a single platform as multi-platform images cannot be loaded to local context
-          set: |
-            *.platform=${{ matrix.platform }}
-          load: true
-          push: false
-
-      # run docker compose tests and print the logs from all services
-      - name: Run docker compose tests
-        run: |
-          DC_ARGS=''
-          if [ -f docker-compose.yml ]; then
-            DC_ARGS="${DC_ARGS} -f docker-compose.yml"
-          fi
-          if [ -f docker-compose.test.yml ]; then
-            DC_ARGS="${DC_ARGS} -f docker-compose.test.yml"
-          fi
-          docker compose ${DC_ARGS} up sut --exit-code-from sut || { docker compose ${DC_ARGS} logs ; exit 1 ; }
-          docker compose ${DC_ARGS} logs
-
-  docker_publish:
-    name: Publish docker
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
-    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [project_types, versioned_source, npm_test, docker_test, custom_test]
-    if: |
-      !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      join(fromJSON(needs.project_types.outputs.docker_images)) != ''
-
-    defaults:
-      run:
-        working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     strategy:
@@ -1108,12 +1004,15 @@ jobs:
     env:
       BAKE_OVERRIDE: /tmp/docker-bake.override.json
       BAKE_EMPTY: /tmp/docker-bake.empty.json
+      SUT_IMAGE: localhost:5000/sut
+
+    services:
+      registry:
+        image: registry:2.8.1
+        ports:
+          - 5000:5000
 
     steps:
-      - name: Check test result
-        if: needs.docker_test.result != 'success'
-        run: echo "::warning::Missing docker-compose tests whilst using docker building/publishing"
-
       - name: Login to GitHub Container Registry
         continue-on-error: true
         uses: docker/login-action@v2
@@ -1154,36 +1053,44 @@ jobs:
             echo "PREFIX=${{ matrix.target }}-" >> $GITHUB_ENV
           fi
 
+          if [ -f "${{ needs.project_types.outputs.docker_compose }}" ]
+          then
+            echo "COMPOSE_FILE=${{ needs.project_types.outputs.docker_compose }}:${{ needs.project_types.outputs.docker_compose_test }}" >> $GITHUB_ENV
+          else
+            echo "COMPOSE_FILE=${{ needs.project_types.outputs.docker_compose_test }}" >> $GITHUB_ENV
+          fi
+
       # https://github.com/docker/metadata-action
       - name: Generate draft labels and tags
         id: meta
         uses: docker/metadata-action@v4
         with:
+          # fallback to the local image ref if we are not publishing anything
           images: |
-            ${{ env.DOCKER_IMAGES }}
+            ${{ env.DOCKER_IMAGES || env.SUT_IMAGE }}
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
             type=raw,value=${{ github.event.pull_request.head.ref }}
+          labels: org.opencontainers.image.version=${{ needs.versioned_source.outputs.new_tag }}
           flavor: |
             latest=false
             prefix=${{ env.PREFIX }}
 
-      # this override file will add additional cache sources and inherit the docker-metadata-action
+      # this override file will add additional cache sources and inherit the docker-metadata-action target
       # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
       - name: Create bake override
         run: |
-          jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
+          jq -n '{target:{"${{ matrix.target }}":{}}}' > ${BAKE_EMPTY}
           docker buildx bake --print ${{ matrix.target }} \
             -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
             | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
-            | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
-            | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
-            | jq '.target |= map_values(."cache-from" += ${{ toJSON(fromJSON(steps.meta.outputs.json).tags) }})' \
+            | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
+            | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
             > "${BAKE_OVERRIDE}"
-            jq . "${BAKE_OVERRIDE}"
+          jq . "${BAKE_OVERRIDE}"
 
       # https://github.com/docker/bake-action
-      - name: Docker bake and push
+      - name: Docker bake and push to local registry
         uses: docker/bake-action@v2
         with:
           workdir: ${{ inputs.working_directory }}
@@ -1191,8 +1098,42 @@ jobs:
             ${{ env.BAKE_OVERRIDE }}
             ${{ steps.meta.outputs.bake-file }}
           targets: ${{ matrix.target }}
+          # Override the destination tags so we only push to the local registry
+          # for testing. If tests pass or are skipped, the crane copy action
+          # will publish the images to the public registries
+          set: |
+            *.tags=${{ env.SUT_IMAGE }}:${{ env.PREFIX }}latest
+          # load must be false to support multiple platforms
           load: false
           push: true
+
+      # run docker compose tests and print the logs from all services
+      - name: Run docker compose tests
+        id: compose_test
+        if: needs.project_types.outputs.docker_compose_test != ''
+        env:
+          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
+          DOCKER_BUILDKIT: "1"
+        run: |
+          if [ -n "${COMPOSE_VARS}" ]
+          then
+            echo "${COMPOSE_VARS}" | base64 --decode > .env
+          fi
+
+          docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
+          docker compose logs
+
+      - name: Warn if tests skipped
+        if: join(fromJSON(needs.project_types.outputs.docker_images)) != '' && steps.compose_test.result == 'skipped'
+        run: echo "::warning::Publishing Docker images without docker compose tests!"
+
+      - name: Publish draft tags
+        if: join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ${{ env.SUT_IMAGE }}:${{ env.PREFIX }}latest
+          dst: |
+            ${{ steps.meta.outputs.tags }}
 
   docker_finalize:
     name: Finalize docker
@@ -1922,7 +1863,6 @@ jobs:
         custom_publish,
         custom_test,
         python_test,
-        docker_publish,
         docker_test,
         event_types,
         npm_publish,


### PR DESCRIPTION
This will allow testing of the same image that is published by using image: `localhost:5000/sut` in a compose file.

It also ensures only one build and improved caching.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>