### PR TITLE
Save image to file before running compose tests

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1141,6 +1141,9 @@ jobs:
           set: |
             *.platform=${{ matrix.platform }}
           load: true
+      - name: Save image to file
+        run: |
+          docker save ${{ fromJSON(steps.meta.outputs.json).tags[0] }} > ${{ env.IMAGE_TAR }}
       - name: Run docker compose tests
         if: needs.project_types.outputs.docker_compose_yaml != ''
         env:
@@ -1160,9 +1163,6 @@ jobs:
 
           docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
           docker compose logs
-      - name: Save image to file
-        run: |
-          docker save ${{ fromJSON(steps.meta.outputs.json).tags[0] }} > ${{ env.IMAGE_TAR }}
       - name: Upload arifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1315,6 +1315,10 @@ jobs:
             *.platform=${{ matrix.platform }}
           load: true
 
+      - name: Save image to file
+        run: |
+          docker save ${{ fromJSON(steps.meta.outputs.json).tags[0] }} > ${{ env.IMAGE_TAR }}
+
       # run docker compose tests and print the logs from all services
       - name: Run docker compose tests
         if: needs.project_types.outputs.docker_compose_yaml != ''
@@ -1335,10 +1339,6 @@ jobs:
 
           docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
           docker compose logs
-
-      - name: Save image to file
-        run: |
-          docker save ${{ fromJSON(steps.meta.outputs.json).tags[0] }} > ${{ env.IMAGE_TAR }}
 
       # https://github.com/actions/upload-artifact
       - name: Upload arifacts


### PR DESCRIPTION
This prevents accidentally uploading images that were built with docker-compose tests.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>