### PR TITLE
Add input for custom website build

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -213,6 +213,11 @@ on:
         type: string
         required: false
         default: ""
+      docusaurus_website:
+        description: Set to false to disable building a docusaurus website. If false the script `npm run deploy-docs` will be run if it exists.
+        type: boolean
+        required: false
+        default: false
       github_prerelease:
         description: Finalise releases on merge.
         type: boolean
@@ -1414,7 +1419,6 @@ jobs:
       - versioned_source
       - event_types
     if: |
-      needs.project_types.outputs.has_readme == 'true' &&
       inputs.cloudflare_website != ''
     steps:
       - name: Download source artifact
@@ -1430,12 +1434,19 @@ jobs:
         with:
           node-version: 18
       - name: Docusaurus Builder
-        uses: product-os/docusaurus-builder@master
+        if: |
+          needs.project_types.outputs.has_readme == 'true' &&
+          inputs.docusaurus_website != false
+        uses: product-os/docusaurus-theme@9cb615b78bcf2c2f9d8fa683a296a52d7beefae1
         with:
           repo: ${{ github.event.repository.name }}
           org: ${{ github.repository_owner }}
           default_branch: ${{ github.event.repository.default_branch }}
-          url: https://${{ inputs.cloudflare_website }}.pages.dev
+          url: https://${{ inputs.cloudflare_website }}.pages.dev/
+      - name: Custom Website Builder
+        if: |
+          inputs.docusaurus_website == false
+        run: npm run deploy-docs --if-present
       - name: Update deploy branch for merged PRs
         if: needs.event_types.outputs.pr_merged == 'true'
         run: |
@@ -2070,7 +2081,7 @@ jobs:
             exit 1
           fi
 
