### PR TITLE
Break monolithic jobs into smaller services

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -394,13 +394,13 @@ jobs:
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
-  process_source:
-    name: Process source
+  npm_check:
+    name: Check npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - sanitize_inputs
+      - versioned_source
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -409,62 +409,17 @@ jobs:
       npm: ${{ steps.npm.outputs.enabled }}
       npm_private: ${{ steps.npm.outputs.private }}
       npm_docs: ${{ steps.npm.outputs.docs }}
-      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
-      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
-      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
-      balena: ${{ steps.balena.outputs.enabled }}
       node_versions: ${{ steps.node_versions.outputs.json }}
-      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
-      python_versions: ${{ steps.python_versions.outputs.json }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
-      has_readme: ${{ steps.has_readme.outputs.enabled }}
-      custom_test: ${{ steps.custom.outputs.test }}
-      custom_publish: ${{ steps.custom.outputs.publish }}
-      custom_finalize: ${{ steps.custom.outputs.finalize }}
-      custom_clean: ${{ steps.custom.outputs.clean }}
-      custom_always: ${{ steps.custom.outputs.always }}
     steps:
-      - name: Checkout merge branch
-        if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
-        id: checkout_merge
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Download source artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: refs/pull/${{ github.event.number }}/merge
-      - name: Checkout sha
-        if: steps.checkout_merge.outcome == 'skipped'
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-        with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
-      - name: Check external contributor limitations
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-        run: |
-          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
-          then
-            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
-          then
-            echo "::notice::Modifications to workflow files are not supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
-          then
-            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
-              Please contact a member of the organization for assistance."
-            exit 0
-          fi
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+      - name: Extract source artifact
+        shell: pwsh
+        working-directory: .
+        run: tar -xvf ${{ runner.temp }}/source.tgz
       - name: Check for package.json
         id: npm
         run: |
@@ -534,6 +489,73 @@ jobs:
           if [ "${NODE_VERSIONS}" != "[]" ]
           then
             echo "json=${NODE_VERSIONS}" >> $GITHUB_OUTPUT
+          fi
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - context_check
+      - sanitize_inputs
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
+      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
+      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
+      balena: ${{ steps.balena.outputs.enabled }}
+      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
+      python_versions: ${{ steps.python_versions.outputs.json }}
+      cargo: ${{ steps.cargo.outputs.enabled }}
+      has_readme: ${{ steps.has_readme.outputs.enabled }}
+      custom_test: ${{ steps.custom.outputs.test }}
+      custom_publish: ${{ steps.custom.outputs.publish }}
+      custom_finalize: ${{ steps.custom.outputs.finalize }}
+      custom_clean: ${{ steps.custom.outputs.clean }}
+      custom_always: ${{ steps.custom.outputs.always }}
+    steps:
+      - name: Checkout merge branch
+        if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
+        id: checkout_merge
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.FLOWZONE_TOKEN }}
+          ref: refs/pull/${{ github.event.number }}/merge
+      - name: Checkout sha
+        if: steps.checkout_merge.outcome == 'skipped'
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.FLOWZONE_TOKEN }}
+      - name: Check external contributor limitations
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
+        run: |
+          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
+          then
+            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
+          then
+            echo "::notice::Modifications to workflow files are not supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
+          then
+            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
+              Please contact a member of the organization for assistance."
+            exit 0
           fi
       - name: Check for balena.yml
         id: balena
@@ -869,11 +891,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - npm_check
       - versioned_source
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.npm == 'true'
+      needs.npm_check.outputs.npm == 'true'
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -881,7 +903,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJSON(needs.process_source.outputs.node_versions) }}
+        node_version: ${{ fromJSON(needs.npm_check.outputs.node_versions) }}
     outputs:
       package: ${{ steps.meta.outputs.package }}
       version: ${{ steps.meta.outputs.version }}
@@ -957,14 +979,14 @@ jobs:
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
       - name: Generate docs (if present)
-        if: needs.process_source.outputs.npm_docs == 'true'
+        if: needs.npm_check.outputs.npm_docs == 'true'
         shell: bash
         run: npm run doc
       - name: Compress docs
-        if: needs.process_source.outputs.npm_docs == 'true'
+        if: needs.npm_check.outputs.npm_docs == 'true'
         run: tar -acvf ${{ runner.temp }}/docs.tgz ./docs
       - name: Upload artifact
-        if: needs.process_source.outputs.npm_docs == 'true'
+        if: needs.npm_check.outputs.npm_docs == 'true'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
@@ -976,14 +998,14 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - npm_check
       - npm_test
       - custom_test
     if: |
       !failure() && !cancelled() &&
       needs.npm_test.result == 'success' &&
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.npm_private != 'true'
+      needs.npm_check.outputs.npm_private != 'true'
     defaults:
       run:
         working-directory: .
@@ -993,7 +1015,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.npm_check.outputs.node_versions)[0] }}
       - name: Login to registry
         run: |
           echo '//${{ env.NPM_REGISTRY }}/:_authToken=${{ secrets.NPM_TOKEN }}' > ~/.npmrc
@@ -1018,11 +1040,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - npm_check
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.npm == 'true' &&
-      needs.process_source.outputs.npm_private != 'true'
+      needs.npm_check.outputs.npm == 'true' &&
+      needs.npm_check.outputs.npm_private != 'true'
     defaults:
       run:
         working-directory: .
@@ -1035,7 +1057,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.npm_check.outputs.node_versions)[0] }}
       - name: Login to registry
         run: |
           if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
@@ -1052,10 +1074,10 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - npm_check
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.npm_docs == 'true'
+      needs.npm_check.outputs.npm_docs == 'true'
     defaults:
       run:
         working-directory: .
@@ -1068,7 +1090,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
+          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.npm_check.outputs.node_versions)[0] }}
       - name: Extract docs artifact
         run: |
           docs="$(ls ${{ runner.temp }}/*.tgz | sort -t- -n -k3 | tail -n1)"

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -256,8 +256,8 @@ env:
   NPM_REGISTRY: registry.npmjs.org
   CARGO_REGISTRY: crates.io
 jobs:
-  event_types:
-    name: Event types
+  context_check:
+    name: Check context
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     if: |
@@ -311,15 +311,15 @@ jobs:
         id: tagged
         run: |
           echo "${JSON}" || true
-  project_types:
-    name: Project types
+  sanitize_inputs:
+    name: Sanitize inputs
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
+      - context_check
     defaults:
       run:
-        working-directory: ${{ inputs.working_directory }}
+        working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     outputs:
       balena_slugs: ${{ steps.balena_slugs.outputs.build }}
@@ -327,44 +327,11 @@ jobs:
       bake_targets: ${{ steps.bake_targets.outputs.build }}
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       docker_images_crlf: ${{ steps.docker_images_crlf.outputs.build }}
-      npm: ${{ steps.npm.outputs.enabled }}
-      npm_private: ${{ steps.npm.outputs.private }}
-      npm_docs: ${{ steps.npm.outputs.docs }}
-      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
-      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
-      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
-      balena: ${{ steps.balena.outputs.enabled }}
-      node_versions: ${{ steps.node_versions.outputs.json }}
-      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
-      python_versions: ${{ steps.python_versions.outputs.json }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
-      has_readme: ${{ steps.has_readme.outputs.enabled }}
-      custom_test: ${{ steps.custom.outputs.test }}
       custom_test_matrix: ${{ steps.custom_test_matrix.outputs.build }}
-      custom_publish: ${{ steps.custom.outputs.publish }}
       custom_publish_matrix: ${{ steps.custom_publish_matrix.outputs.build }}
-      custom_finalize: ${{ steps.custom.outputs.finalize }}
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.build }}
-      custom_clean: ${{ steps.custom.outputs.clean }}
-      custom_always: ${{ steps.custom.outputs.always }}
     steps:
-      - name: Checkout merge branch
-        if: github.event_name == 'pull_request_target' && needs.event_types.outputs.pr_closed != true
-        id: checkout_merge
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-        with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: refs/pull/${{ github.event.number }}/merge
-      - name: Checkout sha
-        if: steps.checkout_merge.outcome == 'skipped'
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-        with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
-      - name: Convert balena_slugs to a JSON array
+      - name: Convert balena_slugs to json
         id: balena_slugs
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
         env:
@@ -372,7 +339,7 @@ jobs:
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
-      - name: Convert docker_images to a JSON array
+      - name: Convert docker_images to json
         id: docker_images
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
         env:
@@ -380,7 +347,7 @@ jobs:
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
-      - name: Convert bake_targets to a JSON array
+      - name: Convert bake_targets to json
         id: bake_targets
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
         env:
@@ -388,7 +355,7 @@ jobs:
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
-      - name: Convert cargo_targets to a JSON array
+      - name: Convert cargo_targets to json
         id: cargo_targets
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
         env:
@@ -403,6 +370,76 @@ jobs:
           echo "build<<EOF" >> $GITHUB_OUTPUT
           echo "${build}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      - name: Convert custom_test_matrix to json
+        id: custom_test_matrix
+        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
+        env:
+          INPUT: ${{ inputs.custom_test_matrix }}
+        with:
+          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
+          separator: ","
+      - name: Convert custom_publish_matrix to json
+        id: custom_publish_matrix
+        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
+        env:
+          INPUT: ${{ inputs.custom_publish_matrix }}
+        with:
+          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
+          separator: ","
+      - name: Convert custom_finalize_matrix to json
+        id: custom_finalize_matrix
+        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
+        env:
+          INPUT: ${{ inputs.custom_finalize_matrix }}
+        with:
+          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
+          separator: ","
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - context_check
+      - sanitize_inputs
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      npm: ${{ steps.npm.outputs.enabled }}
+      npm_private: ${{ steps.npm.outputs.private }}
+      npm_docs: ${{ steps.npm.outputs.docs }}
+      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
+      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
+      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
+      balena: ${{ steps.balena.outputs.enabled }}
+      node_versions: ${{ steps.node_versions.outputs.json }}
+      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
+      python_versions: ${{ steps.python_versions.outputs.json }}
+      cargo: ${{ steps.cargo.outputs.enabled }}
+      has_readme: ${{ steps.has_readme.outputs.enabled }}
+      custom_test: ${{ steps.custom.outputs.test }}
+      custom_publish: ${{ steps.custom.outputs.publish }}
+      custom_finalize: ${{ steps.custom.outputs.finalize }}
+      custom_clean: ${{ steps.custom.outputs.clean }}
+      custom_always: ${{ steps.custom.outputs.always }}
+    steps:
+      - name: Checkout merge branch
+        if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
+        id: checkout_merge
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.FLOWZONE_TOKEN }}
+          ref: refs/pull/${{ github.event.number }}/merge
+      - name: Checkout sha
+        if: steps.checkout_merge.outcome == 'skipped'
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.FLOWZONE_TOKEN }}
       - name: Check external contributor limitations
         if: github.event.pull_request.head.repo.full_name != github.repository
         env:
@@ -644,30 +681,6 @@ jobs:
           then
             echo "always=true" >> $GITHUB_OUTPUT
           fi
-      - name: Convert custom_test_matrix to a JSON array
-        id: custom_test_matrix
-        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
-        env:
-          INPUT: ${{ inputs.custom_test_matrix }}
-        with:
-          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
-          separator: ","
-      - name: Convert custom_publish_matrix to a JSON array
-        id: custom_publish_matrix
-        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
-        env:
-          INPUT: ${{ inputs.custom_publish_matrix }}
-        with:
-          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
-          separator: ","
-      - name: Convert custom_finalize_matrix to a JSON array
-        id: custom_finalize_matrix
-        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
-        env:
-          INPUT: ${{ inputs.custom_finalize_matrix }}
-        with:
-          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
-          separator: ","
       - name: Pre-process Docker compose files
         id: docker_compose
         env:
@@ -701,7 +714,6 @@ jobs:
           echo "base64=$(docker compose ${args} config | base64 -w0)" >> $GITHUB_OUTPUT
       - name: Pre-process Docker bake files
         id: docker_bake
-        if: join(fromJSON(steps.docker_images.outputs.build)) != '' || steps.docker_compose.outputs.base64 != ''
         env:
           BAKE_FILE: /tmp/docker-bake.json
         run: |
@@ -709,11 +721,11 @@ jobs:
           then
             files="$(echo $(ls -1 docker-bake{.override,}.{json,hcl} 2>/dev/null) | sed 's/ / -f /')"
           else
-            echo '${{ steps.bake_targets.outputs.build }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
+            echo '${{ needs.sanitize_inputs.outputs.bake_targets }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
             files="${BAKE_FILE}"
           fi
 
-          json="$(docker buildx bake --print ${{ join(fromJSON(steps.bake_targets.outputs.build),' ') }} -f ${files} \
+          json="$(docker buildx bake --print ${{ join(fromJSON(needs.sanitize_inputs.outputs.bake_targets),' ') }} -f ${files} \
             | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
             | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
             | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
@@ -729,8 +741,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
     defaults:
       run:
         working-directory: .
@@ -740,7 +751,7 @@ jobs:
       version: ${{ steps.new_version.outputs.semver }}
     steps:
       - name: Checkout merge branch
-        if: github.event_name == 'pull_request_target' && needs.event_types.outputs.pr_closed != true
+        if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
         id: checkout_merge
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
@@ -763,7 +774,7 @@ jobs:
             exit 1
           fi
       - name: Import GPG key for signing commits
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549
         with:
@@ -773,11 +784,11 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Install versionist
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           npm install -g balena-versionist@0.14.12 versionist@6.9.2
       - name: Generate changelog
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           if [ ! -f .versionbot/CHANGELOG.yml ]
           then
@@ -793,13 +804,13 @@ jobs:
       - name: Get latest tag for current branch
         continue-on-error: true
         id: old_version
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n1)"
           echo "semver=${tag/v/}" >> $GITHUB_OUTPUT
           echo "tag=${tag}" >> $GITHUB_OUTPUT
       - name: Run versionist
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           balena-versionist
       - name: Git describe
@@ -807,7 +818,7 @@ jobs:
         run: echo "tag=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
       - name: Inspect versioned files
         id: new_version
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           git status --porcelain
           versions=()
