### PR TITLE
Don't publish to npmjs if already published

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -723,15 +723,19 @@ jobs:
           npm whoami
       - name: Publish draft release
         run: |
-          pack="$(ls /tmp/npm-*/*.tgz | sort -t- -n -k3 | tail -n1)"
-          tar xvf "${pack}"
-          (cd package
-          npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${{ needs.npm_test.outputs.version_tag }} --allow-same-version
-          )
-          tar czvf "${pack}" package
-          npm --loglevel=verbose --logs-max=0 unpublish ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} || true
-          npm --loglevel=verbose --logs-max=0 publish --tag=${{ needs.npm_test.outputs.sha_tag }} "${pack}"
-          npm --loglevel=verbose --logs-max=0 dist-tag add ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} ${{ needs.npm_test.outputs.branch_tag }}
+          if npm info ${{ needs.npm_test.outputs.package }} | grep -q ${{ needs.npm_test.outputs.version_tag }}; then
+            echo "${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} already published to npmjs, skipping..."
+          else
+            pack="$(ls /tmp/npm-*/*.tgz | sort -t- -n -k3 | tail -n1)"
+            tar xvf "${pack}"
+            (cd package
+            npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${{ needs.npm_test.outputs.version_tag }} --allow-same-version
+            )
+            tar czvf "${pack}" package
+            npm --loglevel=verbose --logs-max=0 unpublish ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} || true
+            npm --loglevel=verbose --logs-max=0 publish --tag=${{ needs.npm_test.outputs.sha_tag }} "${pack}" || true
+            npm --loglevel=verbose --logs-max=0 dist-tag add ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} ${{ needs.npm_test.outputs.branch_tag }}
+          fi
   npm_finalize:
     name: Finalize npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -837,15 +837,19 @@ jobs:
       # before publishing
       - name: Publish draft release
         run: |
-          pack="$(ls /tmp/npm-*/*.tgz | sort -t- -n -k3 | tail -n1)"
-          tar xvf "${pack}"
-          (cd package
-          npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${{ needs.npm_test.outputs.version_tag }} --allow-same-version
-          )
-          tar czvf "${pack}" package
-          npm --loglevel=verbose --logs-max=0 unpublish ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} || true
-          npm --loglevel=verbose --logs-max=0 publish --tag=${{ needs.npm_test.outputs.sha_tag }} "${pack}"
-          npm --loglevel=verbose --logs-max=0 dist-tag add ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} ${{ needs.npm_test.outputs.branch_tag }}
+          if npm info ${{ needs.npm_test.outputs.package }} | grep -q ${{ needs.npm_test.outputs.version_tag }}; then
+            echo "${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} already published to npmjs, skipping..."
+          else
+            pack="$(ls /tmp/npm-*/*.tgz | sort -t- -n -k3 | tail -n1)"
+            tar xvf "${pack}"
+            (cd package
+            npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${{ needs.npm_test.outputs.version_tag }} --allow-same-version
+            )
+            tar czvf "${pack}" package
+            npm --loglevel=verbose --logs-max=0 unpublish ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} || true
+            npm --loglevel=verbose --logs-max=0 publish --tag=${{ needs.npm_test.outputs.sha_tag }} "${pack}"
+            npm --loglevel=verbose --logs-max=0 dist-tag add ${{ needs.npm_test.outputs.package }}@${{ needs.npm_test.outputs.version_tag }} ${{ needs.npm_test.outputs.branch_tag }}
+          fi
 
   npm_finalize:
     name: Finalize npm


### PR DESCRIPTION
If published package has been downloaded,
npm doesn't allow to unpublish it.

Assuming that the same commit produces the same package,
publishing can be skipped altogether

Prompted by: https://balena.zulipchat.com/#narrow/stream/345890-loop.2Fbalena-io/topic/Test.20docker.20on.20open-balena-api
Change-type: patch