### PR TITLE
Support fetching submodule commits not in the repository HEAD

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -104,6 +104,11 @@ on:
         type: string
         required: false
         default: "Flowzone"
+      checkout_fetch_depth:
+        description: "Configures the depth of the actions/checkout git fetch."
+        type: number
+        required: false
+        default: 1
       custom_test_matrix:
         description: "Comma-delimited string of values that will be passed to the custom test action"
         type: string
@@ -237,7 +242,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v3
         with:
-          fetch-depth: 1
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
           submodules: "recursive"
           token: ${{ secrets.FLOWZONE_TOKEN }}
 


### PR DESCRIPTION
As [discussed](https://balena.zulipchat.com/#narrow/stream/345882-_help/topic/balena-phytec.20checkout) we either change the default `fetch-depth` in project_types to `0` or we make just that configurable, which is this patch.

I'd go for the simplest approach, but that probably affects the overall speed of flowzone so this PR is a compromise with a worst UX (we use `fetch-depth` in two jobs but the global input only configures one.