@@ -836,7 +847,7 @@ jobs:
           git show -1
           git log -n 2
       - name: Push versioned commit
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr_merged == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr_merged == 'true'
         continue-on-error: true
         run: |
           git push origin HEAD:refs/heads/${{ github.base_ref }}
@@ -857,12 +868,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.npm == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.npm == 'true'
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -870,7 +881,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJSON(needs.project_types.outputs.node_versions) }}
+        node_version: ${{ fromJSON(needs.process_source.outputs.node_versions) }}
     outputs:
       package: ${{ steps.meta.outputs.package }}
       version: ${{ steps.meta.outputs.version }}
@@ -946,14 +957,14 @@ jobs:
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
       - name: Generate docs (if present)
-        if: needs.project_types.outputs.npm_docs == 'true'
+        if: needs.process_source.outputs.npm_docs == 'true'
         shell: bash
         run: npm run doc
       - name: Compress docs
-        if: needs.project_types.outputs.npm_docs == 'true'
+        if: needs.process_source.outputs.npm_docs == 'true'
         run: tar -acvf ${{ runner.temp }}/docs.tgz ./docs
       - name: Upload artifact
-        if: needs.project_types.outputs.npm_docs == 'true'
+        if: needs.process_source.outputs.npm_docs == 'true'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
@@ -964,16 +975,15 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
-      - versioned_source
+      - context_check
+      - process_source
       - npm_test
       - custom_test
     if: |
       !failure() && !cancelled() &&
       needs.npm_test.result == 'success' &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.npm_private != 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.npm_private != 'true'
     defaults:
       run:
         working-directory: .
@@ -983,7 +993,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.project_types.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
       - name: Login to registry
         run: |
           echo '//${{ env.NPM_REGISTRY }}/:_authToken=${{ secrets.NPM_TOKEN }}' > ~/.npmrc
@@ -1007,13 +1017,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
-      - versioned_source
+      - context_check
+      - process_source
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.npm == 'true' &&
-      needs.project_types.outputs.npm_private != 'true'
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.npm == 'true' &&
+      needs.process_source.outputs.npm_private != 'true'
     defaults:
       run:
         working-directory: .
@@ -1026,7 +1035,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.project_types.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
       - name: Login to registry
         run: |
           if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
@@ -1042,12 +1051,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
-      - versioned_source
+      - context_check
+      - process_source
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.npm_docs == 'true'
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.npm_docs == 'true'
     defaults:
       run:
         working-directory: .
@@ -1060,7 +1068,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.project_types.outputs.node_versions)[0] }}
+          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
       - name: Extract docs artifact
         run: |
           docs="$(ls ${{ runner.temp }}/*.tgz | sort -t- -n -k3 | tail -n1)"
@@ -1076,20 +1084,21 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
+      - sanitize_inputs
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_base64 != '')
+      (join(fromJSON(needs.process_source.outputs.docker_images)) != '' || needs.process_source.outputs.docker_compose_base64 != '')
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.project_types.outputs.docker_bake_matrix) }}
+      matrix: ${{ fromJSON(needs.process_source.outputs.docker_bake_matrix) }}
     env:
       DOCKER_BAKE_FILE: /tmp/docker-bake.json
       COMPOSE_FILE: docker-compose.yml
@@ -1122,7 +1131,7 @@ jobs:
 
           echo "PLATFORM=$(echo ${{ matrix.platform }} | sed 's/[^[:alnum:]]/-/g')" >> $GITHUB_ENV
 
-          echo '${{ needs.project_types.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
+          echo '${{ needs.process_source.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
           jq . "${DOCKER_BAKE_FILE}"
       - name: Generate image labels and sut tags
         id: meta
@@ -1131,7 +1140,7 @@ jobs:
           images: |
             sut
             localhost:5000/sut
-            ${{ needs.project_types.outputs.docker_images_crlf }}
+            ${{ needs.sanitize_inputs.outputs.docker_images_crlf }}
             ${{ github.repository }}
           tags: |
             type=raw,value=${{ matrix.target }}
@@ -1154,12 +1163,12 @@ jobs:
         run: |
           docker save ${{ fromJSON(steps.meta.outputs.json).tags[0] }} > ${{ env.IMAGE_TAR }}
       - name: Run docker compose tests
-        if: needs.project_types.outputs.docker_compose_base64 != ''
+        if: needs.process_source.outputs.docker_compose_base64 != ''
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
           DOCKER_BUILDKIT: "1"
         run: |
-          echo '${{ needs.project_types.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
+          echo '${{ needs.process_source.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
           yq . "${COMPOSE_FILE}"
 
@@ -1187,13 +1196,13 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
-      - versioned_source
+      - context_check
+      - process_source
       - docker_test
+      - sanitize_inputs
     if: |
-      !failure() && !cancelled() && needs.event_types.outputs.do_draft == 'true' &&
-      join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+      !failure() && !cancelled() && needs.context_check.outputs.do_draft == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
     defaults:
       run:
         working-directory: .
@@ -1206,12 +1215,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.project_types.outputs.bake_targets) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.bake_targets) }}
     env:
       LOCAL_TAG: localhost:5000/sut:latest
     steps:
       - name: Warn if tests skipped
-        if: needs.project_types.outputs.docker_compose_base64 == ''
+        if: needs.process_source.outputs.docker_compose_base64 == ''
         run: echo "::warning::Publishing Docker images without docker compose tests!"
       - name: Download all artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -1228,7 +1237,7 @@ jobs:
         uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96
         with:
           images: |
-            ${{ needs.project_types.outputs.docker_images_crlf }}
+            ${{ needs.sanitize_inputs.outputs.docker_images_crlf }}
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
             type=raw,value=build-${{ github.event.pull_request.head.ref }}
@@ -1240,7 +1249,7 @@ jobs:
         run: |
           target="$(echo ${{ matrix.TARGET }} | sed 's/[^[:alnum:]]/-/g')"
 
-          platforms="$(echo '${{ needs.project_types.outputs.docker_bake_matrix }}' | \
+          platforms="$(echo '${{ needs.process_source.outputs.docker_bake_matrix }}' | \
             jq -r '.include[] | select(.target == "${{ matrix.target}}") | .platform' | \
             sed 's/[^[:alnum:]]/-/g')"
 
@@ -1273,7 +1282,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER || secrets.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
       - name: Publish draft tags
-        if: join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+        if: join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
         uses: akhilerm/tag-push-action@85bf542f43f5f2060ef76262a67ee3607cb6db37
         with:
           src: ${{ env.LOCAL_TAG }}
@@ -1284,12 +1293,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
-      - versioned_source
+      - context_check
+      - process_source
+      - sanitize_inputs
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+      needs.context_check.outputs.do_final == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
     defaults:
       run:
         working-directory: .
@@ -1297,8 +1306,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ fromJSON(needs.project_types.outputs.docker_images) }}
-        target: ${{ fromJSON(needs.project_types.outputs.bake_targets) }}
+        image: ${{ fromJSON(needs.sanitize_inputs.outputs.docker_images) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.bake_targets) }}
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -1385,21 +1394,22 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
       - npm_test
       - docker_test
       - custom_test
+      - sanitize_inputs
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.balena == 'true' &&
-      join(fromJSON(needs.project_types.outputs.balena_slugs)) != ''
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.balena == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
     strategy:
       fail-fast: false
       matrix:
-        slug: ${{ fromJSON(needs.project_types.outputs.balena_slugs) }}
+        slug: ${{ fromJSON(needs.sanitize_inputs.outputs.balena_slugs) }}
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -1426,17 +1436,18 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
+      - sanitize_inputs
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.balena == 'true' &&
-      join(fromJSON(needs.project_types.outputs.balena_slugs)) != ''
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.balena == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
     strategy:
       fail-fast: false
       matrix:
-        slug: ${{ fromJSON(needs.project_types.outputs.balena_slugs) }}
+        slug: ${{ fromJSON(needs.sanitize_inputs.outputs.balena_slugs) }}
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -1463,12 +1474,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.python_poetry == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.python_poetry == 'true'
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -1476,7 +1487,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(needs.project_types.outputs.python_versions) }}
+        python-version: ${{ fromJSON(needs.process_source.outputs.python_versions) }}
     outputs:
       package: ${{ steps.meta.outputs.package }}
       version: ${{ steps.meta.outputs.version }}
@@ -1543,9 +1554,9 @@ jobs:
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
     needs:
-      - project_types
+      - process_source
       - versioned_source
-      - event_types
+      - context_check
     if: |
       inputs.cloudflare_website != ''
     steps:
@@ -1563,7 +1574,7 @@ jobs:
           node-version: 18
       - name: Docusaurus Builder
         if: |
-          needs.project_types.outputs.has_readme == 'true' &&
+          needs.process_source.outputs.has_readme == 'true' &&
           inputs.docusaurus_website != false
         uses: product-os/docusaurus-builder@c44214ff7bc25e1b511cf4c5c0e7c56737f5e437
         with:
@@ -1576,7 +1587,7 @@ jobs:
           inputs.docusaurus_website == false
         run: npm run deploy-docs --if-present
       - name: Update deploy branch for merged PRs
-        if: needs.event_types.outputs.pr_merged == 'true'
+        if: needs.context_check.outputs.pr_merged == 'true'
         run: |
           echo "CF_BRANCH=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
       - name: Cloudflare Pages
@@ -1590,12 +1601,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true'
+      needs.context_check.outputs.do_draft == 'true'
     defaults:
       run:
         working-directory: .
@@ -1619,16 +1630,16 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - project_types
+      - process_source
       - versioned_source
       - github_prepare
       - npm_publish
       - cargo_publish
       - custom_publish
-      - event_types
+      - context_check
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true'
+      needs.context_check.outputs.do_draft == 'true'
     defaults:
       run:
         working-directory: .
@@ -1663,11 +1674,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
-      needs.event_types.outputs.do_final == 'true'
+      needs.context_check.outputs.do_final == 'true'
     defaults:
       run:
         working-directory: .
@@ -1718,12 +1729,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
-        needs.event_types.outputs.pr == 'true' &&
+        needs.context_check.outputs.pr == 'true' &&
         github.event.pull_request.merged == false &&
         github.event.action == 'closed'
     defaults:
@@ -1749,13 +1760,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
+      - sanitize_inputs
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.cargo == 'true' &&
-      join(fromJSON(needs.project_types.outputs.cargo_targets)) != ''
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.cargo == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -1763,7 +1775,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.project_types.outputs.cargo_targets) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.cargo_targets) }}
     outputs:
       package: ${{ steps.meta.outputs.package }}
       version: ${{ steps.meta.outputs.version }}
@@ -1812,16 +1824,17 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - project_types
+      - process_source
       - versioned_source
       - cargo_test
       - custom_test
-      - event_types
+      - context_check
+      - sanitize_inputs
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
+      needs.context_check.outputs.do_draft == 'true' &&
       needs.cargo_test.result == 'success' &&
-      join(fromJSON(needs.project_types.outputs.cargo_targets)) != '' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != '' &&
       inputs.rust_binaries == true
     defaults:
       run:
@@ -1830,7 +1843,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.project_types.outputs.cargo_targets) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.cargo_targets) }}
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -1867,13 +1880,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
+      - sanitize_inputs
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.cargo == 'true' &&
-      join(fromJSON(needs.project_types.outputs.cargo_targets)) != ''
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.cargo == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
     defaults:
       run:
         working-directory: .
@@ -1903,16 +1917,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
+      - sanitize_inputs
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.custom_test == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.custom_test == 'true'
     strategy:
       fail-fast: false
       matrix:
-        value: ${{ fromJSON(needs.project_types.outputs.custom_test_matrix) }}
+        value: ${{ fromJSON(needs.sanitize_inputs.outputs.custom_test_matrix) }}
         os: ${{ fromJSON(inputs.tests_run_on) }}
     steps:
       - name: Download source artifact
@@ -1937,21 +1952,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
       - npm_test
       - docker_test
       - cargo_test
       - custom_test
+      - sanitize_inputs
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.custom_publish == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.custom_publish == 'true'
     strategy:
       fail-fast: false
       matrix:
-        value: ${{ fromJSON(needs.project_types.outputs.custom_publish_matrix) }}
+        value: ${{ fromJSON(needs.sanitize_inputs.outputs.custom_publish_matrix) }}
         os: ${{ fromJSON(inputs.tests_run_on) }}
     steps:
       - name: Download source artifact
@@ -1976,16 +1992,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
+      - sanitize_inputs
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.custom_finalize == 'true'
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.custom_finalize == 'true'
     strategy:
       fail-fast: false
       matrix:
-        value: ${{ fromJSON(needs.project_types.outputs.custom_finalize_matrix) }}
+        value: ${{ fromJSON(needs.sanitize_inputs.outputs.custom_finalize_matrix) }}
         os: ${{ fromJSON(inputs.tests_run_on) }}
     steps:
       - name: Download source artifact
