### PR TITLE
Allow continue on error when pushing versioned commit

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -798,6 +798,7 @@ jobs:
           git log -n 2
       - name: Push versioned commit
         if: inputs.disable_versioning != true && needs.event_types.outputs.pr_merged == 'true'
+        continue-on-error: true
         run: |
           git push origin HEAD:${{ github.base_ref }}
           # We push the tag separately so that it is only pushed if the commit push succeed, this avoids

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -912,6 +912,7 @@ jobs:
       # push the versioned commit only if the PR is merged
       - name: Push versioned commit
         if: inputs.disable_versioning != true && needs.event_types.outputs.pr_merged == 'true'
+        continue-on-error: true
         run: |
           git push origin HEAD:${{ github.base_ref }}
           # We push the tag separately so that it is only pushed if the commit push succeed, this avoids


### PR DESCRIPTION
If we need to re-run a merge job due to a failed publish, we don't want to be blocked by the fact that the commit already exists in the base branch.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>