### PR TITLE
Skip custom actions for external contributions by default

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -138,6 +138,11 @@ on:
         type: string
         required: false
         default: ""
+      restrict_custom_actions:
+        description: Do not execute custom actions for external contributors. Only remove this restriction if custom actions have been vetted as secure.
+        type: boolean
+        required: false
+        default: true
       custom_test_matrix:
         description: Comma-delimited string of values that will be passed to the custom test action
         type: string
@@ -500,7 +505,8 @@ jobs:
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
-      - name: Check for custom jobs
+      - name: Check for custom actions
+        if: github.event.pull_request.head.repo.full_name == github.repository || inputs.restrict_custom_actions == false
         id: custom
         working-directory: .
         run: |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`protect_branch`](#protect_branch)
     - [`disable_versioning`](#disable_versioning)
     - [`required_approving_review_count`](#required_approving_review_count)
+    - [`restrict_custom_actions`](#restrict_custom_actions)
     - [`custom_test_matrix`](#custom_test_matrix)
     - [`custom_publish_matrix`](#custom_publish_matrix)
     - [`custom_finalize_matrix`](#custom_finalize_matrix)
@@ -455,6 +456,14 @@ Setting this value to zero effectively means merge==deploy without approval(s).
 Type: _string_
 
 Default: `''`
+
+#### `restrict_custom_actions`
+
+Do not execute custom actions for external contributors. Only remove this restriction if custom actions have been vetted as secure.
+
+Type: _boolean_
+
+Default: `true`
 
 #### `custom_test_matrix`
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -157,6 +157,11 @@ on:
         type: string
         required: false
         default: ""
+      restrict_custom_actions:
+        description: "Do not execute custom actions for external contributors. Only remove this restriction if custom actions have been vetted as secure."
+        type: boolean
+        required: false
+        default: true
       custom_test_matrix:
         description: "Comma-delimited string of values that will be passed to the custom test action"
         type: string
@@ -582,7 +587,9 @@ jobs:
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Check for custom jobs
+      - name: Check for custom actions
+        # skip custom actions for external contributions by default
+        if: github.event.pull_request.head.repo.full_name == github.repository || inputs.restrict_custom_actions == false
         id: custom
         working-directory: .
         run: |


### PR DESCRIPTION
This toggle can be changed via an input after the custom actions have been vetted for security and cannot leak secrets.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/product-os/flowzone/issues/332