### PR TITLE
Renove balena-cli from e2e tests and re-enable fatrw

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,14 +71,13 @@ jobs:
         repository:
           [
             balena-io/balena-api,
-            balena-io/balena-cli,
             balena-io/docs,
             balena-io/environment-staging,
             balena-os/balena-engine,
             balena-os/balena-supervisor,
             balenaltd/handbook,
             product-os/environment-staging,
-            # balena-os/fatrw,
+            balena-os/fatrw,
           ]
 
     env:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>