### PR TITLE
Avoid failing Flowzone self-tests when COMPOSE_VARS is unset

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -5,8 +5,6 @@
 # was instantiated correctly
 if [ -z "${REPO_SECRET}" ]; then
 	echo "REPO_SECRET is not set"
-	exit 1
 else
 	echo "value ${REPO_SECRET} found"
-	exit 0
 fi


### PR DESCRIPTION
We block external contributors when this secret is set so in order to allow contributions to flowzone itself we need to remove the secret and avoid failing the docker compose tests.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/product-os/flowzone/issues/332, https://github.com/product-os/flowzone/pull/336