### PR TITLE
Restore target prefix for non-default targets

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1197,6 +1197,12 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           path: ${{ runner.temp }}
+      - name: Set env vars
+        run: |
+          if [ ${{ matrix.target }} != 'default' ]
+          then
+            echo "PREFIX=$(echo ${{ matrix.target }} | sed 's/[^[:alnum:]]/-/g')-" >> $GITHUB_ENV
+          fi
       - name: Generate image tags
         id: meta
         uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1378,6 +1378,13 @@ jobs:
         with:
           path: ${{ runner.temp }}
 
+      - name: Set env vars
+        run: |
+          if [ ${{ matrix.target }} != 'default' ]
+          then
+            echo "PREFIX=$(echo ${{ matrix.target }} | sed 's/[^[:alnum:]]/-/g')-" >> $GITHUB_ENV
+          fi
+
       # https://github.com/docker/metadata-action
       - name: Generate image tags
         id: meta


### PR DESCRIPTION
This bug prevented the target name from being
prefixed on docker images tags.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>