@@ -2014,12 +2031,12 @@ jobs:
         os: ${{ fromJSON(inputs.tests_run_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
-      needs.event_types.outputs.do_clean == 'true' &&
-      needs.project_types.outputs.custom_clean == 'true'
+      needs.context_check.outputs.do_clean == 'true' &&
+      needs.process_source.outputs.custom_clean == 'true'
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -2043,14 +2060,15 @@ jobs:
         os: ${{ fromJSON(inputs.tests_run_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
+      - context_check
       - custom_test
       - custom_publish
       - custom_finalize
       - custom_clean
+      - process_source
     if: |
       always() &&
-      needs.project_types.outputs.custom_always == 'true'
+      needs.process_source.outputs.custom_always == 'true'
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -2075,18 +2093,18 @@ jobs:
       - custom_test
       - python_test
       - docker_test
-      - event_types
+      - context_check
       - npm_publish
       - npm_test
       - cargo_test
       - cargo_publish
       - github_publish
-      - project_types
+      - process_source
       - versioned_source
       - website_build
     if: |
       always() &&
-      needs.event_types.outputs.do_draft == 'true' &&
+      needs.context_check.outputs.do_draft == 'true' &&
       inputs.protect_branch == true &&
       github.event.pull_request.head.repo.full_name == github.repository
     outputs:
@@ -2292,9 +2310,9 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
+      - context_check
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
+      needs.context_check.outputs.do_final == 'true' &&
       inputs.repo_config == true
     steps:
       - name: Configure repository

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -686,6 +686,41 @@ jobs:
           then
             echo "json=${PYTHON_VERSIONS}" >> $GITHUB_OUTPUT
           fi
+  cargo_check:
+    name: Check rust
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - context_check
+      - versioned_source
+      - sanitize_inputs
+    if: join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      cargo: ${{ steps.cargo.outputs.enabled }}
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+      - name: Extract source artifact
+        shell: pwsh
+        working-directory: .
+        run: tar -xvf ${{ runner.temp }}/source.tgz
+      - name: Check Cargo.toml
+        id: cargo
+        run: |
+          if test -f "Cargo.toml"
+          then
+            echo "found Cargo.toml"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
   process_source:
     name: Process source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -698,7 +733,6 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     outputs:
       balena: ${{ steps.balena.outputs.enabled }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
       has_readme: ${{ steps.has_readme.outputs.enabled }}
       custom_test: ${{ steps.custom.outputs.test }}
       custom_publish: ${{ steps.custom.outputs.publish }}
@@ -753,16 +787,6 @@ jobs:
           if test -f balena.yml
           then
             echo "found balena.yml"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Check Cargo.toml
-        id: cargo
-        run: |
-          if test -f "Cargo.toml"
-          then
-            echo "found Cargo.toml"
             echo "enabled=true" >> $GITHUB_OUTPUT
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
@@ -1828,13 +1852,12 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - cargo_check
       - versioned_source
       - sanitize_inputs
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.cargo == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
+      needs.cargo_check.outputs.cargo == 'true'
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -1891,7 +1914,6 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - process_source
       - versioned_source
       - cargo_test
       - custom_test
@@ -1901,7 +1923,6 @@ jobs:
       !failure() && !cancelled() &&
       needs.context_check.outputs.do_draft == 'true' &&
       needs.cargo_test.result == 'success' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != '' &&
       inputs.rust_binaries == true
     defaults:
       run:
@@ -1948,13 +1969,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - cargo_check
       - versioned_source
-      - sanitize_inputs
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.cargo == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
+      needs.cargo_check.outputs.cargo == 'true'
     defaults:
       run:
         working-directory: .

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -790,31 +790,6 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.FLOWZONE_TOKEN }}
-      - name: Check external contributor limitations
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-        run: |
-          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
-          then
-            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
-          then
-            echo "::notice::Modifications to workflow files are not supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
-          then
-            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
-              Please contact a member of the organization for assistance."
-            exit 0
-          fi
       - name: Check for README for building a website
         id: has_readme
         run: |
@@ -880,6 +855,31 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.FLOWZONE_TOKEN }}
+      - name: Check external contributor limitations
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
+        run: |
+          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
+          then
+            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
+          then
+            echo "::notice::Modifications to workflow files are not supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
+          then
+            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
+              Please contact a member of the organization for assistance."
+            exit 0
+          fi
       - name: Reject merge commits
         run: |
           if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -756,6 +756,58 @@ jobs:
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
+  custom_check:
+    name: Check custom
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - context_check
+      - versioned_source
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      custom_test: ${{ steps.custom.outputs.test }}
+      custom_publish: ${{ steps.custom.outputs.publish }}
+      custom_finalize: ${{ steps.custom.outputs.finalize }}
+      custom_clean: ${{ steps.custom.outputs.clean }}
+      custom_always: ${{ steps.custom.outputs.always }}
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+      - name: Extract source artifact
+        shell: pwsh
+        working-directory: .
+        run: tar -xvf ${{ runner.temp }}/source.tgz
+      - name: Check for custom actions
+        if: github.event.pull_request.head.repo.full_name == github.repository || inputs.restrict_custom_actions == false
+        id: custom
+        working-directory: .
+        run: |
+          if [ -d .github/actions/test ]
+          then
+            echo "test=true" >> $GITHUB_OUTPUT
+          fi
+          if [ -d .github/actions/publish ]
+          then
+            echo "publish=true" >> $GITHUB_OUTPUT
+          fi
+          if [ -d .github/actions/finalize ]
+          then
+            echo "finalize=true" >> $GITHUB_OUTPUT
+          fi
+          if [ -d .github/actions/clean ]
+          then
+            echo "clean=true" >> $GITHUB_OUTPUT
+          fi
+          if [ -d .github/actions/always ]
+          then
+            echo "always=true" >> $GITHUB_OUTPUT
+          fi
   process_source:
     name: Process source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -768,11 +820,6 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     outputs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
-      custom_test: ${{ steps.custom.outputs.test }}
-      custom_publish: ${{ steps.custom.outputs.publish }}
-      custom_finalize: ${{ steps.custom.outputs.finalize }}
-      custom_clean: ${{ steps.custom.outputs.clean }}
-      custom_always: ${{ steps.custom.outputs.always }}
     steps:
       - name: Checkout merge branch
         if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
@@ -799,31 +846,6 @@ jobs:
             echo "enabled=true" >> $GITHUB_OUTPUT
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Check for custom actions
-        if: github.event.pull_request.head.repo.full_name == github.repository || inputs.restrict_custom_actions == false
-        id: custom
-        working-directory: .
-        run: |
-          if [ -d .github/actions/test ]
-          then
-            echo "test=true" >> $GITHUB_OUTPUT
-          fi
-          if [ -d .github/actions/publish ]
-          then
-            echo "publish=true" >> $GITHUB_OUTPUT
-          fi
-          if [ -d .github/actions/finalize ]
-          then
-            echo "finalize=true" >> $GITHUB_OUTPUT
-          fi
-          if [ -d .github/actions/clean ]
-          then
-            echo "clean=true" >> $GITHUB_OUTPUT
-          fi
-          if [ -d .github/actions/always ]
-          then
-            echo "always=true" >> $GITHUB_OUTPUT
           fi
   versioned_source:
     name: Versioned source
@@ -2024,12 +2046,12 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - custom_check
       - versioned_source
       - sanitize_inputs
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.custom_test == 'true'
+      needs.custom_check.outputs.custom_test == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -2059,7 +2081,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - custom_check
       - versioned_source
       - npm_test
       - docker_test
@@ -2069,7 +2091,7 @@ jobs:
     if: |
       !failure() && !cancelled() &&
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.custom_publish == 'true'
+      needs.custom_check.outputs.custom_publish == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -2099,12 +2121,12 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - custom_check
       - versioned_source
       - sanitize_inputs
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.custom_finalize == 'true'
+      needs.custom_check.outputs.custom_finalize == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -2138,11 +2160,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - custom_check
       - versioned_source
     if: |
       needs.context_check.outputs.do_clean == 'true' &&
-      needs.process_source.outputs.custom_clean == 'true'
+      needs.custom_check.outputs.custom_clean == 'true'
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -2171,10 +2193,11 @@ jobs:
       - custom_publish
       - custom_finalize
       - custom_clean
-      - process_source
+      - custom_check
+      - versioned_source
     if: |
       always() &&
-      needs.process_source.outputs.custom_always == 'true'
+      needs.custom_check.outputs.custom_always == 'true'
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -571,79 +571,30 @@ jobs:
             
           echo "json=${json}">> $GITHUB_OUTPUT
           echo "matrix=${matrix}">> $GITHUB_OUTPUT
-  process_source:
-    name: Process source
+  python_check:
+    name: Check python
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
+      - versioned_source
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     outputs:
-      balena: ${{ steps.balena.outputs.enabled }}
       python_poetry: ${{ steps.python_poetry.outputs.enabled }}
       python_versions: ${{ steps.python_versions.outputs.json }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
-      has_readme: ${{ steps.has_readme.outputs.enabled }}
-      custom_test: ${{ steps.custom.outputs.test }}
-      custom_publish: ${{ steps.custom.outputs.publish }}
-      custom_finalize: ${{ steps.custom.outputs.finalize }}
-      custom_clean: ${{ steps.custom.outputs.clean }}
-      custom_always: ${{ steps.custom.outputs.always }}
     steps:
-      - name: Checkout merge branch
-        if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
-        id: checkout_merge
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Download source artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: refs/pull/${{ github.event.number }}/merge
-      - name: Checkout sha
-        if: steps.checkout_merge.outcome == 'skipped'
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-        with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
-      - name: Check external contributor limitations
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-        run: |
-          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
-          then
-            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
-          then
-            echo "::notice::Modifications to workflow files are not supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
-          then
-            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
-              Please contact a member of the organization for assistance."
-            exit 0
-          fi
-      - name: Check for balena.yml
-        id: balena
-        run: |
-          if test -f balena.yml
-          then
-            echo "found balena.yml"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-          fi
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+      - name: Extract source artifact
+        shell: pwsh
+        working-directory: .
+        run: tar -xvf ${{ runner.temp }}/source.tgz
       - name: Check for Python Poetry pyproject.toml
         id: python_poetry
         run: |
@@ -734,6 +685,77 @@ jobs:
           if [ "${PYTHON_VERSIONS}" != "[]" ]
           then
             echo "json=${PYTHON_VERSIONS}" >> $GITHUB_OUTPUT
+          fi
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - context_check
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      balena: ${{ steps.balena.outputs.enabled }}
+      cargo: ${{ steps.cargo.outputs.enabled }}
+      has_readme: ${{ steps.has_readme.outputs.enabled }}
+      custom_test: ${{ steps.custom.outputs.test }}
+      custom_publish: ${{ steps.custom.outputs.publish }}
+      custom_finalize: ${{ steps.custom.outputs.finalize }}
+      custom_clean: ${{ steps.custom.outputs.clean }}
+      custom_always: ${{ steps.custom.outputs.always }}
+    steps:
+      - name: Checkout merge branch
+        if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
+        id: checkout_merge
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.FLOWZONE_TOKEN }}
+          ref: refs/pull/${{ github.event.number }}/merge
+      - name: Checkout sha
+        if: steps.checkout_merge.outcome == 'skipped'
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.FLOWZONE_TOKEN }}
+      - name: Check external contributor limitations
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
+        run: |
+          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
+          then
+            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
+          then
+            echo "::notice::Modifications to workflow files are not supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
+          then
+            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
+              Please contact a member of the organization for assistance."
+            exit 0
+          fi
+      - name: Check for balena.yml
+        id: balena
+        run: |
+          if test -f balena.yml
+          then
+            echo "found balena.yml"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
           fi
       - name: Check Cargo.toml
         id: cargo
@@ -1520,11 +1542,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - python_check
       - versioned_source
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.python_poetry == 'true'
+      needs.python_check.outputs.python_poetry == 'true'
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -1532,7 +1554,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(needs.process_source.outputs.python_versions) }}
+        python-version: ${{ fromJSON(needs.python_check.outputs.python_versions) }}
     outputs:
       package: ${{ steps.meta.outputs.package }}
       version: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1676,8 +1676,8 @@ jobs:
           echo "branch_tag=${branch_tag}" >> $GITHUB_OUTPUT
           echo "sha_tag=${sha_tag}" >> $GITHUB_OUTPUT
           echo "version_tag=${version_tag}" >> $GITHUB_OUTPUT
-  website_build:
-    name: Build website using Docusaurus
+  website_publish:
+    name: Publish website
     runs-on: ${{fromJSON(inputs.runs_on)}}
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
@@ -1722,8 +1722,8 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: pages publish --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ >> $GITHUB_STEP_SUMMARY
-  github_prepare:
-    name: Clean previous GitHub draft release
+  github_clean:
+    name: Clean GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
@@ -1731,7 +1731,8 @@ jobs:
       - versioned_source
     if: |
       !failure() && !cancelled() &&
-      needs.context_check.outputs.do_draft == 'true'
+      (needs.context_check.outputs.do_draft == 'true' ||
+      (needs.context_check.outputs.pr_closed == 'true' && needs.context_check.outputs.pr_merged == 'false'))
     defaults:
       run:
         working-directory: .
@@ -1751,12 +1752,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
   github_publish:
-    name: Publish draft Github release
+    name: Publish Github release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - versioned_source
-      - github_prepare
+      - github_clean
       - npm_publish
       - cargo_publish
       - custom_publish
@@ -1847,36 +1847,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-  github_clean:
-    name: Clean unused GitHub release
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
-    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs:
-      - context_check
-      - versioned_source
-    if: |
-      !failure() && !cancelled() &&
-        needs.context_check.outputs.pr == 'true' &&
-        github.event.pull_request.merged == false &&
-        github.event.action == 'closed'
-    defaults:
-      run:
-        working-directory: .
-        shell: bash --noprofile --norc -eo pipefail -x {0}
-    steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-        with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: tar -xvf ${{ runner.temp }}/source.tgz
-      - name: Delete draft release
-        run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
   cargo_test:
     name: Test rust
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -1941,7 +1911,7 @@ jobs:
           echo "sha_tag=${sha_tag}" >> $GITHUB_OUTPUT
           echo "version_tag=${version_tag}" >> $GITHUB_OUTPUT
   cargo_publish:
-    name: Build rust release artifacts
+    name: Publish rust
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
@@ -2218,7 +2188,7 @@ jobs:
       - cargo_publish
       - github_publish
       - versioned_source
-      - website_build
+      - website_publish
     if: |
       always() &&
       needs.context_check.outputs.do_draft == 'true' &&
@@ -2423,11 +2393,12 @@ jobs:
             gh pr merge ${{ github.event.pull_request.number }} --merge --auto
           fi
   repo_config:
-    name: Standardise repository settings
+    name: Apply repo settings
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
+      - sanitize_inputs
     if: |
       needs.context_check.outputs.do_final == 'true' &&
       inputs.repo_config == true

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -808,12 +808,14 @@ jobs:
           then
             echo "always=true" >> $GITHUB_OUTPUT
           fi
