### PR TITLE
Run clippy using cross for rust targets

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1526,13 +1526,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-          components: rustfmt, clippy
+          components: rustfmt
       - name: Check formatting
         run: cargo fmt --check
-      - name: Lint with clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Install cross
         run: cargo install cross
+      - name: Lint with clippy
+        run: cross clippy --all-targets --all-features -- -D warnings
       - name: Run tests for toolchain ${{ matrix.target }}
         run: cross test --target ${{ matrix.target }}
       - name: Generate metadata

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -97,7 +97,7 @@ on:
         description: Comma-delimited string of Rust stable targets to publish (skipped if empty)
         type: string
         required: false
-        default: aarch64-unknown-linux-gnu, armv7-unknown-linux-gnueabi, arm-unknown-linux-gnueabihf, x86_64-unknown-linux-gnu, i686-unknown-linux-gnu
+        default: aarch64-unknown-linux-gnu, armv7-unknown-linux-gnueabihf, arm-unknown-linux-gnueabihf, x86_64-unknown-linux-gnu, i686-unknown-linux-gnu
       rust_binaries:
         description: Set to true to publish Rust binary release artifacts to GitHub
         type: boolean

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Multiple versions (>=3.7, <3.11) of Python will be tested as long as they meet t
 
 If a `Cargo.toml` file is found in the root of the repository, Flowzone will run tests on the code formatting (using `cargo fmt` and `cargo clippy`) and then run tests for a set of target architectures given in [`cargo_targets`](#cargo_targets). In order to disable Rust testing, set the value of that variable to `""`.
 
+For cross building targets, flowzone uses [cross](https://github.com/cross-rs/cross). This also means that further build options (e.g. [pre-build hooks](https://github.com/cross-rs/cross#pre-build-hook)) can be defined by adding a `Cross.toml` file to the local repository.
+
 When [`rust_binaries`](#rust_binaries) is set to `true`, Flowzone will also build release artifacts for each target architecture given in [`cargo_targets`](#cargo_targets) and upload the artifacts to the GitHub release.
 
 ### GitHub

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1697,16 +1697,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-          components: rustfmt, clippy
+          components: rustfmt
 
       - name: Check formatting
         run: cargo fmt --check
 
-      - name: Lint with clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
       - name: Install cross
         run: cargo install cross
+
+      - name: Lint with clippy
+        run: cross clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests for toolchain ${{ matrix.target }}
         run: cross test --target ${{ matrix.target }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -113,7 +113,7 @@ on:
         type: string
         required: false
         default: aarch64-unknown-linux-gnu,
-          armv7-unknown-linux-gnueabi,
+          armv7-unknown-linux-gnueabihf,
           arm-unknown-linux-gnueabihf,
           x86_64-unknown-linux-gnu,
           i686-unknown-linux-gnu


### PR DESCRIPTION
Clippy needs to install repository dependencies before running. These dependencies may sometimes require external packages, which are provided by `cross` [pre-build hook](https://github.com/cross-rs/cross#pre-build-hook) feature.

This PR changes the rust steps order so clippy is run using cross instead of default cargo.

Change-type: patch