### PR TITLE
Restore old tag lookup behaviour

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -571,7 +571,7 @@ jobs:
       - name: Get version from tags
         id: version_tag
         run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
+          tag="$(git describe --all --tags --always | cat)"
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
       - name: Compress source
@@ -1308,7 +1308,7 @@ jobs:
       - name: Get version from tags
         id: version_tag
         run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
+          tag="$(git describe --all --tags --always | cat)"
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
       - name: Setup QEMU
@@ -1525,7 +1525,7 @@ jobs:
       - name: Get version from tags
         id: version_tag
         run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
+          tag="$(git describe --all --tags --always | cat)"
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
       - name: Set env vars
@@ -1715,7 +1715,7 @@ jobs:
       - name: Get version from tags
         id: version_tag
         run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
+          tag="$(git describe --all --tags --always | cat)"
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
       - name: Set up Python ${{ matrix.python-version }}
@@ -1911,7 +1911,7 @@ jobs:
       - name: Get version from tags
         id: version_tag
         run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
+          tag="$(git describe --all --tags --always | cat)"
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
       - name: Finalize GitHub release (if any)
@@ -1983,7 +1983,7 @@ jobs:
       - name: Get version from tags
         id: version_tag
         run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
+          tag="$(git describe --all --tags --always | cat)"
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
       - name: Set up toolchain ${{ matrix.target }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -17,7 +17,7 @@
     name: Get version from tags
     id: version_tag
     run: |
-      tag="$(git tag --points-at HEAD | tail -n1)"
+      tag="$(git describe --all --tags --always | cat)"
       echo "tag=${tag}" >> $GITHUB_OUTPUT
       echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
If versioning is disabled and a PR is open, there
will likely not be a tag on the HEAD commit.

However we still want to use something to tag
our artifacts so use git descibe.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>