### PR TITLE
Remove compose test file from bake override

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -880,7 +880,6 @@ jobs:
           jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
           docker buildx bake --print ${{ matrix.target }} \
             -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
-            -f ${{ needs.project_types.outputs.docker_compose_test }} \
             | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
             | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
             > "${BAKE_OVERRIDE}"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1013,7 +1013,6 @@ jobs:
           jq -n '{target:{default:{}}}' > ${BAKE_EMPTY}
           docker buildx bake --print ${{ matrix.target }} \
             -f ${{ join(fromJSON(needs.project_types.outputs.docker_bake),' -f ') || env.BAKE_EMPTY }} \
-            -f ${{ needs.project_types.outputs.docker_compose_test }} \
             | jq '.target |= map_values(."cache-to" += ["type=gha,scope=buildkit,mode=max"])' \
             | jq '.target |= map_values(."cache-from" += ["type=gha,scope=buildkit"])' \
             > "${BAKE_OVERRIDE}"


### PR DESCRIPTION
This was only being used for image pre-build and will cause issues if it depends on resources in docker-compose.yml.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>