### PR TITLE
Do not include the merge commit in the release notes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1359,11 +1359,14 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@v3
+      - name: Download source artifact from PR
+        uses: dawidd6/action-download-artifact@v2
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          github_token: ${{ secrets.FLOWZONE_TOKEN }}
+          commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
+          workflow_conclusion: success
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
       - name: Extract source artifact
         shell: pwsh
         working-directory: .

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1528,7 +1528,19 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     steps:
-      - *downloadSourceArtifact
+      # https://github.com/dawidd6/action-download-artifact
+      # TODO: what if this is a tag event and PR artifacts do not exist?
+      # We want to use the source artifact from the PR instead of the merge
+      # action so the release notes don't include the merge commit
+      - name: Download source artifact from PR
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.FLOWZONE_TOKEN }}
+          commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+          workflow_conclusion: success
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+
       - *extractSourceArtifact
 
       # https://docs.github.com/en/rest/releases


### PR DESCRIPTION
During merge, we want to use the PR source for creating the release notes instead of the latest source since that will include the merge commit and it will pollute the notes.

See https://github.com/balena-os/fatrw/releases/tag/v0.2.14 for an example

Change-type: patch