### PR TITLE
Pin the default worker to ubuntu-22.04

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -62,7 +62,7 @@ on:
         description: GitHub Actions runner type.
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
       jobs_timeout_minutes:
         description: Timeout for the job(s).
         type: number
@@ -207,7 +207,7 @@ on:
         description: GitHub Actions runner type for custom jobs.
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
       cloudflare_website:
         description: Setting this to your existing CF pages project name will generate and deploy a website. Skipped if empty.
         type: string

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -77,7 +77,7 @@ on:
         description: "GitHub Actions runner type."
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
       jobs_timeout_minutes:
         description: "Timeout for the job(s)."
         type: number
@@ -226,7 +226,7 @@ on:
         description: GitHub Actions runner type for custom jobs.
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["ubuntu-22.04"]'
       cloudflare_website:
         description: "Setting this to your existing CF pages project name will generate and deploy a website. Skipped if empty."
         type: string


### PR DESCRIPTION
Recently the ubuntu-latest link has started to change from 20.04 to 22.04 and we were caught off guard.

This commit will set the default worker to ubuntu-22.04 unless otherwise specified.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/product-os/flowzone/issues/397