-  process_source:
-    name: Process source
+  website_check:
+    name: Check website
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
+      - versioned_source
+    if: inputs.cloudflare_website != ''
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -821,22 +823,15 @@ jobs:
     outputs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
     steps:
-      - name: Checkout merge branch
-        if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
-        id: checkout_merge
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Download source artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
-          ref: refs/pull/${{ github.event.number }}/merge
-      - name: Checkout sha
-        if: steps.checkout_merge.outcome == 'skipped'
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-        with:
-          fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.FLOWZONE_TOKEN }}
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+      - name: Extract source artifact
+        shell: pwsh
+        working-directory: .
+        run: tar -xvf ${{ runner.temp }}/source.tgz
       - name: Check for README for building a website
         id: has_readme
         run: |
@@ -1687,11 +1682,9 @@ jobs:
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
     needs:
-      - process_source
+      - website_check
       - versioned_source
       - context_check
-    if: |
-      inputs.cloudflare_website != ''
     steps:
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -1707,7 +1700,7 @@ jobs:
           node-version: 18
       - name: Docusaurus Builder
         if: |
-          needs.process_source.outputs.has_readme == 'true' &&
+          needs.website_check.outputs.has_readme == 'true' &&
           inputs.docusaurus_website != false
         uses: product-os/docusaurus-builder@c44214ff7bc25e1b511cf4c5c0e7c56737f5e437
         with:
@@ -1735,7 +1728,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
@@ -1763,7 +1755,6 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - process_source
       - versioned_source
       - github_prepare
       - npm_publish
@@ -1808,7 +1799,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
       - versioned_source
     if: |
       needs.context_check.outputs.do_final == 'true'
@@ -1863,7 +1853,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
@@ -2228,7 +2217,6 @@ jobs:
       - cargo_test
       - cargo_publish
       - github_publish
-      - process_source
       - versioned_source
       - website_build
     if: |

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -721,6 +721,41 @@ jobs:
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
+  balena_check:
+    name: Check balena
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - context_check
+      - versioned_source
+      - sanitize_inputs
+    if: join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      balena: ${{ steps.balena.outputs.enabled }}
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+      - name: Extract source artifact
+        shell: pwsh
+        working-directory: .
+        run: tar -xvf ${{ runner.temp }}/source.tgz
+      - name: Check for balena.yml
+        id: balena
+        run: |
+          if test -f balena.yml
+          then
+            echo "found balena.yml"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
   process_source:
     name: Process source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -732,7 +767,6 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     outputs:
-      balena: ${{ steps.balena.outputs.enabled }}
       has_readme: ${{ steps.has_readme.outputs.enabled }}
       custom_test: ${{ steps.custom.outputs.test }}
       custom_publish: ${{ steps.custom.outputs.publish }}
@@ -780,16 +814,6 @@ jobs:
             echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
               Please contact a member of the organization for assistance."
             exit 0
-          fi
-      - name: Check for balena.yml
-        id: balena
-        run: |
-          if test -f balena.yml
-          then
-            echo "found balena.yml"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
           fi
       - name: Check for README for building a website
         id: has_readme
@@ -1486,17 +1510,15 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - balena_check
       - versioned_source
       - npm_test
       - docker_test
       - custom_test
       - sanitize_inputs
     if: |
-      !failure() && !cancelled() &&
-      needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.balena == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
+      !failure() && !cancelled() && needs.balena_check.result == 'success' &&
+      needs.context_check.outputs.do_draft == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1528,13 +1550,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - balena_check
       - versioned_source
       - sanitize_inputs
     if: |
-      needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.balena == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
+      needs.context_check.outputs.do_final == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -490,12 +490,13 @@ jobs:
           then
             echo "json=${NODE_VERSIONS}" >> $GITHUB_OUTPUT
           fi
-  process_source:
-    name: Process source
+  docker_check:
+    name: Check docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
+      - versioned_source
       - sanitize_inputs
     defaults:
       run:
@@ -505,6 +506,82 @@ jobs:
       docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
       docker_bake_json: ${{ steps.docker_bake.outputs.json }}
       docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          path: ${{ runner.temp }}
+      - name: Extract source artifact
+        shell: pwsh
+        working-directory: .
+        run: tar -xvf ${{ runner.temp }}/source.tgz
+      - name: Pre-process Docker compose files
+        id: docker_compose
+        env:
+          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
+        run: |
+          test -n "$(ls docker-compose.test.{yml,yaml} 2>/dev/null)" || exit 0
+
+          if [ -n "${COMPOSE_VARS}" ]
+          then
+            echo "${COMPOSE_VARS}" | base64 --decode > .env
+
+            # mask secrets
+            while read -r line; do
+              secret="$(echo "${line}" | awk -F'=' '{print $2}')"
+              echo "::add-mask::${secret}"
+            done <<< "$(cat < .env)"
+          fi
+
+          files="
+            docker-compose.yml
+            docker-compose.yaml
+            docker-compose.test.yml
+            docker-compose.test.yaml
+          "
+          args=""
+
+          for file in ${files}; do
+            test -f "${file}" && args="${args} -f ${file}"
+          done
+
+          echo "base64=$(docker compose ${args} config | base64 -w0)" >> $GITHUB_OUTPUT
+      - name: Pre-process Docker bake files
+        id: docker_bake
+        env:
+          BAKE_FILE: /tmp/docker-bake.json
+        run: |
+          if [ -n "$(ls docker-bake{.override,}.{json,hcl} 2>/dev/null)" ]
+          then
+            files="$(echo $(ls -1 docker-bake{.override,}.{json,hcl} 2>/dev/null) | sed 's/ / -f /')"
+          else
+            echo '${{ needs.sanitize_inputs.outputs.bake_targets }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
+            files="${BAKE_FILE}"
+          fi
+
+          json="$(docker buildx bake --print ${{ join(fromJSON(needs.sanitize_inputs.outputs.bake_targets),' ') }} -f ${files} \
+            | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
+            | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
+            | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
+            | jq '.target |= map_values(."platforms" //= ["linux/amd64"])' \
+            | jq -cr)"
+
+          matrix="$(jq -cr '.target | to_entries | { include: map(.value.platforms[] as $p | {target: .key, platform: $p})}' <<< "${json}")"
+            
+          echo "json=${json}">> $GITHUB_OUTPUT
+          echo "matrix=${matrix}">> $GITHUB_OUTPUT
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - context_check
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
       balena: ${{ steps.balena.outputs.enabled }}
       python_poetry: ${{ steps.python_poetry.outputs.enabled }}
       python_versions: ${{ steps.python_versions.outputs.json }}
@@ -703,61 +780,6 @@ jobs:
           then
             echo "always=true" >> $GITHUB_OUTPUT
           fi
-      - name: Pre-process Docker compose files
-        id: docker_compose
-        env:
-          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
-        run: |
-          test -n "$(ls docker-compose.test.{yml,yaml} 2>/dev/null)" || exit 0
-
-          if [ -n "${COMPOSE_VARS}" ]
-          then
-            echo "${COMPOSE_VARS}" | base64 --decode > .env
-
-            # mask secrets
-            while read -r line; do
-              secret="$(echo "${line}" | awk -F'=' '{print $2}')"
-              echo "::add-mask::${secret}"
-            done <<< "$(cat < .env)"
-          fi
-
-          files="
-            docker-compose.yml
-            docker-compose.yaml
-            docker-compose.test.yml
-            docker-compose.test.yaml
-          "
-          args=""
-
-          for file in ${files}; do
-            test -f "${file}" && args="${args} -f ${file}"
-          done
-
-          echo "base64=$(docker compose ${args} config | base64 -w0)" >> $GITHUB_OUTPUT
-      - name: Pre-process Docker bake files
-        id: docker_bake
-        env:
-          BAKE_FILE: /tmp/docker-bake.json
-        run: |
-          if [ -n "$(ls docker-bake{.override,}.{json,hcl} 2>/dev/null)" ]
-          then
-            files="$(echo $(ls -1 docker-bake{.override,}.{json,hcl} 2>/dev/null) | sed 's/ / -f /')"
-          else
-            echo '${{ needs.sanitize_inputs.outputs.bake_targets }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
-            files="${BAKE_FILE}"
-          fi
-
-          json="$(docker buildx bake --print ${{ join(fromJSON(needs.sanitize_inputs.outputs.bake_targets),' ') }} -f ${files} \
-            | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
-            | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
-            | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
-            | jq '.target |= map_values(."platforms" //= ["linux/amd64"])' \
-            | jq -cr)"
-
-          matrix="$(jq -cr '.target | to_entries | { include: map(.value.platforms[] as $p | {target: .key, platform: $p})}' <<< "${json}")"
-            
-          echo "json=${json}">> $GITHUB_OUTPUT
-          echo "matrix=${matrix}">> $GITHUB_OUTPUT
   versioned_source:
     name: Versioned source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -1107,20 +1129,21 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - docker_check
       - versioned_source
       - sanitize_inputs
     if: |
-      !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      (join(fromJSON(needs.process_source.outputs.docker_images)) != '' || needs.process_source.outputs.docker_compose_base64 != '')
+      needs.context_check.outputs.do_draft == 'true' && (
+        join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != '' ||
+        needs.docker_check.outputs.docker_compose_base64 != ''
+      )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.process_source.outputs.docker_bake_matrix) }}
+      matrix: ${{ fromJSON(needs.docker_check.outputs.docker_bake_matrix) }}
     env:
       DOCKER_BAKE_FILE: /tmp/docker-bake.json
       COMPOSE_FILE: docker-compose.yml
@@ -1153,7 +1176,7 @@ jobs:
 
           echo "PLATFORM=$(echo ${{ matrix.platform }} | sed 's/[^[:alnum:]]/-/g')" >> $GITHUB_ENV
 
-          echo '${{ needs.process_source.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
+          echo '${{ needs.docker_check.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
           jq . "${DOCKER_BAKE_FILE}"
       - name: Generate image labels and sut tags
         id: meta
@@ -1185,12 +1208,12 @@ jobs:
         run: |
           docker save ${{ fromJSON(steps.meta.outputs.json).tags[0] }} > ${{ env.IMAGE_TAR }}
       - name: Run docker compose tests
-        if: needs.process_source.outputs.docker_compose_base64 != ''
+        if: needs.docker_check.outputs.docker_compose_base64 != ''
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
           DOCKER_BUILDKIT: "1"
         run: |
-          echo '${{ needs.process_source.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
+          echo '${{ needs.docker_check.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
           yq . "${COMPOSE_FILE}"
 
@@ -1219,11 +1242,11 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - docker_check
       - docker_test
       - sanitize_inputs
     if: |
-      !failure() && !cancelled() && needs.context_check.outputs.do_draft == 'true' &&
+      needs.context_check.outputs.do_draft == 'true' &&
       join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
     defaults:
       run:
@@ -1242,7 +1265,7 @@ jobs:
       LOCAL_TAG: localhost:5000/sut:latest
     steps:
       - name: Warn if tests skipped
-        if: needs.process_source.outputs.docker_compose_base64 == ''
+        if: needs.docker_check.outputs.docker_compose_base64 == ''
         run: echo "::warning::Publishing Docker images without docker compose tests!"
       - name: Download all artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -1271,7 +1294,7 @@ jobs:
         run: |
           target="$(echo ${{ matrix.TARGET }} | sed 's/[^[:alnum:]]/-/g')"
 
-          platforms="$(echo '${{ needs.process_source.outputs.docker_bake_matrix }}' | \
+          platforms="$(echo '${{ needs.docker_check.outputs.docker_bake_matrix }}' | \
             jq -r '.include[] | select(.target == "${{ matrix.target}}") | .platform' | \
             sed 's/[^[:alnum:]]/-/g')"
 
@@ -1316,7 +1339,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - docker_check
       - sanitize_inputs
     if: |
       needs.context_check.outputs.do_final == 'true' &&

--- a/balena.yml
+++ b/balena.yml
@@ -1,1 +1,0 @@
-tests/balena.yml

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -26,7 +26,7 @@
     # for pull_request_target events that are not closed we need to specify the merge branch manually
     # because the default checkout ref is the tip of the main/master branch
     name: Checkout merge branch
-    if: github.event_name == 'pull_request_target' && needs.event_types.outputs.pr_closed != true
+    if: github.event_name == 'pull_request_target' && needs.context_check.outputs.pr_closed != true
     id: checkout_merge
     uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
     with:
@@ -310,8 +310,8 @@ jobs:
   ## event types
   ###################################################
 
-  event_types:
-    name: Event types
+  context_check:
+    name: Check context
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     # all jobs depend on this one in some way so add global trigger rules here
@@ -376,19 +376,15 @@ jobs:
         run: |
           echo "${JSON}" || true
 
-  ###################################################
-  ## project types
-  ###################################################
-
-  project_types:
-    name: Project types
+  sanitize_inputs:
+    name: Sanitize inputs
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types]
+    needs: [context_check]
 
     defaults:
       run:
-        working-directory: ${{ inputs.working_directory }}
+        working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     outputs:
@@ -398,33 +394,12 @@ jobs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       docker_images_crlf: ${{ steps.docker_images_crlf.outputs.build }}
 
-      npm: ${{ steps.npm.outputs.enabled }}
-      npm_private: ${{ steps.npm.outputs.private }} # can be null or unset
-      npm_docs: ${{ steps.npm.outputs.docs }} # can be null or unset
-      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
-      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
-      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
-      balena: ${{ steps.balena.outputs.enabled }}
-      node_versions: ${{ steps.node_versions.outputs.json }}
-      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
-      python_versions: ${{ steps.python_versions.outputs.json }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
-      has_readme: ${{ steps.has_readme.outputs.enabled }}
-
-      custom_test: ${{ steps.custom.outputs.test }}
       custom_test_matrix: ${{ steps.custom_test_matrix.outputs.build }}
-      custom_publish: ${{ steps.custom.outputs.publish }}
       custom_publish_matrix: ${{ steps.custom_publish_matrix.outputs.build }}
-      custom_finalize: ${{ steps.custom.outputs.finalize }}
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.build }}
-      custom_clean: ${{ steps.custom.outputs.clean }}
-      custom_always: ${{ steps.custom.outputs.always }}
 
     steps:
