### PR TITLE
Use merge_commit_sha to checkout PR sources

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -262,7 +262,7 @@ jobs:
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
           submodules: recursive
           token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
       - name: Convert balena_slugs to a JSON array
         id: balena_slugs
         uses: kanga333/json-array-builder@v0.2.1
@@ -600,8 +600,6 @@ jobs:
     outputs:
       new_tag: ${{ steps.new_version.outputs.tag || steps.git_describe.outputs.tag }}
       version: ${{ steps.new_version.outputs.semver }}
-    env:
-      merge_ref: refs/pull/${{ github.event.number }}/merge
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -609,7 +607,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: ${{ github.event.head_commit.id || env.merge_ref }}
+          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
       - name: Reject merge commits
         run: |
           if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -308,7 +308,7 @@ jobs:
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
           submodules: "recursive"
           token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
 
       - name: Convert balena_slugs to a JSON array
         id: balena_slugs
@@ -696,9 +696,6 @@ jobs:
       new_tag: ${{ steps.new_version.outputs.tag || steps.git_describe.outputs.tag }}
       version: ${{ steps.new_version.outputs.semver }}
 
-    env:
-      merge_ref: "refs/pull/${{ github.event.number }}/merge"
-
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -708,7 +705,7 @@ jobs:
           token: ${{ secrets.FLOWZONE_TOKEN }}
           # we need the merge commit in the checkout in order to push versioned changes
           # otherwise our branch appears to be behind upstream
-          ref: ${{ github.event.head_commit.id || env.merge_ref }}
+          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
 
       # fail on merge commits (ones with more than one parent)
       - name: Reject merge commits


### PR DESCRIPTION
Using the direct link to refs/pull does not work for merged PRs.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/product-os/flowzone/pull/346