### PR TITLE
Cancel concurrent jobs with the exception of merged PRs

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -255,7 +255,7 @@ on:
         default: ""
 concurrency:
   group: flowzone-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != github.base_ref }}
 env:
   GHCR_USER: flowzone
   NPM_REGISTRY: registry.npmjs.org

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -312,7 +312,8 @@ on:
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
   group: flowzone-${{ github.ref }}
-  cancel-in-progress: true
+  # cancel jobs in progress as long as it's not a merged PR
+  cancel-in-progress: ${{ github.ref != github.base_ref }}
 
 env:
   GHCR_USER: "flowzone" # does not seem to matter what is used here


### PR DESCRIPTION
We always want merged PRs to queue up and complete in order or versioning will break.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/product-os/flowzone/issues/419