-          # here the number of required approvals sent to the gh API is checked back from the PUT response from GH api 
+          # here the number of required approvals sent to the gh API is checked back from the PUT response from GH api
           # Specifies the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers (successful checks => merge) .
           if [[ $(echo "$result" | jq '.required_pull_request_reviews.required_approving_review_count') -ne ${{ inputs.required_approving_review_count }} ]]; then
             echo "::warning::Failed to set required approvers count. Check that branch protection is enabled on your repo and try again."

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
   - [Custom](#custom)
   - [Versioning](#versioning)
   - [Docs](#docs)
+  - [Website](#Website)
 - [Customization](#customization)
   - [Secrets](#secrets)
     - [`FLOWZONE_TOKEN`](#flowzone_token)
@@ -71,6 +72,8 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`custom_test_matrix`](#custom_test_matrix)
     - [`custom_publish_matrix`](#custom_publish_matrix)
     - [`custom_finalize_matrix`](#custom_finalize_matrix)
+    - [`cloudflare_website`](#cloudflare_website)
+    - [`docusaurus_website`](#docusaurus_website)
 
 - [Maintenance](#maintenance)
   - [Generate GPG keys](#generate-gpg-keys)
@@ -318,6 +321,13 @@ If you have [VersionBot3](https://github.com/apps/versionbot3) installed it will
 ### Docs
 
 If you have an `npm run doc` script then it will automatically be run and the generated `docs` folder will be published to a `docs` branch for github pages use.
+
+### Website
+
+If you have docs that you intend to publish on a website, checkout the [Getting Started](https://docusaurus-builder.pages.dev/) section of the Docusaurus builder. The docs will be built using the Docusaurus framework and published on Cloudflare Pages. 
+
+If you intend to use a custom framework for your docs build, then you can make use of the custom website build option by adding your desired build command in a input called `custom_website_build`. This command should generate your static site into a folder called `build` which will then be deployed to Cloudflare Pages. 
+
 
 ## Customization
 
@@ -669,6 +679,22 @@ Comma-delimited string of values that will be passed to the custom finalize acti
 Type: _string_
 
 Default: `''`
+
+#### `cloudflare_website`
+
+Setting this to your existing CF pages project name will generate and deploy a website. Skipped if empty.
+
+Type: _string_
+
+Default: `""`
+
+#### `docusaurus_website`
+
+Set to false to disable building a docusaurus website. If false the script `npm run deploy-docs` will be run if it exists.
+
+Type: _string_
+
+Default: true
 
 ## Maintenance
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -232,11 +232,11 @@ on:
         type: string
         required: false
         default: ""
-      custom_website_build:
-        description: "Add the custom command or script you want to run to build the website. Skipped if empty."
-        type: string
+      docusaurus_website:
+        description: "Set to false to disable building a docusaurus website. If false the script `npm run deploy-docs` will be run if it exists."
+        type: boolean
         required: false
-        default: ""
+        default: false
       github_prerelease:
         description: "Finalise releases on merge."
         type: boolean
@@ -708,12 +708,12 @@ jobs:
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
-      # Check if we have atleast a README to build a website from
+      # Check if we have at least a README to build a website from
 
       - name: Check for README for building a website
         id: has_readme
         run: |
-          if test -f "README.md"
+          if test -e "README.md"
           then
             echo "found README.md"
             echo "enabled=true" >> $GITHUB_OUTPUT
@@ -1607,10 +1607,15 @@ jobs:
     runs-on: ${{fromJSON(inputs.runs_on)}}
     env:
      CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
+
     needs:
       - project_types
       - versioned_source
       - event_types
+
+    if: |
+      inputs.cloudflare_website != ''
+
     steps:
       - *downloadSourceArtifact
       - *extractSourceArtifact
@@ -1622,8 +1627,8 @@ jobs:
       - name: Docusaurus Builder
         if: |
           needs.project_types.outputs.has_readme == 'true' &&
-          inputs.cloudflare_website != '' && inputs.custom_website_build = ''
-        uses: product-os/docusaurus-theme@master
+          inputs.docusaurus_website != false
+        uses: product-os/docusaurus-theme@9cb615b78bcf2c2f9d8fa683a296a52d7beefae1 # 1.3.0
         with:
           repo: ${{ github.event.repository.name }}
           org: ${{ github.repository_owner }}
@@ -1632,8 +1637,8 @@ jobs:
 
       - name: Custom Website Builder
         if: |
-          inputs.custom_website_build != ''
-        run: ${{ inputs.custom_website_build }}
+          inputs.docusaurus_website == false
+        run: npm run deploy-docs --if-present
 
       - name: Update deploy branch for merged PRs
         if: needs.event_types.outputs.pr_merged == 'true'
@@ -1645,7 +1650,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages publish --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} $GITHUB_WORKSPACE/build/ >> $GITHUB_STEP_SUMMARY
+          command: pages publish --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ >> $GITHUB_STEP_SUMMARY
 
   ###################################################
   # GitHub
@@ -2267,7 +2272,7 @@ jobs:
             exit 1
           fi
 
-          # here the number of required approvals sent to the gh API is checked back from the PUT response from GH api 
+          # here the number of required approvals sent to the gh API is checked back from the PUT response from GH api
           # Specifies the number of reviewers required to approve pull requests. Use a number between 1 and 6 or 0 to not require reviewers (successful checks => merge) .
           if [[ $(echo "$result" | jq '.required_pull_request_reviews.required_approving_review_count') -ne ${{ inputs.required_approving_review_count }} ]]; then
             echo "::warning::Failed to set required approvers count. Check that branch protection is enabled on your repo and try again."

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -232,6 +232,11 @@ on:
         type: string
         required: false
         default: ""
+      custom_website_build:
+        description: "Add the custom command or script you want to run to build the website. Skipped if empty."
+        type: string
+        required: false
+        default: ""
       github_prerelease:
         description: "Finalise releases on merge."
         type: boolean
@@ -704,10 +709,11 @@ jobs:
           fi
 
       # Check if we have atleast a README to build a website from
+
       - name: Check for README for building a website
         id: has_readme
         run: |
-          if test -e "README.md"
+          if test -f "README.md"
           then
             echo "found README.md"
             echo "enabled=true" >> $GITHUB_OUTPUT
@@ -1605,9 +1611,6 @@ jobs:
       - project_types
       - versioned_source
       - event_types
-    if: |
-      needs.project_types.outputs.has_readme == 'true' &&
-      inputs.cloudflare_website != ''
     steps:
       - *downloadSourceArtifact
       - *extractSourceArtifact
@@ -1617,12 +1620,20 @@ jobs:
           node-version: 18
 
       - name: Docusaurus Builder
-        uses: product-os/docusaurus-builder@master
+        if: |
+          needs.project_types.outputs.has_readme == 'true' &&
+          inputs.cloudflare_website != '' && inputs.custom_website_build = ''
+        uses: product-os/docusaurus-theme@master
         with:
           repo: ${{ github.event.repository.name }}
           org: ${{ github.repository_owner }}
           default_branch: ${{ github.event.repository.default_branch }}
-          url: https://${{ inputs.cloudflare_website }}.pages.dev
+          url: https://${{ inputs.cloudflare_website }}.pages.dev/
+
+      - name: Custom Website Builder
+        if: |
+          inputs.custom_website_build != ''
+        run: ${{ inputs.custom_website_build }}
 
       - name: Update deploy branch for merged PRs
         if: needs.event_types.outputs.pr_merged == 'true'
@@ -1634,7 +1645,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages publish --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ >> $GITHUB_STEP_SUMMARY
+          command: pages publish --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} $GITHUB_WORKSPACE/build/ >> $GITHUB_STEP_SUMMARY
 
   ###################################################
   # GitHub


### PR DESCRIPTION
BalenaCloud docs is the special butterfly that would need this custom website build command to enable it's deployment on Cloudflare Pages using Flowzone. This is a patch until we can actually move the balenaCloud docs to Docusaurus but that will take a long time and this custom way of building websites could potenially be useful to others. 

Things to check 

- [x] @vipulgupta2048 will test the working balena-docs
- [x] Reviewers can check out the security implications of providing a free for all command to the users. 
