### PR TITLE
Saves the COMPOSE_VARS secret to .env for docker-compose pre-processing.

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -670,10 +670,23 @@ jobs:
           separator: ","
       - name: Pre-process Docker compose files
         id: docker_compose
+        env:
+          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
         run: |
           test -n "$(ls docker-compose.test.{yml,yaml} 2>/dev/null)" || exit 0
 
           export COMPOSE_FILE="$(echo $(ls -1 docker-compose.test.{yml,yaml} docker-compose.{yml,yaml} 2>/dev/null) | sed 's/ /:/')"
+          if [ -n "${COMPOSE_VARS}" ]
+          then
+            echo "${COMPOSE_VARS}" | base64 --decode > .env
+
+            # mask secrets
+            while read -r line; do
+              secret="$(echo "${line}" | awk -F'=' '{print $2}')"
+              echo "::add-mask::${secret}"
+            done <<< "$(cat < .env)"
+          fi
+
           yaml="$(docker compose config)"
 
           echo "yaml<<EOF" >> $GITHUB_OUTPUT

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -774,10 +774,23 @@ jobs:
       # merge all compose files in the project and record the merged config as a multiline yaml output
       - name: Pre-process Docker compose files
         id: docker_compose
+        env:
+          COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
         run: |
           test -n "$(ls docker-compose.test.{yml,yaml} 2>/dev/null)" || exit 0
 
           export COMPOSE_FILE="$(echo $(ls -1 docker-compose.test.{yml,yaml} docker-compose.{yml,yaml} 2>/dev/null) | sed 's/ /:/')"
+          if [ -n "${COMPOSE_VARS}" ]
+          then
+            echo "${COMPOSE_VARS}" | base64 --decode > .env
+
+            # mask secrets
+            while read -r line; do
+              secret="$(echo "${line}" | awk -F'=' '{print $2}')"
+              echo "::add-mask::${secret}"
+            done <<< "$(cat < .env)"
+          fi
+
           yaml="$(docker compose config)"
 
           echo "yaml<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This fixes the `no such file or directory` error when docker compose pre-processing (`docker compose config`) is done for a docker-compose that requires a `.env` file.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>