### PR TITLE
Make the Rust toolchain version user configurable

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -103,6 +103,11 @@ on:
           arm-unknown-linux-gnueabihf,
           x86_64-unknown-linux-gnu,
           i686-unknown-linux-gnu
+      rust_toolchain:
+        description: Version specifier (e.g. 1.65, stable, nigthly) for the toolchain to use when building Rust sources
+        type: string
+        required: false
+        default: stable
       rust_binaries:
         description: Set to true to publish Rust binary release artifacts to GitHub
         type: boolean
@@ -1884,8 +1889,9 @@ jobs:
         working-directory: .
         run: tar -xvf ${{ runner.temp }}/source.tgz
       - name: Set up toolchain ${{ matrix.target }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ inputs.rust_toolchain }}
           targets: ${{ matrix.target }}
           components: rustfmt
       - name: Check formatting
@@ -1944,8 +1950,9 @@ jobs:
         working-directory: .
         run: tar -xvf ${{ runner.temp }}/source.tgz
       - name: Set up toolchain ${{ matrix.target }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ inputs.rust_toolchain }}
           targets: ${{ matrix.target }}
       - name: Install cross
         run: cargo install cross

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`balena_slugs`](#balena_slugs)
     - [`cargo_targets`](#cargo_targets)
     - [`rust_binaries`](#rust_binaries)
+    - [`rust_toolchain`](#rust_toolchain)
     - [`protect_branch`](#protect_branch)
     - [`repo_config`](#repo_config)
     - [`repo_allow_forking`](#repo_allow_forking)
@@ -486,6 +487,14 @@ Set to true to publish Rust binary artifacts to GitHub.
 Type: _boolean_
 
 Default: `true`
+
+## `rust_toolchain`
+
+Version specifier (e.g. 1.65, stable, nigthly) for the toolchain to use when building Rust sources.
+
+Type: _string_
+
+Default: `'stable'`
 
 #### `protect_branch`
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -149,6 +149,11 @@ on:
           arm-unknown-linux-gnueabihf,
           x86_64-unknown-linux-gnu,
           i686-unknown-linux-gnu
+      rust_toolchain:
+        description: "Version specifier (e.g. 1.65, stable, nigthly) for the toolchain to use when building Rust sources"
+        type: string
+        required: false
+        default: stable
       rust_binaries:
         description: "Set to true to publish Rust binary release artifacts to GitHub"
         type: boolean
@@ -2056,8 +2061,9 @@ jobs:
       - *extractSourceArtifact
 
       - name: Set up toolchain ${{ matrix.target }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ inputs.rust_toolchain }}
           targets: ${{ matrix.target }}
           components: rustfmt
 
@@ -2119,8 +2125,9 @@ jobs:
       - *extractSourceArtifact
 
       - name: Set up toolchain ${{ matrix.target }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ inputs.rust_toolchain }}
           targets: ${{ matrix.target }}
 
       - name: Install cross


### PR DESCRIPTION
Adds a `rust_toolchain` (defaults to `stable`) to allow users to configure their preferred toolchain to use when building Rust binaries.

Change-type: minor