### PR TITLE
Check if python dev dependencies are already installed.

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1202,7 +1202,15 @@ jobs:
           poetry install
       - name: Add linters and pytest to poetry
         run: |
-          poetry add --group dev flake8@latest pydocstyle@latest pytest@latest
+          dep_list=`poetry show`
+          if (grep -wq ^flake8 <<< "$dep_list") && \
+             (grep -wq ^pydocstyle <<< "$dep_list") && \
+             (grep -wq ^pytest <<< "$dep_list")
+          then 
+            echo "Dev dependencies already installed"
+          else 
+            poetry add --group dev flake8@latest pydocstyle@latest pytest@latest
+          fi
       - name: Lint with flake8
         run: |
           poetry run flake8 --max-line-length=120 --benchmark --extend-ignore=E203

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1354,7 +1354,15 @@ jobs:
           poetry install
       - name: Add linters and pytest to poetry
         run : |
-          poetry add --group dev flake8@latest pydocstyle@latest pytest@latest
+          dep_list=`poetry show`
+          if (grep -wq ^flake8 <<< "$dep_list") && \
+             (grep -wq ^pydocstyle <<< "$dep_list") && \
+             (grep -wq ^pytest <<< "$dep_list")
+          then 
+            echo "Dev dependencies already installed"
+          else 
+            poetry add --group dev flake8@latest pydocstyle@latest pytest@latest
+          fi
       - name: Lint with flake8
         run: |
           poetry run flake8 --max-line-length=120 --benchmark --extend-ignore=E203


### PR DESCRIPTION
If dev dependencies are already included in the lock file, `poetry install` installs them by default when installing the main packages.
Regardless of that we ask poetry to add the latest version of flake8, pydocstyle and pytest to the project which results in updating all dependencies from scratch and generating a new lock file, which takes ~2-3 mins on the runner if there are a lot of packages.

Now we will perform a check if the dev dependencies are installed and install them only if needed.

Change-type: patch