### PR TITLE
Only login to docker registries immediately before pushing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -901,20 +901,6 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - name: Login to GitHub Container Registry
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
-      - name: Login to Docker Hub
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
       - name: Download source artifact
         uses: actions/download-artifact@v3
         with:
@@ -1001,6 +987,20 @@ jobs:
       - name: Warn if tests skipped
         if: join(fromJSON(needs.project_types.outputs.docker_images)) != '' && steps.compose_test.result == 'skipped'
         run: echo "::warning::Publishing Docker images without docker compose tests!"
+      - name: Login to GitHub Container Registry
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
+      - name: Login to Docker Hub
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
       - name: Publish draft tags
         if: join(fromJSON(needs.project_types.outputs.docker_images)) != ''
         uses: akhilerm/tag-push-action@v2.0.0
@@ -1038,20 +1038,6 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar -xvf ${{ runner.temp }}/source.tgz
-      - name: Login to GitHub Container Registry
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
-      - name: Login to Docker Hub
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
       - name: Set env vars
         run: |
           if [ ${{ matrix.target }} != 'default' ]
@@ -1086,6 +1072,20 @@ jobs:
           flavor: |
             latest=auto
             prefix=${{ env.PREFIX }},onlatest=true
+      - name: Login to GitHub Container Registry
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
+      - name: Login to Docker Hub
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
       - name: Publish final tags
         uses: akhilerm/tag-push-action@v2.0.0
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1046,22 +1046,6 @@ jobs:
           - 5000:5000
 
     steps:
-      - name: Login to GitHub Container Registry
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
-
-      - name: Login to Docker Hub
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
-
       - *downloadSourceArtifact
       - *extractSourceArtifact
 
@@ -1160,6 +1144,22 @@ jobs:
         if: join(fromJSON(needs.project_types.outputs.docker_images)) != '' && steps.compose_test.result == 'skipped'
         run: echo "::warning::Publishing Docker images without docker compose tests!"
 
+      - name: Login to GitHub Container Registry
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
+
+      - name: Login to Docker Hub
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
+
       - name: Publish draft tags
         if: join(fromJSON(needs.project_types.outputs.docker_images)) != ''
         uses: akhilerm/tag-push-action@v2.0.0
@@ -1191,22 +1191,6 @@ jobs:
     steps:
       - *downloadSourceArtifact
       - *extractSourceArtifact
-
-      - name: Login to GitHub Container Registry
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ env.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
-
-      - name: Login to Docker Hub
-        continue-on-error: true
-        uses: docker/login-action@v2
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
 
       - name: Set env vars
         run: |
@@ -1248,6 +1232,22 @@ jobs:
           flavor: |
             latest=auto
             prefix=${{ env.PREFIX }},onlatest=true
+
+      - name: Login to GitHub Container Registry
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_USER }}
+          password: ${{ secrets.GHCR_TOKEN || secrets.FLOWZONE_TOKEN }}
+
+      - name: Login to Docker Hub
+        continue-on-error: true
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
 
       # only one of the destination lines should have values based on the meta restrictions above
       - name: Publish final tags


### PR DESCRIPTION
This prevents docker credentials from leaking into arbitrary test code.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/product-os/flowzone/issues/332