### PR TITLE
 Use latest source when creating github release notes

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -22,3 +22,11 @@ runs:
         echo "${INPUTS}"
         echo "${SECRETS}"
         echo "${GITHUB}"
+
+    # Test publishing release artifacts to github
+    - name: Upload generated flowzone.yml
+      uses: actions/upload-artifact@v3
+      with:
+        name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+        path: .github/workflows/flowzone.yml
+        retention-days: 1

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1352,9 +1352,11 @@ jobs:
           set -ea
 
           artifact_count=0
-          [ -d "${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}" ] && \
-              artifact_count=$(ls "${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}" | wc -l | sed 's/^ *//;s/ *$//')
+          [ -d "$GH_ARTIFACTS" ] && \
+              artifact_count=$(ls "$GH_ARTIFACTS" | wc -l | sed 's/^ *//;s/ *$//')
           echo "count=$artifact_count" >> $GITHUB_OUTPUT
+        env:
+          GH_ARTIFACTS: ${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
       - name: Publish artifacts
         if: steps.gh_artifacts.outputs.count != '0'
         uses: softprops/action-gh-release@v1
@@ -1379,27 +1381,23 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact from PR
-        uses: dawidd6/action-download-artifact@v2
+      - name: Download source artifact
+        uses: actions/download-artifact@v3
         with:
-          github_token: ${{ secrets.FLOWZONE_TOKEN }}
-          commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-          workflow_conclusion: success
           name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
         run: tar -xvf ${{ runner.temp }}/source.tgz
       - name: Finalize GitHub release (if any)
         if: needs.versioned_source.outputs.version != ''
-        shell: bash
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
           previous_tag="$(git tag --sort=-version:refname | head -n 2 | tail -n 1)"
-          release_notes="$(git log ${previous_tag}..HEAD --pretty=reference)"
+          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
 
           if gh release view '${{ github.event.pull_request.head.ref }}'; then
             gh release edit '${{ github.event.pull_request.head.ref }}' \

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1518,9 +1518,11 @@ jobs:
           set -ea
 
           artifact_count=0
-          [ -d "${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}" ] && \
-              artifact_count=$(ls "${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}" | wc -l | sed 's/^ *//;s/ *$//')
+          [ -d "$GH_ARTIFACTS" ] && \
+              artifact_count=$(ls "$GH_ARTIFACTS" | wc -l | sed 's/^ *//;s/ *$//')
           echo "count=$artifact_count" >> $GITHUB_OUTPUT
+        env:
+          GH_ARTIFACTS: ${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
 
       - name: Publish artifacts
         if: steps.gh_artifacts.outputs.count != '0'
@@ -1547,31 +1549,18 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     steps:
-      # https://github.com/dawidd6/action-download-artifact
-      # TODO: what if this is a tag event and PR artifacts do not exist?
-      # We want to use the source artifact from the PR instead of the merge
-      # action so the release notes don't include the merge commit
-      - name: Download source artifact from PR
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{ secrets.FLOWZONE_TOKEN }}
-          commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-          workflow_conclusion: success
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-
+      - *downloadSourceArtifact
       - *extractSourceArtifact
 
       # https://docs.github.com/en/rest/releases
       - name: Finalize GitHub release (if any)
         if: needs.versioned_source.outputs.version != ''
-        shell: bash
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
           previous_tag="$(git tag --sort=-version:refname | head -n 2 | tail -n 1)"
-          release_notes="$(git log ${previous_tag}..HEAD --pretty=reference)"
+          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
 
           if gh release view '${{ github.event.pull_request.head.ref }}'; then
             gh release edit '${{ github.event.pull_request.head.ref }}' \


### PR DESCRIPTION
The `github_finalize` job was trying to use the original source of the PR
for creating the release notes. This required the source artifact to
exist at the moment of merge which is not always true as merge can
happen at any point after creating the PR. This changes the job to use
the latest source but exclude the last two commits (merge and version)
from the release notes.

Change-type: patch
