### PR TITLE
Remove docker-compose.yml from parsed bake files

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -342,7 +342,7 @@ jobs:
         id: docker_bake
         uses: kanga333/json-array-builder@v0.1.0
         with:
-          cmd: bash -c "find ${{ github.workspace }}/${{ inputs.working_directory }} -maxdepth 1 -name 'docker-bake*' -o -name 'docker-compose.yml' -o -name 'docker-compose.yaml'" || true
+          cmd: bash -c "find ${{ github.workspace }}/${{ inputs.working_directory }} -maxdepth 1 -name 'docker-bake*'" || true
           separator: newline
       - name: Check for balena.yml
         id: balena

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -400,7 +400,7 @@ jobs:
         id: docker_bake
         uses: kanga333/json-array-builder@v0.1.0
         with:
-          cmd: bash -c "find ${{ github.workspace }}/${{ inputs.working_directory }} -maxdepth 1 -name 'docker-bake*' -o -name 'docker-compose.yml' -o -name 'docker-compose.yaml'" || true
+          cmd: bash -c "find ${{ github.workspace }}/${{ inputs.working_directory }} -maxdepth 1 -name 'docker-bake*'" || true
           separator: newline
 
       - name: Check for balena.yml


### PR DESCRIPTION
Since compose yaml files are often used for balena deployments, and optionally for docker compose tests, let's avoid overloading the file further and ignore it when looking for bake files.

This should avoid a confusing mess of services to build when both compose files and bake files are present in a repo.

Bake files used for docker build and deploy.
Compose files used for docker compose tests and balena deploy.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>