### PR TITLE
Fix refence to merge_commit_sha that was returning empty

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -262,7 +262,7 @@ jobs:
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
           submodules: recursive
           token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.head_commit.id }}
       - name: Convert balena_slugs to a JSON array
         id: balena_slugs
         uses: kanga333/json-array-builder@v0.2.1
@@ -607,7 +607,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.head_commit.id }}
       - name: Reject merge commits
         run: |
           if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -308,7 +308,7 @@ jobs:
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
           submodules: "recursive"
           token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.head_commit.id }}
 
       - name: Convert balena_slugs to a JSON array
         id: balena_slugs
@@ -705,7 +705,7 @@ jobs:
           token: ${{ secrets.FLOWZONE_TOKEN }}
           # we need the merge commit in the checkout in order to push versioned changes
           # otherwise our branch appears to be behind upstream
-          ref: ${{ github.event.pull_request.head.merge_commit_sha || github.event.head_commit.id }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.head_commit.id }}
 
       # fail on merge commits (ones with more than one parent)
       - name: Reject merge commits


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>