### PR TITLE
Allow GitHub pre-release(s)

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -138,6 +138,11 @@ on:
         type: string
         required: false
         default: ""
+      github_prerelease:
+        description: Finalise releases on merge.
+        type: boolean
+        required: false
+        default: false
       restrict_custom_actions:
         description: Do not execute custom actions for external contributors. Only remove this restriction if custom actions have been vetted as secure.
         type: boolean
@@ -1468,13 +1473,16 @@ jobs:
               --notes "${release_notes}" \
               --title 'v${{ needs.versioned_source.outputs.version }}' \
               --tag 'v${{ needs.versioned_source.outputs.version }}' \
-              --prerelease=false \
+              --prerelease='${{ inputs.github_prerelease }}' \
               --draft=false
-            release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/v${{ needs.versioned_source.outputs.version }}" \
-              -H 'Accept: application/vnd.github+json' | jq -r .id)"
-            gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
-              -H 'Accept: application/vnd.github+json' \
-              -F make_latest="true"
+
+            if [[ ${{ inputs.github_prerelease }} =~ false ]]; then
+                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/v${{ needs.versioned_source.outputs.version }}" \
+                  -H 'Accept: application/vnd.github+json' | jq -r .id)"
+                gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
+                  -H 'Accept: application/vnd.github+json' \
+                  -F make_latest=true
+            fi
           else
             echo "No release found for the current PR"
           fi

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`protect_branch`](#protect_branch)
     - [`disable_versioning`](#disable_versioning)
     - [`required_approving_review_count`](#required_approving_review_count)
+    - [`github_prerelease`](#github_prerelease)
     - [`restrict_custom_actions`](#restrict_custom_actions)
     - [`custom_test_matrix`](#custom_test_matrix)
     - [`custom_publish_matrix`](#custom_publish_matrix)
     - [`custom_finalize_matrix`](#custom_finalize_matrix)
+
 - [Maintenance](#maintenance)
   - [Generate GPG keys](#generate-gpg-keys)
 - [Help](#help)
@@ -224,7 +226,7 @@ An example of multiple bake targets can be found here: <https://github.com/balen
 
 If a `balena.yml` file is found in the root of the repository Flowzone will attempt to push draft releases to your fleet's slug(s) and finalize on merge.
 
-This will **require** either your organization or your repository to have a balenaCloud API key set as a secret named `BALENA_API_KEY`. If you intend to set the secret at the org level then make sure that the API key is valid for all repositories in that organization. A repository-level secret will override an organization-level secret. This API key will be used to login into balena-cli and push draft releases to your fleet in balenaCloud.  
+This will **require** either your organization or your repository to have a balenaCloud API key set as a secret named `BALENA_API_KEY`. If you intend to set the secret at the org level then make sure that the API key is valid for all repositories in that organization. A repository-level secret will override an organization-level secret. This API key will be used to login into balena-cli and push draft releases to your fleet in balenaCloud.
 
 To disable publishing of releases to balenaCloud set [`balena_slugs`](#balena_slugs) to `""`.
 
@@ -492,6 +494,14 @@ Setting this value to zero effectively means merge==deploy without approval(s).
 Type: _string_
 
 Default: `''`
+
+#### `github_prerelease`
+
+Make GitHub release final on merge.
+
+Type: _boolean_
+
+Default: `false`
 
 #### `restrict_custom_actions`
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -157,6 +157,11 @@ on:
         type: string
         required: false
         default: ""
+      github_prerelease:
+        description: "Finalise releases on merge."
+        type: boolean
+        required: false
+        default: false
       restrict_custom_actions:
         description: "Do not execute custom actions for external contributors. Only remove this restriction if custom actions have been vetted as secure."
         type: boolean
@@ -1647,13 +1652,16 @@ jobs:
               --notes "${release_notes}" \
               --title 'v${{ needs.versioned_source.outputs.version }}' \
               --tag 'v${{ needs.versioned_source.outputs.version }}' \
-              --prerelease=false \
+              --prerelease='${{ inputs.github_prerelease }}' \
               --draft=false
-            release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/v${{ needs.versioned_source.outputs.version }}" \
-              -H 'Accept: application/vnd.github+json' | jq -r .id)"
-            gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
-              -H 'Accept: application/vnd.github+json' \
-              -F make_latest="true"
+
+            if [[ ${{ inputs.github_prerelease }} =~ false ]]; then
+                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/v${{ needs.versioned_source.outputs.version }}" \
+                  -H 'Accept: application/vnd.github+json' | jq -r .id)"
+                gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
+                  -H 'Accept: application/vnd.github+json' \
+                  -F make_latest=true
+            fi
           else
             echo "No release found for the current PR"
           fi


### PR DESCRIPTION
This change allows projects like Etcher to be configured to not make every release final, thus avoiding signalling potentially garbage/invalid releases to the world.

It is entirely possible for all Etcher tests to pass with flying colours (green that is) and still not work once installed on one or more platforms. One way to gain more confidence here is to expand Etcher test coverage, implementing proper e2e tests, but we are not there yet.

So, setting `github_prerelease: true` on Etcher repository will create GH releases and enable manual testing to take place before marking a release final/latest.

cc @aethernet @zwhitchcox @mcraa 