### PR TITLE
Update previous tag search to match the v prefix

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1581,11 +1581,13 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
           previous_tag="$(git tag -l --sort=-version:refname "v*" | head -n1)"
-          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="$(mktemp)"
+
+          git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference > "${release_notes}"
 
           if gh release view '${{ github.event.pull_request.head.ref }}'; then
             gh release edit '${{ github.event.pull_request.head.ref }}' \
-              --notes "${release_notes}" \
+              --notes-file "${release_notes}" \
               --title 'v${{ needs.versioned_source.outputs.version }}' \
               --tag 'v${{ needs.versioned_source.outputs.version }}' \
               --prerelease='${{ inputs.github_prerelease }}' \

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1580,7 +1580,7 @@ jobs:
           set -ea
           # prevent git from existing with 141
           set +o pipefail
-          previous_tag="$(git tag --sort=-version:refname | head -n 2 | tail -n 1)"
+          previous_tag="$(git tag -l --sort=-version:refname "v*" | head -n1)"
           release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
 
           if gh release view '${{ github.event.pull_request.head.ref }}'; then

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1755,11 +1755,13 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
           previous_tag="$(git tag -l --sort=-version:refname "v*" | head -n1)"
-          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="$(mktemp)"
+
+          git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference > "${release_notes}"
 
           if gh release view '${{ github.event.pull_request.head.ref }}'; then
             gh release edit '${{ github.event.pull_request.head.ref }}' \
-              --notes "${release_notes}" \
+              --notes-file "${release_notes}" \
               --title 'v${{ needs.versioned_source.outputs.version }}' \
               --tag 'v${{ needs.versioned_source.outputs.version }}' \
               --prerelease='${{ inputs.github_prerelease }}' \

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1754,7 +1754,7 @@ jobs:
           set -ea
           # prevent git from existing with 141
           set +o pipefail
-          previous_tag="$(git tag --sort=-version:refname | head -n 2 | tail -n 1)"
+          previous_tag="$(git tag -l --sort=-version:refname "v*" | head -n1)"
           release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
 
           if gh release view '${{ github.event.pull_request.head.ref }}'; then


### PR DESCRIPTION
We encountered cases in balena-engine where the tag sorting did not return the expected most recent v tag.