-      - *checkoutMergeBranch
-      - *checkoutSha
-
-      - name: Convert balena_slugs to a JSON array
+      - name: Convert balena_slugs to json
         id: balena_slugs
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
         env:
@@ -433,7 +408,7 @@ jobs:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
 
-      - name: Convert docker_images to a JSON array
+      - name: Convert docker_images to json
         id: docker_images
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
         env:
@@ -442,7 +417,7 @@ jobs:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
 
-      - name: Convert bake_targets to a JSON array
+      - name: Convert bake_targets to json
         id: bake_targets
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
         env:
@@ -451,7 +426,7 @@ jobs:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
 
-      - name: Convert cargo_targets to a JSON array
+      - name: Convert cargo_targets to json
         id: cargo_targets
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
         env:
@@ -467,6 +442,68 @@ jobs:
           echo "build<<EOF" >> $GITHUB_OUTPUT
           echo "${build}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Convert custom_test_matrix to json
+        id: custom_test_matrix
+        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
+        env:
+          INPUT: ${{ inputs.custom_test_matrix }}
+        with:
+          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
+          separator: ","
+
+      - name: Convert custom_publish_matrix to json
+        id: custom_publish_matrix
+        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
+        env:
+          INPUT: ${{ inputs.custom_publish_matrix }}
+        with:
+          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
+          separator: ","
+
+      - name: Convert custom_finalize_matrix to json
+        id: custom_finalize_matrix
+        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
+        env:
+          INPUT: ${{ inputs.custom_finalize_matrix }}
+        with:
+          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
+          separator: ","
+
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs: [context_check, sanitize_inputs]
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
+      npm: ${{ steps.npm.outputs.enabled }}
+      npm_private: ${{ steps.npm.outputs.private }} # can be null or unset
+      npm_docs: ${{ steps.npm.outputs.docs }} # can be null or unset
+      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
+      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
+      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
+      balena: ${{ steps.balena.outputs.enabled }}
+      node_versions: ${{ steps.node_versions.outputs.json }}
+      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
+      python_versions: ${{ steps.python_versions.outputs.json }}
+      cargo: ${{ steps.cargo.outputs.enabled }}
+      has_readme: ${{ steps.has_readme.outputs.enabled }}
+
+      custom_test: ${{ steps.custom.outputs.test }}
+      custom_publish: ${{ steps.custom.outputs.publish }}
+      custom_finalize: ${{ steps.custom.outputs.finalize }}
+      custom_clean: ${{ steps.custom.outputs.clean }}
+      custom_always: ${{ steps.custom.outputs.always }}
+
+    steps:
+      - *checkoutMergeBranch
+      - *checkoutSha
 
       # reject external contribution workflow in certain conditions to prevent leaking secrets
       - name: Check external contributor limitations
@@ -743,33 +780,6 @@ jobs:
             echo "always=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Convert custom_test_matrix to a JSON array
-        id: custom_test_matrix
-        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
-        env:
-          INPUT: ${{ inputs.custom_test_matrix }}
-        with:
-          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
-          separator: ","
-
-      - name: Convert custom_publish_matrix to a JSON array
-        id: custom_publish_matrix
-        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
-        env:
-          INPUT: ${{ inputs.custom_publish_matrix }}
-        with:
-          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
-          separator: ","
-
-      - name: Convert custom_finalize_matrix to a JSON array
-        id: custom_finalize_matrix
-        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
-        env:
-          INPUT: ${{ inputs.custom_finalize_matrix }}
-        with:
-          cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
-          separator: ","
-
       # only if docker-compose test files are found
       # merge all compose files in the project and record the merged config as a multiline yaml output
       - name: Pre-process Docker compose files
@@ -809,7 +819,6 @@ jobs:
       # in this custom bake json we also set some default cache values, and inherit the docker-metadata-action
       - name: Pre-process Docker bake files
         id: docker_bake
-        if: join(fromJSON(steps.docker_images.outputs.build)) != '' || steps.docker_compose.outputs.base64 != ''
         env:
           BAKE_FILE: /tmp/docker-bake.json
         run: |
@@ -817,11 +826,11 @@ jobs:
           then
             files="$(echo $(ls -1 docker-bake{.override,}.{json,hcl} 2>/dev/null) | sed 's/ / -f /')"
           else
-            echo '${{ steps.bake_targets.outputs.build }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
+            echo '${{ needs.sanitize_inputs.outputs.bake_targets }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
             files="${BAKE_FILE}"
           fi
 
-          json="$(docker buildx bake --print ${{ join(fromJSON(steps.bake_targets.outputs.build),' ') }} -f ${files} \
+          json="$(docker buildx bake --print ${{ join(fromJSON(needs.sanitize_inputs.outputs.bake_targets),' ') }} -f ${files} \
             | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
             | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
             | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
@@ -841,7 +850,7 @@ jobs:
     name: Versioned source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types]
+    needs: [context_check]
 
     defaults:
       run:
@@ -866,7 +875,7 @@ jobs:
           fi
 
       - name: Import GPG key for signing commits
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
         with:
@@ -877,12 +886,12 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Install versionist
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           npm install -g balena-versionist@0.14.12 versionist@6.9.2
 
       - name: Generate changelog
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           if [ ! -f .versionbot/CHANGELOG.yml ]
           then
@@ -901,7 +910,7 @@ jobs:
       - name: Get latest tag for current branch
         continue-on-error: true
         id: old_version
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n1)"
           echo "semver=${tag/v/}" >> $GITHUB_OUTPUT
@@ -909,7 +918,7 @@ jobs:
 
       # install and run versionist via balena-versionist
       - name: Run versionist
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           balena-versionist
 
@@ -922,7 +931,7 @@ jobs:
       # TODO: versionist should provide the new version via stdout!
       - name: Inspect versioned files
         id: new_version
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr == 'true'
         run: |
           git status --porcelain
           versions=()
@@ -955,7 +964,7 @@ jobs:
 
       # push the versioned commit only if the PR is merged
       - name: Push versioned commit
-        if: inputs.disable_versioning != true && needs.event_types.outputs.pr_merged == 'true'
+        if: inputs.disable_versioning != true && needs.context_check.outputs.pr_merged == 'true'
         continue-on-error: true
         run: |
           git push origin HEAD:refs/heads/${{ github.base_ref }}
@@ -983,10 +992,10 @@ jobs:
     name: Test npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source]
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.npm == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.npm == 'true'
 
     defaults:
       run:
@@ -996,7 +1005,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJSON(needs.project_types.outputs.node_versions) }}
+        node_version: ${{ fromJSON(needs.process_source.outputs.node_versions) }}
 
     outputs:
       package: ${{ steps.meta.outputs.package }}
@@ -1078,16 +1087,16 @@ jobs:
           retention-days: 90
 
       - name: Generate docs (if present)
-        if: needs.project_types.outputs.npm_docs == 'true'
+        if: needs.process_source.outputs.npm_docs == 'true'
         shell: bash
         run: npm run doc
 
       - name: Compress docs
-        if: needs.project_types.outputs.npm_docs == 'true'
+        if: needs.process_source.outputs.npm_docs == 'true'
         run: tar -acvf ${{ runner.temp }}/docs.tgz ./docs
 
       - name: Upload artifact
-        if: needs.project_types.outputs.npm_docs == 'true'
+        if: needs.process_source.outputs.npm_docs == 'true'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
@@ -1098,12 +1107,13 @@ jobs:
     name: Publish npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source, npm_test, custom_test]
+    needs:
+      [context_check, process_source, npm_test, custom_test]
     if: |
       !failure() && !cancelled() &&
       needs.npm_test.result == 'success' &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.npm_private != 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.npm_private != 'true'
 
     defaults:
       run:
@@ -1115,7 +1125,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.project_types.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
 
       - name: Login to registry
         run: |
@@ -1143,11 +1153,11 @@ jobs:
     name: Finalize npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source]
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.npm == 'true' &&
-      needs.project_types.outputs.npm_private != 'true'
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.npm == 'true' &&
+      needs.process_source.outputs.npm_private != 'true'
 
     defaults:
       run:
@@ -1164,7 +1174,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.project_types.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
 
       - name: Login to registry
         run: |
@@ -1182,10 +1192,10 @@ jobs:
     name: Finalize npm docs
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source]
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.npm_docs == 'true'
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.npm_docs == 'true'
 
     defaults:
       run:
@@ -1202,7 +1212,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.project_types.outputs.node_versions)[0] }}
+          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
 
       - name: Extract docs artifact
         run: |
@@ -1226,11 +1236,11 @@ jobs:
     name: Test docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source, sanitize_inputs]
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_base64 != '')
+      (join(fromJSON(needs.process_source.outputs.docker_images)) != '' || needs.process_source.outputs.docker_compose_base64 != '')
 
     defaults:
       run:
@@ -1239,7 +1249,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.project_types.outputs.docker_bake_matrix) }}
+      matrix: ${{ fromJSON(needs.process_source.outputs.docker_bake_matrix) }}
 
     env:
       DOCKER_BAKE_FILE: /tmp/docker-bake.json
@@ -1275,7 +1285,7 @@ jobs:
 
           echo "PLATFORM=$(echo ${{ matrix.platform }} | sed 's/[^[:alnum:]]/-/g')" >> $GITHUB_ENV
 
-          echo '${{ needs.project_types.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
+          echo '${{ needs.process_source.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
           jq . "${DOCKER_BAKE_FILE}"
 
       # https://github.com/docker/metadata-action
@@ -1300,7 +1310,7 @@ jobs:
           images: |
             sut
             localhost:5000/sut
-            ${{ needs.project_types.outputs.docker_images_crlf }}
+            ${{ needs.sanitize_inputs.outputs.docker_images_crlf }}
             ${{ github.repository }}
           tags: |
             type=raw,value=${{ matrix.target }}
@@ -1328,12 +1338,12 @@ jobs:
 
       # run docker compose tests and print the logs from all services
       - name: Run docker compose tests
-        if: needs.project_types.outputs.docker_compose_base64 != ''
+        if: needs.process_source.outputs.docker_compose_base64 != ''
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
           DOCKER_BUILDKIT: "1"
         run: |
-          echo '${{ needs.project_types.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
+          echo '${{ needs.process_source.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
           yq . "${COMPOSE_FILE}"
 
@@ -1363,10 +1373,16 @@ jobs:
     name: Publish docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source, docker_test]
+    needs:
+      [
+        context_check,
+        process_source,
+        docker_test,
+        sanitize_inputs,
+      ]
     if: |
-      !failure() && !cancelled() && needs.event_types.outputs.do_draft == 'true' &&
-      join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+      !failure() && !cancelled() && needs.context_check.outputs.do_draft == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
 
     defaults:
       run:
@@ -1382,15 +1398,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.project_types.outputs.bake_targets) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.bake_targets) }}
 
     env:
       LOCAL_TAG: localhost:5000/sut:latest
 
     steps:
-
       - name: Warn if tests skipped
-        if: needs.project_types.outputs.docker_compose_base64 == ''
+        if: needs.process_source.outputs.docker_compose_base64 == ''
         run: echo "::warning::Publishing Docker images without docker compose tests!"
 
       - name: Download all artifacts
@@ -1411,7 +1426,7 @@ jobs:
         uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 # v4
         with:
           images: |
-            ${{ needs.project_types.outputs.docker_images_crlf }}
+            ${{ needs.sanitize_inputs.outputs.docker_images_crlf }}
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
             type=raw,value=build-${{ github.event.pull_request.head.ref }}
@@ -1424,7 +1439,7 @@ jobs:
         run: |
           target="$(echo ${{ matrix.TARGET }} | sed 's/[^[:alnum:]]/-/g')"
 
-          platforms="$(echo '${{ needs.project_types.outputs.docker_bake_matrix }}' | \
+          platforms="$(echo '${{ needs.process_source.outputs.docker_bake_matrix }}' | \
             jq -r '.include[] | select(.target == "${{ matrix.target}}") | .platform' | \
             sed 's/[^[:alnum:]]/-/g')"
 
@@ -1460,7 +1475,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN || secrets.DOCKER_REGISTRY_PASS }}
 
       - name: Publish draft tags
-        if: join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+        if: join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
         uses: akhilerm/tag-push-action@85bf542f43f5f2060ef76262a67ee3607cb6db37 # v2.1.0
         with:
           src: ${{ env.LOCAL_TAG }}
@@ -1471,10 +1486,10 @@ jobs:
     name: Finalize docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, sanitize_inputs]
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      join(fromJSON(needs.project_types.outputs.docker_images)) != ''
+      needs.context_check.outputs.do_final == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
 
     defaults:
       run:
@@ -1484,8 +1499,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ fromJSON(needs.project_types.outputs.docker_images) }}
-        target: ${{ fromJSON(needs.project_types.outputs.bake_targets) }}
+        image: ${{ fromJSON(needs.sanitize_inputs.outputs.docker_images) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.bake_targets) }}
 
     steps:
       - *downloadSourceArtifact
@@ -1587,23 +1602,24 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       [
-        event_types,
-        project_types,
+        context_check,
+        process_source,
         versioned_source,
         npm_test,
         docker_test,
         custom_test,
+        sanitize_inputs,
       ]
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.balena == 'true' &&
-      join(fromJSON(needs.project_types.outputs.balena_slugs)) != ''
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.balena == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
 
     strategy:
       fail-fast: false
       matrix:
-        slug: ${{ fromJSON(needs.project_types.outputs.balena_slugs) }}
+        slug: ${{ fromJSON(needs.sanitize_inputs.outputs.balena_slugs) }}
 
     defaults:
       run:
@@ -1619,16 +1635,16 @@ jobs:
     name: Finalize balena
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source, sanitize_inputs]
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.balena == 'true' &&
-      join(fromJSON(needs.project_types.outputs.balena_slugs)) != ''
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.balena == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
 
     strategy:
       fail-fast: false
       matrix:
