### PR TITLE
Move workflow de-duplication condition into flowzone core

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -261,8 +261,9 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     if: |
-      (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && inputs.disable_versioning == true)
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && inputs.disable_versioning == true) ||
+      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
+      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     outputs:
       pr: ${{ steps.pr.outcome == 'success' }}
       pr_opened: ${{ steps.pr_opened.outcome == 'success' }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1984,7 +1984,8 @@ jobs:
     if: |
       always() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      inputs.protect_branch == true
+      inputs.protect_branch == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       result: ${{ steps.apply_branch_protection_rules.outputs.result }}
     defaults:

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -926,6 +926,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - project_types
       - versioned_source
       - npm_test
@@ -1037,6 +1038,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - project_types
       - versioned_source
     if: |
@@ -1485,6 +1487,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - project_types
       - versioned_source
     if: |
@@ -1519,6 +1522,7 @@ jobs:
       - npm_publish
       - cargo_publish
       - custom_publish
+      - event_types
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true'
@@ -1709,6 +1713,7 @@ jobs:
       - versioned_source
       - cargo_test
       - custom_test
+      - event_types
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   flowzone:
     name: Flowzone
-    if: |
-      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
-      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     uses: ./.github/workflows/flowzone.yml
     secrets: inherit
     with:

--- a/README.md
+++ b/README.md
@@ -110,11 +110,6 @@ jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
-    # prevent duplicate workflows and only allow one `pull_request` or `pull_request_target` for
-    # internal or external contributions respectively
-    if: |
-      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
-      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets:
       FLOWZONE_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
       GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -146,11 +141,6 @@ jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
-    # prevent duplicate workflows and only allow one `pull_request` or `pull_request_target` for
-    # internal or external contributions respectively
-    if: |
-      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
-      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
     secrets: inherit
 ```
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1055,7 +1055,7 @@ jobs:
     name: Publish npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [project_types, versioned_source, npm_test, custom_test]
+    needs: [event_types, project_types, versioned_source, npm_test, custom_test]
     if: |
       !failure() && !cancelled() &&
       needs.npm_test.result == 'success' &&
@@ -1183,7 +1183,7 @@ jobs:
     name: Test docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [project_types, versioned_source]
+    needs: [event_types, project_types, versioned_source]
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&
@@ -1661,6 +1661,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - project_types
       - versioned_source
     if: |
@@ -1692,6 +1693,7 @@ jobs:
       - npm_publish
       - cargo_publish
       - custom_publish
+      - event_types
 
     if: |
       !failure() && !cancelled() &&
@@ -1889,6 +1891,7 @@ jobs:
       - versioned_source
       - cargo_test
       - custom_test
+      - event_types
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -316,8 +316,9 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     # all jobs depend on this one in some way so add global trigger rules here
     if: |
-      (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && inputs.disable_versioning == true)
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && inputs.disable_versioning == true) ||
+      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
+      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target')
 
     outputs:
       pr: ${{ steps.pr.outcome == 'success' }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2152,7 +2152,8 @@ jobs:
     if: |
       always() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      inputs.protect_branch == true
+      inputs.protect_branch == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     outputs:
       result: ${{ steps.apply_branch_protection_rules.outputs.result }}


### PR DESCRIPTION
This check to prevent duplicate runs when both pull_request and pull_request_target are triggered is always required, and is better defined inside Flowzone itself rather than the calling workflow.

Change-type: minor
Signed-off-by: Kyle Harding <kyle@balena.io>