### PR TITLE
Avoid name clashes by specifying branches with heads reference

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -830,7 +830,7 @@ jobs:
         if: inputs.disable_versioning != true && needs.event_types.outputs.pr_merged == 'true'
         continue-on-error: true
         run: |
-          git push origin HEAD:${{ github.base_ref }}
+          git push origin HEAD:refs/heads/${{ github.base_ref }}
           # We push the tag separately so that it is only pushed if the commit push succeed, this avoids
           # issues if something else updates the main branch whilst we're running and causes us to push
           # the tag successfully but not the main branch and breaks future versioning attempts

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -949,7 +949,7 @@ jobs:
         if: inputs.disable_versioning != true && needs.event_types.outputs.pr_merged == 'true'
         continue-on-error: true
         run: |
-          git push origin HEAD:${{ github.base_ref }}
+          git push origin HEAD:refs/heads/${{ github.base_ref }}
           # We push the tag separately so that it is only pushed if the commit push succeed, this avoids
           # issues if something else updates the main branch whilst we're running and causes us to push
           # the tag successfully but not the main branch and breaks future versioning attempts


### PR DESCRIPTION
From https://github.com/balena-os/meta-balena/actions/runs/3996330198/jobs/6856271201:

```
error: dst refspec 2.107.x matches more than one
error: failed to push some refs to 'https://github.com/balena-os/meta-balena'
Error: Process completed with exit code 1.
```