-        slug: ${{ fromJSON(needs.project_types.outputs.balena_slugs) }}
+        slug: ${{ fromJSON(needs.sanitize_inputs.outputs.balena_slugs) }}
 
     defaults:
       run:
@@ -1648,10 +1664,10 @@ jobs:
     name: Test python poetry
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source]
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.python_poetry == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.python_poetry == 'true'
 
     defaults:
       run:
@@ -1661,7 +1677,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(needs.project_types.outputs.python_versions) }}
+        python-version: ${{ fromJSON(needs.process_source.outputs.python_versions) }}
 
     outputs:
       package: ${{ steps.meta.outputs.package }}
@@ -1737,9 +1753,9 @@ jobs:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
 
     needs:
-      - project_types
+      - process_source
       - versioned_source
-      - event_types
+      - context_check
 
     if: |
       inputs.cloudflare_website != ''
@@ -1754,7 +1770,7 @@ jobs:
 
       - name: Docusaurus Builder
         if: |
-          needs.project_types.outputs.has_readme == 'true' &&
+          needs.process_source.outputs.has_readme == 'true' &&
           inputs.docusaurus_website != false
         uses: product-os/docusaurus-builder@c44214ff7bc25e1b511cf4c5c0e7c56737f5e437 # v1.5.0
         with:
@@ -1769,7 +1785,7 @@ jobs:
         run: npm run deploy-docs --if-present
 
       - name: Update deploy branch for merged PRs
-        if: needs.event_types.outputs.pr_merged == 'true'
+        if: needs.context_check.outputs.pr_merged == 'true'
         run: |
           echo "CF_BRANCH=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
 
@@ -1789,12 +1805,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true'
+      needs.context_check.outputs.do_draft == 'true'
 
     defaults:
       run:
@@ -1815,17 +1831,17 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - project_types
+      - process_source
       - versioned_source
       - github_prepare
       - npm_publish
       - cargo_publish
       - custom_publish
-      - event_types
+      - context_check
 
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true'
+      needs.context_check.outputs.do_draft == 'true'
 
     defaults:
       run:
@@ -1865,9 +1881,9 @@ jobs:
     name: Finalize GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source]
     if: |
-      needs.event_types.outputs.do_final == 'true'
+      needs.context_check.outputs.do_final == 'true'
 
     defaults:
       run:
@@ -1916,12 +1932,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
-        needs.event_types.outputs.pr == 'true' &&
+        needs.context_check.outputs.pr == 'true' &&
         github.event.pull_request.merged == false &&
         github.event.action == 'closed'
 
@@ -1948,13 +1964,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
-      - project_types
+      - context_check
+      - process_source
       - versioned_source
+      - sanitize_inputs
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.cargo == 'true' &&
-      join(fromJSON(needs.project_types.outputs.cargo_targets)) != ''
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.cargo == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
 
     defaults:
       run:
@@ -1964,7 +1981,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.project_types.outputs.cargo_targets) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.cargo_targets) }}
 
     outputs:
       package: ${{ steps.meta.outputs.package }}
@@ -2015,16 +2032,17 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - project_types
+      - process_source
       - versioned_source
       - cargo_test
       - custom_test
-      - event_types
+      - context_check
+      - sanitize_inputs
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
+      needs.context_check.outputs.do_draft == 'true' &&
       needs.cargo_test.result == 'success' &&
-      join(fromJSON(needs.project_types.outputs.cargo_targets)) != '' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != '' &&
       inputs.rust_binaries == true
 
     defaults:
@@ -2035,7 +2053,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.project_types.outputs.cargo_targets) }}
+        target: ${{ fromJSON(needs.sanitize_inputs.outputs.cargo_targets) }}
 
     steps:
       - *downloadSourceArtifact
@@ -2073,11 +2091,11 @@ jobs:
     name: Finalize rust
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source, sanitize_inputs]
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.cargo == 'true' &&
-      join(fromJSON(needs.project_types.outputs.cargo_targets)) != ''
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.cargo == 'true' &&
+      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
 
     defaults:
       run:
@@ -2108,15 +2126,15 @@ jobs:
     name: Test custom
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source, sanitize_inputs]
     if: |
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.custom_test == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.custom_test == 'true'
 
     strategy:
       fail-fast: false
       matrix:
-        value: ${{ fromJSON(needs.project_types.outputs.custom_test_matrix) }}
+        value: ${{ fromJSON(needs.sanitize_inputs.outputs.custom_test_matrix) }}
         os: ${{ fromJSON(inputs.tests_run_on) }}
 
     steps:
@@ -2139,23 +2157,24 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       [
-        event_types,
-        project_types,
+        context_check,
+        process_source,
         versioned_source,
         npm_test,
         docker_test,
         cargo_test,
         custom_test,
+        sanitize_inputs,
       ]
     if: |
       !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      needs.project_types.outputs.custom_publish == 'true'
+      needs.context_check.outputs.do_draft == 'true' &&
+      needs.process_source.outputs.custom_publish == 'true'
 
     strategy:
       fail-fast: false
       matrix:
-        value: ${{ fromJSON(needs.project_types.outputs.custom_publish_matrix) }}
+        value: ${{ fromJSON(needs.sanitize_inputs.outputs.custom_publish_matrix) }}
         os: ${{ fromJSON(inputs.tests_run_on) }}
 
     steps:
@@ -2176,15 +2195,15 @@ jobs:
     name: Finalize custom
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source, sanitize_inputs]
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
-      needs.project_types.outputs.custom_finalize == 'true'
+      needs.context_check.outputs.do_final == 'true' &&
+      needs.process_source.outputs.custom_finalize == 'true'
 
     strategy:
       fail-fast: false
       matrix:
-        value: ${{ fromJSON(needs.project_types.outputs.custom_finalize_matrix) }}
+        value: ${{ fromJSON(needs.sanitize_inputs.outputs.custom_finalize_matrix) }}
         os: ${{ fromJSON(inputs.tests_run_on) }}
 
     steps:
@@ -2209,10 +2228,10 @@ jobs:
       matrix:
         os: ${{ fromJSON(inputs.tests_run_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types, project_types, versioned_source]
+    needs: [context_check, process_source, versioned_source]
     if: |
-      needs.event_types.outputs.do_clean == 'true' &&
-      needs.project_types.outputs.custom_clean == 'true'
+      needs.context_check.outputs.do_clean == 'true' &&
+      needs.process_source.outputs.custom_clean == 'true'
 
     steps:
       - *downloadSourceArtifact
@@ -2232,14 +2251,15 @@ jobs:
         os: ${{ fromJSON(inputs.tests_run_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - event_types
+      - context_check
       - custom_test
       - custom_publish
       - custom_finalize
       - custom_clean
+      - process_source
     if: |
       always() &&
-      needs.project_types.outputs.custom_always == 'true'
+      needs.process_source.outputs.custom_always == 'true'
 
     steps:
       - *downloadSourceArtifact
@@ -2265,13 +2285,13 @@ jobs:
         custom_test,
         python_test,
         docker_test,
-        event_types,
+        context_check,
         npm_publish,
         npm_test,
         cargo_test,
         cargo_publish,
         github_publish,
-        project_types,
+        process_source,
         versioned_source,
         website_build,
       ]
@@ -2279,7 +2299,7 @@ jobs:
     # this job must always run so branch protection rules can depend on it
     if: |
       always() &&
-      needs.event_types.outputs.do_draft == 'true' &&
+      needs.context_check.outputs.do_draft == 'true' &&
       inputs.protect_branch == true &&
       github.event.pull_request.head.repo.full_name == github.repository
 
@@ -2507,9 +2527,9 @@ jobs:
     name: Standardise repository settings
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [event_types]
+    needs: [context_check]
     if: |
-      needs.event_types.outputs.do_final == 'true' &&
+      needs.context_check.outputs.do_final == 'true' &&
       inputs.repo_config == true
     steps:
       - name: Configure repository

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -864,33 +864,6 @@ jobs:
       - *checkoutMergeBranch
       - *checkoutSha
 
-      # reject external contribution workflow in certain conditions to prevent leaking secrets
-      - name: Check external contributor limitations
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-        run: |
-          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
-          then
-            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
-          then
-            echo "::notice::Modifications to workflow files are not supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
-          then
-            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
-              Please contact a member of the organization for assistance."
-            exit 0
-          fi
-
       # Check if we have at least a README to build a website from
 
       - name: Check for README for building a website
@@ -953,6 +926,33 @@ jobs:
     steps:
       - *checkoutMergeBranch
       - *checkoutSha
+
+      # reject external contribution workflow in certain conditions to prevent leaking secrets
+      - name: Check external contributor limitations
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
+        run: |
+          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
+          then
+            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
+          then
+            echo "::notice::Modifications to workflow files are not supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
+          then
+            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
+              Please contact a member of the organization for assistance."
+            exit 0
+          fi
 
       # fail on merge commits (ones with more than one parent)
       - name: Reject merge commits

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -573,11 +573,12 @@ jobs:
             echo "json=${NODE_VERSIONS}" >> $GITHUB_OUTPUT
           fi
 
-  process_source:
-    name: Process source
+  # pre-process any docker-compose and docker-bake files
+  docker_check:
+    name: Check docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, sanitize_inputs]
+    needs: [context_check, versioned_source, sanitize_inputs]
 
     defaults:
       run:
@@ -588,6 +589,84 @@ jobs:
       docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
       docker_bake_json: ${{ steps.docker_bake.outputs.json }}
       docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
+
+    steps:
+      - *downloadSourceArtifact
+      - *extractSourceArtifact
+
+      # merge all compose files in the project and record the merged config as a multiline yaml output
+      - name: Pre-process Docker compose files
+        id: docker_compose
+        env:
+          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
+        run: |
+          test -n "$(ls docker-compose.test.{yml,yaml} 2>/dev/null)" || exit 0
+
+          if [ -n "${COMPOSE_VARS}" ]
+          then
+            echo "${COMPOSE_VARS}" | base64 --decode > .env
+
+            # mask secrets
+            while read -r line; do
+              secret="$(echo "${line}" | awk -F'=' '{print $2}')"
+              echo "::add-mask::${secret}"
+            done <<< "$(cat < .env)"
+          fi
+
+          files="
+            docker-compose.yml
+            docker-compose.yaml
+            docker-compose.test.yml
+            docker-compose.test.yaml
+          "
+          args=""
+
+          for file in ${files}; do
+            test -f "${file}" && args="${args} -f ${file}"
+          done
+
+          echo "base64=$(docker compose ${args} config | base64 -w0)" >> $GITHUB_OUTPUT
+
+      # generate a custom bake json string from the provided bake targets and any discovered bake files
+      # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
+      # in this custom bake json we also set some default cache values, and inherit the docker-metadata-action
+      - name: Pre-process Docker bake files
+        id: docker_bake
+        env:
+          BAKE_FILE: /tmp/docker-bake.json
+        run: |
+          if [ -n "$(ls docker-bake{.override,}.{json,hcl} 2>/dev/null)" ]
+          then
+            files="$(echo $(ls -1 docker-bake{.override,}.{json,hcl} 2>/dev/null) | sed 's/ / -f /')"
+          else
+            echo '${{ needs.sanitize_inputs.outputs.bake_targets }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
+            files="${BAKE_FILE}"
+          fi
+
+          json="$(docker buildx bake --print ${{ join(fromJSON(needs.sanitize_inputs.outputs.bake_targets),' ') }} -f ${files} \
+            | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
+            | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
+            | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
+            | jq '.target |= map_values(."platforms" //= ["linux/amd64"])' \
+            | jq -cr)"
+
+          matrix="$(jq -cr '.target | to_entries | { include: map(.value.platforms[] as $p | {target: .key, platform: $p})}' <<< "${json}")"
+            
+          echo "json=${json}">> $GITHUB_OUTPUT
+          echo "matrix=${matrix}">> $GITHUB_OUTPUT
+
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs: [context_check]
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
       balena: ${{ steps.balena.outputs.enabled }}
       python_poetry: ${{ steps.python_poetry.outputs.enabled }}
       python_versions: ${{ steps.python_versions.outputs.json }}
@@ -797,68 +876,6 @@ jobs:
           then
             echo "always=true" >> $GITHUB_OUTPUT
           fi
-
-      # only if docker-compose test files are found
-      # merge all compose files in the project and record the merged config as a multiline yaml output
-      - name: Pre-process Docker compose files
-        id: docker_compose
-        env:
-          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
-        run: |
-          test -n "$(ls docker-compose.test.{yml,yaml} 2>/dev/null)" || exit 0
-
-          if [ -n "${COMPOSE_VARS}" ]
-          then
-            echo "${COMPOSE_VARS}" | base64 --decode > .env
-
-            # mask secrets
-            while read -r line; do
-              secret="$(echo "${line}" | awk -F'=' '{print $2}')"
-              echo "::add-mask::${secret}"
-            done <<< "$(cat < .env)"
-          fi
-
-          files="
-            docker-compose.yml
-            docker-compose.yaml
-            docker-compose.test.yml
-            docker-compose.test.yaml
-          "
-          args=""
-
-          for file in ${files}; do
-            test -f "${file}" && args="${args} -f ${file}"
-          done
-
-          echo "base64=$(docker compose ${args} config | base64 -w0)" >> $GITHUB_OUTPUT
-
-      # generate a custom bake json string from the provided bake targets and any discovered bake files
-      # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
-      # in this custom bake json we also set some default cache values, and inherit the docker-metadata-action
-      - name: Pre-process Docker bake files
-        id: docker_bake
-        env:
-          BAKE_FILE: /tmp/docker-bake.json
-        run: |
-          if [ -n "$(ls docker-bake{.override,}.{json,hcl} 2>/dev/null)" ]
-          then
-            files="$(echo $(ls -1 docker-bake{.override,}.{json,hcl} 2>/dev/null) | sed 's/ / -f /')"
-          else
-            echo '${{ needs.sanitize_inputs.outputs.bake_targets }}' | jq -s '{target: (map({(.[]):{}}))}' > ${BAKE_FILE}
-            files="${BAKE_FILE}"
-          fi
-
-          json="$(docker buildx bake --print ${{ join(fromJSON(needs.sanitize_inputs.outputs.bake_targets),' ') }} -f ${files} \
-            | jq '.target |= map_values(."inherits" += ["docker-metadata-action"])' \
-            | jq '.target |= map_values(."cache-to" //= ["type=gha"])' \
-            | jq '.target |= map_values(."cache-from" //= ["type=gha"])' \
-            | jq '.target |= map_values(."platforms" //= ["linux/amd64"])' \
-            | jq -cr)"
-
-          matrix="$(jq -cr '.target | to_entries | { include: map(.value.platforms[] as $p | {target: .key, platform: $p})}' <<< "${json}")"
-            
-          echo "json=${json}">> $GITHUB_OUTPUT
-          echo "matrix=${matrix}">> $GITHUB_OUTPUT
 
   ###################################################
   ## versioned source
@@ -1248,17 +1265,16 @@ jobs:
   ## docker
   ###################################################
 
-  # this job combines build & test & publish with buildx bake, docker compose tests, and crane image copy
-  # if there are no compose tests AND no images to publish, this job will be skipped
   docker_test:
     name: Test docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source, sanitize_inputs]
+    needs: [context_check, docker_check, versioned_source, sanitize_inputs]
     if: |
-      !failure() && !cancelled() &&
-      needs.event_types.outputs.do_draft == 'true' &&
-      (join(fromJSON(needs.process_source.outputs.docker_images)) != '' || needs.process_source.outputs.docker_compose_base64 != '')
+      needs.context_check.outputs.do_draft == 'true' && (
+        join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != '' ||
+        needs.docker_check.outputs.docker_compose_base64 != ''
+      )
 
     defaults:
       run:
@@ -1267,7 +1283,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.process_source.outputs.docker_bake_matrix) }}
+      matrix: ${{ fromJSON(needs.docker_check.outputs.docker_bake_matrix) }}
 
     env:
       DOCKER_BAKE_FILE: /tmp/docker-bake.json
