### PR TITLE
Avoid leaking npm secrets during npm tests

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -718,7 +718,8 @@ jobs:
           echo "branch_tag=${branch_tag}" >> $GITHUB_OUTPUT
           echo "sha_tag=${sha_tag}" >> $GITHUB_OUTPUT
           echo "version_tag=${version_tag}" >> $GITHUB_OUTPUT
-      - name: Login to registry
+      - name: Login to registry for private dependencies
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
             echo '//${{ env.NPM_REGISTRY }}/:_authToken=${{ secrets.NPM_TOKEN }}' > ~/.npmrc

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -833,7 +833,9 @@ jobs:
           echo "sha_tag=${sha_tag}" >> $GITHUB_OUTPUT
           echo "version_tag=${version_tag}" >> $GITHUB_OUTPUT
 
-      - name: Login to registry
+      - name: Login to registry for private dependencies
+        # do not log in for external contributions to avoid leaking secrets
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
             echo '//${{ env.NPM_REGISTRY }}/:_authToken=${{ secrets.NPM_TOKEN }}' > ~/.npmrc


### PR DESCRIPTION
Do not login to the npm registry if the pull request is an external contribution.

The npm scripts like preinstall and test are considered arbitrary code and cannot be trusted with secrets in the environment.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/product-os/flowzone/issues/332