### PR TITLE
Reject workflow if latest branch commit is a merge commit

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -570,6 +570,13 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.FLOWZONE_TOKEN }}
+      - name: Reject merge commits
+        run: |
+          if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]
+          then
+            echo "::error::Latest commit appears to be a merge, which is currently unsupported. Try a rebase instead."
+            exit 1
+          fi
       - name: Import GPG key for signing commits
         if: inputs.disable_versioning != true && github.event_name == 'pull_request'
         id: import-gpg

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -662,6 +662,15 @@ jobs:
           submodules: "recursive"
           token: ${{ secrets.FLOWZONE_TOKEN }}
 
+      # fail on merge commits (ones with more than one parent)
+      - name: Reject merge commits
+        run: |
+          if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]
+          then
+            echo "::error::Latest commit appears to be a merge, which is currently unsupported. Try a rebase instead."
+            exit 1
+          fi
+
       - name: Import GPG key for signing commits
         if: inputs.disable_versioning != true && github.event_name == 'pull_request'
         id: import-gpg


### PR DESCRIPTION
This may extend to more valid uses than intended, but for now we need to prevent merging PRs that have had master merged into them. This scenario will break versioning in master.

The intended workflow at balena has always been to rebase PRs, so we have to continue to force this for now and avoid breaking merges.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/product-os/flowzone/issues/245