@@ -1303,7 +1319,7 @@ jobs:
 
           echo "PLATFORM=$(echo ${{ matrix.platform }} | sed 's/[^[:alnum:]]/-/g')" >> $GITHUB_ENV
 
-          echo '${{ needs.process_source.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
+          echo '${{ needs.docker_check.outputs.docker_bake_json }}' > "${DOCKER_BAKE_FILE}"
           jq . "${DOCKER_BAKE_FILE}"
 
       # https://github.com/docker/metadata-action
@@ -1356,12 +1372,12 @@ jobs:
 
       # run docker compose tests and print the logs from all services
       - name: Run docker compose tests
-        if: needs.process_source.outputs.docker_compose_base64 != ''
+        if: needs.docker_check.outputs.docker_compose_base64 != ''
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
           DOCKER_BUILDKIT: "1"
         run: |
-          echo '${{ needs.process_source.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
+          echo '${{ needs.docker_check.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
           yq . "${COMPOSE_FILE}"
 
@@ -1394,12 +1410,12 @@ jobs:
     needs:
       [
         context_check,
-        process_source,
+        docker_check,
         docker_test,
         sanitize_inputs,
       ]
     if: |
-      !failure() && !cancelled() && needs.context_check.outputs.do_draft == 'true' &&
+      needs.context_check.outputs.do_draft == 'true' &&
       join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''
 
     defaults:
@@ -1423,7 +1439,7 @@ jobs:
 
     steps:
       - name: Warn if tests skipped
-        if: needs.process_source.outputs.docker_compose_base64 == ''
+        if: needs.docker_check.outputs.docker_compose_base64 == ''
         run: echo "::warning::Publishing Docker images without docker compose tests!"
 
       - name: Download all artifacts
@@ -1457,7 +1473,7 @@ jobs:
         run: |
           target="$(echo ${{ matrix.TARGET }} | sed 's/[^[:alnum:]]/-/g')"
 
-          platforms="$(echo '${{ needs.process_source.outputs.docker_bake_matrix }}' | \
+          platforms="$(echo '${{ needs.docker_check.outputs.docker_bake_matrix }}' | \
             jq -r '.include[] | select(.target == "${{ matrix.target}}") | .platform' | \
             sed 's/[^[:alnum:]]/-/g')"
 
@@ -1504,7 +1520,7 @@ jobs:
     name: Finalize docker
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, sanitize_inputs]
+    needs: [context_check, docker_check, sanitize_inputs]
     if: |
       needs.context_check.outputs.do_final == 'true' &&
       join(fromJSON(needs.sanitize_inputs.outputs.docker_images)) != ''

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -655,11 +655,11 @@ jobs:
           echo "json=${json}">> $GITHUB_OUTPUT
           echo "matrix=${matrix}">> $GITHUB_OUTPUT
 
-  process_source:
-    name: Process source
+  python_check:
+    name: Check python
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check]
+    needs: [context_check, versioned_source]
 
     defaults:
       run:
@@ -667,59 +667,12 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     outputs:
-      balena: ${{ steps.balena.outputs.enabled }}
       python_poetry: ${{ steps.python_poetry.outputs.enabled }}
       python_versions: ${{ steps.python_versions.outputs.json }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
-      has_readme: ${{ steps.has_readme.outputs.enabled }}
-
-      custom_test: ${{ steps.custom.outputs.test }}
-      custom_publish: ${{ steps.custom.outputs.publish }}
-      custom_finalize: ${{ steps.custom.outputs.finalize }}
-      custom_clean: ${{ steps.custom.outputs.clean }}
-      custom_always: ${{ steps.custom.outputs.always }}
 
     steps:
-      - *checkoutMergeBranch
-      - *checkoutSha
-
-      # reject external contribution workflow in certain conditions to prevent leaking secrets
-      - name: Check external contributor limitations
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-        run: |
-          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
-          then
-            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
-          then
-            echo "::notice::Modifications to workflow files are not supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
-          then
-            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
-              Please contact a member of the organization for assistance."
-            exit 0
-          fi
-
-      - name: Check for balena.yml
-        id: balena
-        run: |
-          if test -f balena.yml
-          then
-            echo "found balena.yml"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-          fi
+      - *downloadSourceArtifact
+      - *extractSourceArtifact
 
       - name: Check for Python Poetry pyproject.toml
         id: python_poetry
@@ -824,6 +777,70 @@ jobs:
           if [ "${PYTHON_VERSIONS}" != "[]" ]
           then
             echo "json=${PYTHON_VERSIONS}" >> $GITHUB_OUTPUT
+          fi
+
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs: [context_check]
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
+      balena: ${{ steps.balena.outputs.enabled }}
+      cargo: ${{ steps.cargo.outputs.enabled }}
+      has_readme: ${{ steps.has_readme.outputs.enabled }}
+
+      custom_test: ${{ steps.custom.outputs.test }}
+      custom_publish: ${{ steps.custom.outputs.publish }}
+      custom_finalize: ${{ steps.custom.outputs.finalize }}
+      custom_clean: ${{ steps.custom.outputs.clean }}
+      custom_always: ${{ steps.custom.outputs.always }}
+
+    steps:
+      - *checkoutMergeBranch
+      - *checkoutSha
+
+      # reject external contribution workflow in certain conditions to prevent leaking secrets
+      - name: Check external contributor limitations
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
+        run: |
+          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
+          then
+            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
+          then
+            echo "::notice::Modifications to workflow files are not supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
+          then
+            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
+              Please contact a member of the organization for assistance."
+            exit 0
+          fi
+
+      - name: Check for balena.yml
+        id: balena
+        run: |
+          if test -f balena.yml
+          then
+            echo "found balena.yml"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Check Cargo.toml
@@ -1698,10 +1715,10 @@ jobs:
     name: Test python poetry
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source]
+    needs: [context_check, python_check, versioned_source]
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.python_poetry == 'true'
+      needs.python_check.outputs.python_poetry == 'true'
 
     defaults:
       run:
@@ -1711,7 +1728,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(needs.process_source.outputs.python_versions) }}
+        python-version: ${{ fromJSON(needs.python_check.outputs.python_versions) }}
 
     outputs:
       package: ${{ steps.meta.outputs.package }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -470,11 +470,12 @@ jobs:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
 
-  process_source:
-    name: Process source
+  # check if the repository has a package.json file and which engine versions are supported
+  npm_check:
+    name: Check npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, sanitize_inputs]
+    needs: [context_check, versioned_source]
 
     defaults:
       run:
@@ -485,52 +486,11 @@ jobs:
       npm: ${{ steps.npm.outputs.enabled }}
       npm_private: ${{ steps.npm.outputs.private }} # can be null or unset
       npm_docs: ${{ steps.npm.outputs.docs }} # can be null or unset
-      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
-      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
-      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
-      balena: ${{ steps.balena.outputs.enabled }}
       node_versions: ${{ steps.node_versions.outputs.json }}
-      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
-      python_versions: ${{ steps.python_versions.outputs.json }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
-      has_readme: ${{ steps.has_readme.outputs.enabled }}
-
-      custom_test: ${{ steps.custom.outputs.test }}
-      custom_publish: ${{ steps.custom.outputs.publish }}
-      custom_finalize: ${{ steps.custom.outputs.finalize }}
-      custom_clean: ${{ steps.custom.outputs.clean }}
-      custom_always: ${{ steps.custom.outputs.always }}
 
     steps:
-      - *checkoutMergeBranch
-      - *checkoutSha
-
-      # reject external contribution workflow in certain conditions to prevent leaking secrets
-      - name: Check external contributor limitations
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-        run: |
-          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
-          then
-            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
-          then
-            echo "::notice::Modifications to workflow files are not supported for external contributions. \
-              Please contact a member of the organization for assistance."
-            exit 1
-          fi
-
-          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
-          then
-            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
-              Please contact a member of the organization for assistance."
-            exit 0
-          fi
+      - *downloadSourceArtifact
+      - *extractSourceArtifact
 
       - name: Check for package.json
         id: npm
@@ -611,6 +571,64 @@ jobs:
           if [ "${NODE_VERSIONS}" != "[]" ]
           then
             echo "json=${NODE_VERSIONS}" >> $GITHUB_OUTPUT
+          fi
+
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs: [context_check, sanitize_inputs]
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
+      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
+      docker_bake_json: ${{ steps.docker_bake.outputs.json }}
+      docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
+      balena: ${{ steps.balena.outputs.enabled }}
+      python_poetry: ${{ steps.python_poetry.outputs.enabled }}
+      python_versions: ${{ steps.python_versions.outputs.json }}
+      cargo: ${{ steps.cargo.outputs.enabled }}
+      has_readme: ${{ steps.has_readme.outputs.enabled }}
+
+      custom_test: ${{ steps.custom.outputs.test }}
+      custom_publish: ${{ steps.custom.outputs.publish }}
+      custom_finalize: ${{ steps.custom.outputs.finalize }}
+      custom_clean: ${{ steps.custom.outputs.clean }}
+      custom_always: ${{ steps.custom.outputs.always }}
+
+    steps:
+      - *checkoutMergeBranch
+      - *checkoutSha
+
+      # reject external contribution workflow in certain conditions to prevent leaking secrets
+      - name: Check external contributor limitations
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          GH_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
+        run: |
+          if [ -n "${{ secrets.COMPOSE_VARS }}" ]
+          then
+            echo "::notice::COMPOSE_VARS secrets are not currently supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
+          then
+            echo "::notice::Modifications to workflow files are not supported for external contributions. \
+              Please contact a member of the organization for assistance."
+            exit 1
+          fi
+
+          if [ "${{ inputs.restrict_custom_actions }}" == "true" ]
+          then
+            echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
+              Please contact a member of the organization for assistance."
+            exit 0
           fi
 
       - name: Check for balena.yml
@@ -992,10 +1010,10 @@ jobs:
     name: Test npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source]
+    needs: [context_check, npm_check, versioned_source]
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.npm == 'true'
+      needs.npm_check.outputs.npm == 'true'
 
     defaults:
       run:
@@ -1005,7 +1023,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ${{ fromJSON(needs.process_source.outputs.node_versions) }}
+        node_version: ${{ fromJSON(needs.npm_check.outputs.node_versions) }}
 
     outputs:
       package: ${{ steps.meta.outputs.package }}
@@ -1087,16 +1105,16 @@ jobs:
           retention-days: 90
 
       - name: Generate docs (if present)
-        if: needs.process_source.outputs.npm_docs == 'true'
+        if: needs.npm_check.outputs.npm_docs == 'true'
         shell: bash
         run: npm run doc
 
       - name: Compress docs
-        if: needs.process_source.outputs.npm_docs == 'true'
+        if: needs.npm_check.outputs.npm_docs == 'true'
         run: tar -acvf ${{ runner.temp }}/docs.tgz ./docs
 
       - name: Upload artifact
-        if: needs.process_source.outputs.npm_docs == 'true'
+        if: needs.npm_check.outputs.npm_docs == 'true'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
@@ -1108,12 +1126,12 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      [context_check, process_source, npm_test, custom_test]
+      [context_check, npm_check, npm_test, custom_test]
     if: |
       !failure() && !cancelled() &&
       needs.npm_test.result == 'success' &&
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.npm_private != 'true'
+      needs.npm_check.outputs.npm_private != 'true'
 
     defaults:
       run:
@@ -1125,7 +1143,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.npm_check.outputs.node_versions)[0] }}
 
       - name: Login to registry
         run: |
@@ -1153,11 +1171,11 @@ jobs:
     name: Finalize npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source]
+    needs: [context_check, npm_check]
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.npm == 'true' &&
-      needs.process_source.outputs.npm_private != 'true'
+      needs.npm_check.outputs.npm == 'true' &&
+      needs.npm_check.outputs.npm_private != 'true'
 
     defaults:
       run:
@@ -1174,7 +1192,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
+          name: npm-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.npm_check.outputs.node_versions)[0] }}
 
       - name: Login to registry
         run: |
@@ -1192,10 +1210,10 @@ jobs:
     name: Finalize npm docs
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source]
+    needs: [context_check, npm_check]
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.npm_docs == 'true'
+      needs.npm_check.outputs.npm_docs == 'true'
 
     defaults:
       run:
