### PR TITLE
Encode docker compose config as base64 to preserve special characters

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -330,7 +330,7 @@ jobs:
       npm: ${{ steps.npm.outputs.enabled }}
       npm_private: ${{ steps.npm.outputs.private }}
       npm_docs: ${{ steps.npm.outputs.docs }}
-      docker_compose_yaml: ${{ steps.docker_compose.outputs.yaml }}
+      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
       docker_bake_json: ${{ steps.docker_bake.outputs.json }}
       docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
       balena: ${{ steps.balena.outputs.enabled }}
@@ -698,14 +698,10 @@ jobs:
             test -f "${file}" && args="${args} -f ${file}"
           done
 
-          yaml="$(docker compose ${args} config)"
-
-          echo "yaml<<EOF" >> $GITHUB_OUTPUT
-          echo "${yaml}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "base64=$(docker compose ${args} config | base64 -w0)" >> $GITHUB_OUTPUT
       - name: Pre-process Docker bake files
         id: docker_bake
-        if: join(fromJSON(steps.docker_images.outputs.build)) != '' || steps.docker_compose.outputs.yaml != ''
+        if: join(fromJSON(steps.docker_images.outputs.build)) != '' || steps.docker_compose.outputs.base64 != ''
         env:
           BAKE_FILE: /tmp/docker-bake.json
         run: |
@@ -1086,7 +1082,7 @@ jobs:
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_yaml != '')
+      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_base64 != '')
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -1158,12 +1154,12 @@ jobs:
         run: |
           docker save ${{ fromJSON(steps.meta.outputs.json).tags[0] }} > ${{ env.IMAGE_TAR }}
       - name: Run docker compose tests
-        if: needs.project_types.outputs.docker_compose_yaml != ''
+        if: needs.project_types.outputs.docker_compose_base64 != ''
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
           DOCKER_BUILDKIT: "1"
         run: |
-          echo '${{ needs.project_types.outputs.docker_compose_yaml }}' > "${COMPOSE_FILE}"
+          echo '${{ needs.project_types.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
           yq . "${COMPOSE_FILE}"
 
@@ -1215,7 +1211,7 @@ jobs:
       LOCAL_TAG: localhost:5000/sut:latest
     steps:
       - name: Warn if tests skipped
-        if: needs.project_types.outputs.docker_compose_yaml == ''
+        if: needs.project_types.outputs.docker_compose_base64 == ''
         run: echo "::warning::Publishing Docker images without docker compose tests!"
       - name: Download all artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -401,7 +401,7 @@ jobs:
       npm: ${{ steps.npm.outputs.enabled }}
       npm_private: ${{ steps.npm.outputs.private }} # can be null or unset
       npm_docs: ${{ steps.npm.outputs.docs }} # can be null or unset
-      docker_compose_yaml: ${{ steps.docker_compose.outputs.yaml }}
+      docker_compose_base64: ${{ steps.docker_compose.outputs.base64 }}
       docker_bake_json: ${{ steps.docker_bake.outputs.json }}
       docker_bake_matrix: ${{ steps.docker_bake.outputs.matrix }}
       balena: ${{ steps.balena.outputs.enabled }}
@@ -802,18 +802,14 @@ jobs:
             test -f "${file}" && args="${args} -f ${file}"
           done
 
-          yaml="$(docker compose ${args} config)"
-          
-          echo "yaml<<EOF" >> $GITHUB_OUTPUT
-          echo "${yaml}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "base64=$(docker compose ${args} config | base64 -w0)" >> $GITHUB_OUTPUT
 
       # generate a custom bake json string from the provided bake targets and any discovered bake files
       # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
       # in this custom bake json we also set some default cache values, and inherit the docker-metadata-action
       - name: Pre-process Docker bake files
         id: docker_bake
-        if: join(fromJSON(steps.docker_images.outputs.build)) != '' || steps.docker_compose.outputs.yaml != ''
+        if: join(fromJSON(steps.docker_images.outputs.build)) != '' || steps.docker_compose.outputs.base64 != ''
         env:
           BAKE_FILE: /tmp/docker-bake.json
         run: |
@@ -1234,7 +1230,7 @@ jobs:
     if: |
       !failure() && !cancelled() &&
       needs.event_types.outputs.do_draft == 'true' &&
-      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_yaml != '')
+      (join(fromJSON(needs.project_types.outputs.docker_images)) != '' || needs.project_types.outputs.docker_compose_base64 != '')
 
     defaults:
       run:
@@ -1332,12 +1328,12 @@ jobs:
 
       # run docker compose tests and print the logs from all services
       - name: Run docker compose tests
-        if: needs.project_types.outputs.docker_compose_yaml != ''
+        if: needs.project_types.outputs.docker_compose_base64 != ''
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
           DOCKER_BUILDKIT: "1"
         run: |
-          echo '${{ needs.project_types.outputs.docker_compose_yaml }}' > "${COMPOSE_FILE}"
+          echo '${{ needs.project_types.outputs.docker_compose_base64 }}' | base64 -d > "${COMPOSE_FILE}"
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
           yq . "${COMPOSE_FILE}"
 
@@ -1394,7 +1390,7 @@ jobs:
     steps:
 
       - name: Warn if tests skipped
-        if: needs.project_types.outputs.docker_compose_yaml == ''
+        if: needs.project_types.outputs.docker_compose_base64 == ''
         run: echo "::warning::Publishing Docker images without docker compose tests!"
 
       - name: Download all artifacts


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

In some cases the formatting of a compose file is broken when exported as an environment variable in GitHub actions. See this example [failed job](https://github.com/klutchell/unbound-docker/actions/runs/4043638837/jobs/6952826663).