@@ -1212,7 +1230,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.process_source.outputs.node_versions)[0] }}
+          name: docs-${{ github.event.pull_request.head.sha }}-${{ fromJSON(needs.npm_check.outputs.node_versions)[0] }}
 
       - name: Extract docs artifact
         run: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -306,9 +306,6 @@ env:
   CARGO_REGISTRY: crates.io
 
 jobs:
-  ###################################################
-  ## event types
-  ###################################################
 
   context_check:
     name: Check context
@@ -921,10 +918,6 @@ jobs:
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
-
-  ###################################################
-  ## versioned source
-  ###################################################
 
   versioned_source:
     name: Versioned source
@@ -1848,8 +1841,8 @@ jobs:
   # Website
   ###################################################
 
-  website_build:
-    name: Build website using Docusaurus
+  website_publish:
+    name: Publish website
     runs-on: ${{fromJSON(inputs.runs_on)}}
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
@@ -1899,8 +1892,8 @@ jobs:
   # GitHub
   ###################################################
 
-  github_prepare:
-    name: Clean previous GitHub draft release
+  github_clean:
+    name: Clean GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
@@ -1908,7 +1901,8 @@ jobs:
       - versioned_source
     if: |
       !failure() && !cancelled() &&
-      needs.context_check.outputs.do_draft == 'true'
+      (needs.context_check.outputs.do_draft == 'true' ||
+      (needs.context_check.outputs.pr_closed == 'true' && needs.context_check.outputs.pr_merged == 'false'))
 
     defaults:
       run:
@@ -1925,12 +1919,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
 
   github_publish:
-    name: Publish draft Github release
+    name: Publish Github release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - versioned_source
-      - github_prepare
+      - github_clean
       - npm_publish
       - cargo_publish
       - custom_publish
@@ -2024,33 +2017,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
 
-  github_clean:
-    name: Clean unused GitHub release
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
-    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs:
-      - context_check
-      - versioned_source
-    if: |
-      !failure() && !cancelled() &&
-        needs.context_check.outputs.pr == 'true' &&
-        github.event.pull_request.merged == false &&
-        github.event.action == 'closed'
-
-    defaults:
-      run:
-        working-directory: .
-        shell: bash --noprofile --norc -eo pipefail -x {0}
-
-    steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
-
-      - name: Delete draft release
-        run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-
   ###################################################
   # rust
   ###################################################
@@ -2123,7 +2089,7 @@ jobs:
           echo "version_tag=${version_tag}" >> $GITHUB_OUTPUT
 
   cargo_publish:
-    name: Build rust release artifacts
+    name: Publish rust
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
@@ -2385,7 +2351,7 @@ jobs:
         cargo_publish,
         github_publish,
         versioned_source,
-        website_build,
+        website_publish,
       ]
     # avoid being skipped when dependencies are skipped
     # this job must always run so branch protection rules can depend on it
@@ -2616,10 +2582,10 @@ jobs:
   ###################################################
 
   repo_config:
-    name: Standardise repository settings
+    name: Apply repo settings
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check]
+    needs: [context_check, sanitize_inputs]
     if: |
       needs.context_check.outputs.do_final == 'true' &&
       inputs.repo_config == true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -891,11 +891,12 @@ jobs:
             echo "always=true" >> $GITHUB_OUTPUT
           fi
 
-  process_source:
-    name: Process source
+  website_check:
+    name: Check website
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check]
+    needs: [context_check, versioned_source]
+    if: inputs.cloudflare_website != ''
 
     defaults:
       run:
@@ -906,11 +907,10 @@ jobs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
 
     steps:
-      - *checkoutMergeBranch
-      - *checkoutSha
+      - *downloadSourceArtifact
+      - *extractSourceArtifact
 
       # Check if we have at least a README to build a website from
-
       - name: Check for README for building a website
         id: has_readme
         run: |
@@ -1855,12 +1855,9 @@ jobs:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
 
     needs:
-      - process_source
+      - website_check
       - versioned_source
       - context_check
-
-    if: |
-      inputs.cloudflare_website != ''
 
     steps:
       - *downloadSourceArtifact
@@ -1872,7 +1869,7 @@ jobs:
 
       - name: Docusaurus Builder
         if: |
-          needs.process_source.outputs.has_readme == 'true' &&
+          needs.website_check.outputs.has_readme == 'true' &&
           inputs.docusaurus_website != false
         uses: product-os/docusaurus-builder@c44214ff7bc25e1b511cf4c5c0e7c56737f5e437 # v1.5.0
         with:
@@ -1908,7 +1905,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
@@ -1933,7 +1929,6 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - process_source
       - versioned_source
       - github_prepare
       - npm_publish
@@ -1983,7 +1978,7 @@ jobs:
     name: Finalize GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source]
+    needs: [context_check, versioned_source]
     if: |
       needs.context_check.outputs.do_final == 'true'
 
@@ -2035,7 +2030,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
       - versioned_source
     if: |
       !failure() && !cancelled() &&
@@ -2390,7 +2384,6 @@ jobs:
         cargo_test,
         cargo_publish,
         github_publish,
-        process_source,
         versioned_source,
         website_build,
       ]

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -841,11 +841,12 @@ jobs:
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
-  process_source:
-    name: Process source
+  # check for custom actions in source
+  custom_check:
+    name: Check custom
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check]
+    needs: [context_check, versioned_source]
 
     defaults:
       run:
@@ -853,7 +854,6 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     outputs:
-      has_readme: ${{ steps.has_readme.outputs.enabled }}
       custom_test: ${{ steps.custom.outputs.test }}
       custom_publish: ${{ steps.custom.outputs.publish }}
       custom_finalize: ${{ steps.custom.outputs.finalize }}
@@ -861,21 +861,8 @@ jobs:
       custom_always: ${{ steps.custom.outputs.always }}
 
     steps:
-      - *checkoutMergeBranch
-      - *checkoutSha
-
-      # Check if we have at least a README to build a website from
-
-      - name: Check for README for building a website
-        id: has_readme
-        run: |
-          if test -e "README.md"
-          then
-            echo "found README.md"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-          fi
+      - *downloadSourceArtifact
+      - *extractSourceArtifact
 
       - name: Check for custom actions
         # skip custom actions for external contributions by default
@@ -902,6 +889,37 @@ jobs:
           if [ -d .github/actions/always ]
           then
             echo "always=true" >> $GITHUB_OUTPUT
+          fi
+
+  process_source:
+    name: Process source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs: [context_check]
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
+      has_readme: ${{ steps.has_readme.outputs.enabled }}
+
+    steps:
+      - *checkoutMergeBranch
+      - *checkoutSha
+
+      # Check if we have at least a README to build a website from
+
+      - name: Check for README for building a website
+        id: has_readme
+        run: |
+          if test -e "README.md"
+          then
+            echo "found README.md"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
   ###################################################
@@ -2206,10 +2224,10 @@ jobs:
     name: Test custom
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source, sanitize_inputs]
+    needs: [context_check, custom_check, versioned_source, sanitize_inputs]
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.custom_test == 'true'
+      needs.custom_check.outputs.custom_test == 'true'
 
     strategy:
       fail-fast: false
@@ -2238,7 +2256,7 @@ jobs:
     needs:
       [
         context_check,
-        process_source,
+        custom_check,
         versioned_source,
         npm_test,
         docker_test,
@@ -2249,7 +2267,7 @@ jobs:
     if: |
       !failure() && !cancelled() &&
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.custom_publish == 'true'
+      needs.custom_check.outputs.custom_publish == 'true'
 
     strategy:
       fail-fast: false
@@ -2275,10 +2293,10 @@ jobs:
     name: Finalize custom
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source, sanitize_inputs]
+    needs: [context_check, custom_check, versioned_source, sanitize_inputs]
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.custom_finalize == 'true'
+      needs.custom_check.outputs.custom_finalize == 'true'
 
     strategy:
       fail-fast: false
@@ -2308,10 +2326,10 @@ jobs:
       matrix:
         os: ${{ fromJSON(inputs.tests_run_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source]
+    needs: [context_check, custom_check, versioned_source]
     if: |
       needs.context_check.outputs.do_clean == 'true' &&
-      needs.process_source.outputs.custom_clean == 'true'
+      needs.custom_check.outputs.custom_clean == 'true'
 
     steps:
       - *downloadSourceArtifact
@@ -2336,10 +2354,11 @@ jobs:
       - custom_publish
       - custom_finalize
       - custom_clean
-      - process_source
+      - custom_check
+      - versioned_source
     if: |
       always() &&
-      needs.process_source.outputs.custom_always == 'true'
+      needs.custom_check.outputs.custom_always == 'true'
 
     steps:
       - *downloadSourceArtifact

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -779,6 +779,36 @@ jobs:
             echo "json=${PYTHON_VERSIONS}" >> $GITHUB_OUTPUT
           fi
 
+  cargo_check:
+    name: Check rust
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs: [context_check, versioned_source, sanitize_inputs]
+    if: join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
+      cargo: ${{ steps.cargo.outputs.enabled }}
+
+    steps:
+      - *downloadSourceArtifact
+      - *extractSourceArtifact
+
+      - name: Check Cargo.toml
+        id: cargo
+        run: |
+          if test -f "Cargo.toml"
+          then
+            echo "found Cargo.toml"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
+
   process_source:
     name: Process source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -792,7 +822,6 @@ jobs:
 
     outputs:
       balena: ${{ steps.balena.outputs.enabled }}
-      cargo: ${{ steps.cargo.outputs.enabled }}
       has_readme: ${{ steps.has_readme.outputs.enabled }}
 
       custom_test: ${{ steps.custom.outputs.test }}
@@ -838,17 +867,6 @@ jobs:
           if test -f balena.yml
           then
             echo "found balena.yml"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Check Cargo.toml
-        id: cargo
-        run: |
-          if test -f "Cargo.toml"
-          then
-            echo "found Cargo.toml"
             echo "enabled=true" >> $GITHUB_OUTPUT
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
@@ -2016,13 +2034,12 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - context_check
-      - process_source
+      - cargo_check
       - versioned_source
       - sanitize_inputs
     if: |
       needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.cargo == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
+      needs.cargo_check.outputs.cargo == 'true'
 
     defaults:
       run:
@@ -2083,7 +2100,6 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
-      - process_source
       - versioned_source
       - cargo_test
       - custom_test
@@ -2093,7 +2109,6 @@ jobs:
       !failure() && !cancelled() &&
       needs.context_check.outputs.do_draft == 'true' &&
       needs.cargo_test.result == 'success' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != '' &&
       inputs.rust_binaries == true
 
     defaults:
@@ -2142,11 +2157,10 @@ jobs:
     name: Finalize rust
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source, sanitize_inputs]
+    needs: [context_check, cargo_check, versioned_source]
     if: |
       needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.cargo == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.cargo_targets)) != ''
+      needs.cargo_check.outputs.cargo == 'true'
 
     defaults:
       run:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -779,6 +779,7 @@ jobs:
             echo "json=${PYTHON_VERSIONS}" >> $GITHUB_OUTPUT
           fi
 
+  # check for Cargo.toml in source
   cargo_check:
     name: Check rust
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -809,6 +810,37 @@ jobs:
             echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
+  # check for balena.yml in source
+  balena_check:
+    name: Check balena
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs: [context_check, versioned_source, sanitize_inputs]
+    if: join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
+      balena: ${{ steps.balena.outputs.enabled }}
+
+    steps:
+      - *downloadSourceArtifact
+      - *extractSourceArtifact
+
+      - name: Check for balena.yml
+        id: balena
+        run: |
+          if test -f balena.yml
+          then
+            echo "found balena.yml"
+            echo "enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
+
   process_source:
     name: Process source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -821,9 +853,7 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
 
     outputs:
-      balena: ${{ steps.balena.outputs.enabled }}
       has_readme: ${{ steps.has_readme.outputs.enabled }}
-
       custom_test: ${{ steps.custom.outputs.test }}
       custom_publish: ${{ steps.custom.outputs.publish }}
       custom_finalize: ${{ steps.custom.outputs.finalize }}
@@ -859,17 +889,6 @@ jobs:
             echo "::notice::Custom actions are disabled for external contributors and will be skipped. \
               Please contact a member of the organization for assistance."
             exit 0
-          fi
-
-      - name: Check for balena.yml
-        id: balena
-        run: |
-          if test -f balena.yml
-          then
-            echo "found balena.yml"
-            echo "enabled=true" >> $GITHUB_OUTPUT
-          else
-            echo "enabled=false" >> $GITHUB_OUTPUT
           fi
 
       # Check if we have at least a README to build a website from
@@ -1672,7 +1691,7 @@ jobs:
     needs:
       [
         context_check,
-        process_source,
+        balena_check,
         versioned_source,
         npm_test,
         docker_test,
@@ -1680,10 +1699,8 @@ jobs:
         sanitize_inputs,
       ]
     if: |
-      !failure() && !cancelled() &&
-      needs.context_check.outputs.do_draft == 'true' &&
-      needs.process_source.outputs.balena == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
+      !failure() && !cancelled() && needs.balena_check.result == 'success' &&
+      needs.context_check.outputs.do_draft == 'true'
 
     strategy:
       fail-fast: false
@@ -1704,11 +1721,9 @@ jobs:
     name: Finalize balena
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
-    needs: [context_check, process_source, versioned_source, sanitize_inputs]
+    needs: [context_check, balena_check, versioned_source, sanitize_inputs]
     if: |
-      needs.context_check.outputs.do_final == 'true' &&
-      needs.process_source.outputs.balena == 'true' &&
-      join(fromJSON(needs.sanitize_inputs.outputs.balena_slugs)) != ''
+      needs.context_check.outputs.do_final == 'true'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
- Add sanitize inputs job
- Rename project_types to process_source
- Rename event_types to check_context

This is the first of a set of commits
to refactor large jobs into smaller components.

This will allow more control over dependencies
while speeding up runtime since more jobs
can run in parallel.

Change-type: major
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/product-os/flowzone/issues/108