### PR TITLE
Gnerate tokens once at start of workflow

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -315,7 +315,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
           then
@@ -352,7 +352,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
           then
@@ -389,7 +389,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ $(gh pr diff ${{ github.event.pull_request.number }} --name-only) =~ ^\.github\/ ]]
           then
@@ -504,24 +504,29 @@ jobs:
         with:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
-  versioned_source:
-    name: Versioned source
+  github_tokens:
+    name: Request GitHub tokens
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_open
       - is_pr_merged
+      - is_pr_closed
+      - is_pushed_tag
     if: |
-      !failure() && !cancelled() &&
-      needs.is_pr_open.result != needs.is_pr_merged.result &&
-      inputs.disable_versioning == false
+      !failure() && !cancelled() && (
+        needs.is_pr_merged.result == 'success' ||
+        needs.is_pr_closed.result == 'success' ||
+        needs.is_pr_open.result == 'success' ||
+        needs.is_pushed_tag.result == 'success'
+      )
     defaults:
       run:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     outputs:
-      tag: ${{ steps.versionist.outputs.tag }}
-      semver: ${{ steps.versionist.outputs.semver }}
+      untrusted: ${{ steps.external_pr.outputs.untrusted || steps.internal_pr.outputs.untrusted }}
+      trusted: ${{ steps.external_pr.outputs.trusted || steps.internal_pr.outputs.trusted }}
     steps:
       - name: Check secrets
         id: check_secrets
@@ -546,6 +551,44 @@ jobs:
           installation_id: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
+      - name: External pull request
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        id: external_pr
+        env:
+          AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
+          echo "untrusted=${AUTO_TOKEN}" >> $GITHUB_OUTPUT
+          echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
+      - name: Internal pull request
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        id: internal_pr
+        env:
+          AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
+          echo "untrusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
+          echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
+  versioned_source:
+    name: Versioned source
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - is_pr_open
+      - is_pr_merged
+      - github_tokens
+    if: |
+      !failure() && !cancelled() &&
+      needs.is_pr_open.result != needs.is_pr_merged.result &&
+      inputs.disable_versioning == false
+    defaults:
+      run:
+        working-directory: .
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      tag: ${{ steps.versionist.outputs.tag }}
+      semver: ${{ steps.versionist.outputs.semver }}
+    steps:
       - name: Checkout merge branch
         if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
         id: checkout_merge
@@ -554,14 +597,14 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.number }}/merge
-          token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ needs.github_tokens.outputs.trusted }}
       - name: Checkout sha
         if: github.event_name != 'pull_request_target' || github.event.action == 'closed'
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           fetch-depth: 0
           submodules: recursive
-          token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ needs.github_tokens.outputs.trusted }}
       - name: Reject merge commits
         run: |
           if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]
@@ -657,6 +700,7 @@ jobs:
     needs:
       - is_pushed_tag
       - is_pr_open
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pushed_tag.result != needs.is_pr_open.result &&
@@ -669,36 +713,13 @@ jobs:
       tag: ${{ steps.version_tag.outputs.tag }}
       semver: ${{ steps.version_tag.outputs.semver }}
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Checkout sha
         if: github.event_name != 'pull_request_target' || github.event.action == 'closed'
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           fetch-depth: 0
           submodules: recursive
-          token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ needs.github_tokens.outputs.trusted }}
       - name: Get version from tags
         id: version_tag
         run: |
@@ -1359,6 +1380,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - npm_check
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -1369,33 +1391,10 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Download npm artifact from last run
         uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415
         with:
-          github_token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github_token: ${{ needs.github_tokens.outputs.trusted }}
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
@@ -1420,6 +1419,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - npm_check
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -1429,33 +1429,10 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Download npm docs artifact from last run
         uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415
         with:
-          github_token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github_token: ${{ needs.github_tokens.outputs.trusted }}
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
@@ -1467,7 +1444,7 @@ jobs:
       - name: Publish generated docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7
         with:
-          github_token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github_token: ${{ needs.github_tokens.outputs.trusted }}
           publish_dir: docs
           publish_branch: docs
   docker_test:
@@ -1478,6 +1455,7 @@ jobs:
       - is_pr_open
       - docker_check
       - sanitize_inputs
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.docker_check.result == 'success' &&
@@ -1511,44 +1489,6 @@ jobs:
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
           echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
-      - name: Split tokens to trusted/untrusted cases
-        id: gh_token_filter
-        env:
-          IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-          AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-        run: |
-          if [ "${IS_EXTERNAL}" = "true" ]
-          then
-            echo "untrusted=${AUTO_TOKEN}" >> $GITHUB_OUTPUT
-            echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
-          else
-            echo "untrusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
-            echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
-          fi
       - name: Setup QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       - name: Setup buildx
@@ -1610,8 +1550,8 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.platform=${{ matrix.platform }}
-            *.args.GITHUB_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}
-            *.args.GH_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}
+            *.args.GITHUB_TOKEN=${{ needs.github_tokens.outputs.untrusted }}
+            *.args.GH_TOKEN=${{ needs.github_tokens.outputs.untrusted }}
           load: true
       - name: Save image to file
         run: |
@@ -1636,12 +1576,12 @@ jobs:
         run: |
           if ! grep -q '^GH_TOKEN=' .env
           then
-            echo "GH_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}" >> .env
+            echo "GH_TOKEN=${{ needs.github_tokens.outputs.untrusted }}" >> .env
           fi
 
           if ! grep -q '^GITHUB_TOKEN=' .env
           then
-            echo "GITHUB_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}" >> .env
+            echo "GITHUB_TOKEN=${{ needs.github_tokens.outputs.untrusted }}" >> .env
           fi
       - name: Run docker compose tests
         if: needs.docker_check.outputs.docker_compose_tests == 'true'
@@ -1706,29 +1646,6 @@ jobs:
     env:
       LOCAL_TAG: localhost:5000/sut:latest
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Warn if tests skipped
         if: needs.docker_check.outputs.docker_compose_tests != 'true'
         run: echo "::warning::Publishing Docker images without docker compose tests!"
@@ -1822,29 +1739,6 @@ jobs:
         image: ${{ fromJSON(needs.sanitize_inputs.outputs.docker_images) }}
         target: ${{ fromJSON(needs.sanitize_inputs.outputs.bake_targets) }}
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Download source artifact
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -2144,6 +2038,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_closed
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_closed.result == 'success'
@@ -2152,29 +2047,6 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Delete draft GitHub release
         run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
         env:
@@ -2182,7 +2054,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
   github_publish:
     name: Publish Github release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -2192,6 +2064,7 @@ jobs:
       - cargo_publish
       - custom_publish
       - is_pr_open
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success'
@@ -2200,29 +2073,6 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Delete draft GitHub release
         run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
         env:
@@ -2230,7 +2080,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
       - name: Download all artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -2250,7 +2100,7 @@ jobs:
         if: steps.gh_artifacts.outputs.count != '0'
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
-          token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ needs.github_tokens.outputs.trusted }}
           name: ${{ github.event.pull_request.head.ref }}
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
@@ -2265,6 +2115,7 @@ jobs:
       - is_pushed_tag
       - versioned_source
       - tagged_source
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result
@@ -2273,38 +2124,6 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-        with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: tar -xvf ${{ runner.temp }}/source.tgz
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2313,6 +2132,12 @@ jobs:
           echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
           echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Finalize GitHub release (if any)
+        env:
+          GH_DEBUG: "true"
+          GH_PAGER: cat
+          GH_PROMPT_DISABLED: "true"
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
         run: |
           set -ea
           # prevent git from existing with 141
@@ -2727,6 +2552,7 @@ jobs:
       - github_publish
       - website_publish
       - custom_always
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2741,29 +2567,6 @@ jobs:
     env:
       BRANCH_PROTECTION_URI: repos/${{ github.repository }}/branches/${{ github.event.repository.default_branch }}/protection
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Check if PR is draft
         id: is_draft
         env:
@@ -2771,7 +2574,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh pr view ${{ github.event.pull_request.number }} --json isDraft | jq -e '.isDraft == true'
           then
@@ -2793,7 +2596,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
         run: |
           result="$(gh api ${{ env.BRANCH_PROTECTION_URI }} || true)"
           message="$(echo "${result}" | jq -r .message)"
@@ -2814,7 +2617,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
           policybot_re: ^policy-?bot
           resinci_re: ^resinci
           flowzone_re: ^${{ inputs.job_name }}
@@ -2932,7 +2735,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
         run: |
           for pr in $(gh pr list --state=open --draft=false --json=number | jq -r '.[].number')
           do
@@ -2948,7 +2751,7 @@ jobs:
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
         run: |
           result="$(echo '${{ fromJSON(steps.parse_prepare_protection_rules.outputs.result) }}' \
             | gh api --method PUT ${{ env.BRANCH_PROTECTION_URI }} --input -)"
@@ -2975,41 +2778,19 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_merged
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result == 'success' &&
       inputs.repo_config == true
     steps:
-      - name: Check secrets
-        id: check_secrets
-        run: |
-          if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-            && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-              false
-          fi
-
-          if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-              echo 'private_key=true' >> $GITHUB_OUTPUT
-          else
-              echo 'private_key=false' >> $GITHUB_OUTPUT
-          fi
-      - name: Generate token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
-        if: steps.check_secrets.outputs.private_key == 'true'
-        id: gh_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Configure repository
         env:
           GH_DEBUG: "true"
           GH_PAGER: cat
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ needs.github_tokens.outputs.trusted }}
         run: |
           # only change repository visibility if explicitly set to one of the permissible values
           visibility=''

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -11,61 +11,6 @@
   - &ifPrivateRepository
     if: github.event.repository.private
 
-  - &checkSecrets
-    name: Check secrets
-    id: check_secrets
-    run: |
-      if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
-        && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-          echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
-          false
-      fi
-
-      if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
-          echo 'private_key=true' >> $GITHUB_OUTPUT
-      else
-          echo 'private_key=false' >> $GITHUB_OUTPUT
-      fi
-
-  - &getEphemeralToken
-    # https://github.com/marketplace/actions/github-app-token
-    name: Generate token
-    uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-    if: steps.check_secrets.outputs.private_key == 'true'
-    id: gh_token
-    with:
-      app_id: ${{ inputs.app_id }}
-      installation_id: ${{ inputs.installation_id }}
-      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      permissions: ${{ inputs.token_scope }}
-
-  - &filterGitHubTokens
-    # for external PRs
-    # - untrusted: auto token (rw for internal, ro for external)
-    # - trusted: input token (controlled via inputs)
-    # for internal PRs
-    # - untrusted: input token (controlled via inputs)
-    # - trusted: input token (controlled via inputs)
-    name: Split tokens to trusted/untrusted cases
-    id: gh_token_filter
-    env:
-      # check if the PR is from a fork by comparing the repository name
-      IS_EXTERNAL: "${{ github.event.pull_request.head.repo.full_name != github.repository }}"
-      # auto token can be rw or ro depending on whether the PR is internal or external
-      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-      AUTO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      # input token is provided via inputs, either an ephemeral token or a personal access token
-      INPUT_TOKEN: "${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}"
-    run: |
-      if [ "${IS_EXTERNAL}" = "true" ]
-      then
-        echo "untrusted=${AUTO_TOKEN}" >> $GITHUB_OUTPUT
-        echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
-      else
-        echo "untrusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
-        echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
-      fi
-
   - &downloadSourceArtifact
     name: Download source artifact
     uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
@@ -109,7 +54,7 @@
       fetch-depth: 0
       submodules: "recursive"
       ref: "refs/pull/${{ github.event.number }}/merge"
-      token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      token: ${{ needs.github_tokens.outputs.trusted }}
 
   - &checkoutSha # otherwise use the default checkout behaviour
     name: Checkout sha
@@ -118,7 +63,7 @@
     with:
       fetch-depth: 0
       submodules: "recursive"
-      token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      token: ${{ needs.github_tokens.outputs.trusted }}
 
   - &loginWithDockerHub
     name: Login to Docker Hub
@@ -160,7 +105,8 @@
     GH_PAGER: "cat"
     GH_PROMPT_DISABLED: "true"
     GH_REPO: "${{ github.repository }}"
-    GH_TOKEN: "${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}"
+    # use the automatic actions token by default
+    GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   - &rejectExternalWorkflowChanges
     name: Reject external workflow changes
@@ -196,13 +142,15 @@
     run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
     env:
       <<: *gitHubCliEnvironment
+      # elevate permissions for this request
+      GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
 
   - &isDraftPullRequest
     # check both the github context (static) and via the gh cli (dynamic)
     name: Check if PR is draft
     id: is_draft
     env:
-      <<: *gitHubCliEnvironment
+      <<: *gitHubCliEnvironment     
     run: |
       if gh pr view ${{ github.event.pull_request.number }} --json isDraft | jq -e '.isDraft == true'
       then
@@ -699,6 +647,82 @@ jobs:
           cmd: bash -c "echo $INPUT | tr -d '[:space:]'"
           separator: ","
 
+  github_tokens:
+    name: Request GitHub tokens
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - is_pr_open
+      - is_pr_merged
+      - is_pr_closed
+      - is_pushed_tag
+    if: |
+      !failure() && !cancelled() && (
+        needs.is_pr_merged.result == 'success' ||
+        needs.is_pr_closed.result == 'success' ||
+        needs.is_pr_open.result == 'success' ||
+        needs.is_pushed_tag.result == 'success'
+      )
+
+    <<: *rootWorkingDirectory
+
+    outputs:
+      untrusted: ${{ steps.external_pr.outputs.untrusted || steps.internal_pr.outputs.untrusted }}
+      trusted: ${{ steps.external_pr.outputs.trusted || steps.internal_pr.outputs.trusted }}
+
+    steps:
+    - name: Check secrets
+      id: check_secrets
+      run: |
+        if [[ -z '${{ secrets.FLOWZONE_TOKEN }}' ]] \
+          && [[ -z '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
+            echo '::error::Must specify either GH_APP_PRIVATE_KEY or FLOWZONE_TOKEN.'
+            false
+        fi
+
+        if [[ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]]; then
+            echo 'private_key=true' >> $GITHUB_OUTPUT
+        else
+            echo 'private_key=false' >> $GITHUB_OUTPUT
+        fi
+
+    # https://github.com/marketplace/actions/github-app-token
+    - name: Generate token
+      uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+      if: steps.check_secrets.outputs.private_key == 'true'
+      id: gh_token
+      with:
+        app_id: ${{ inputs.app_id }}
+        installation_id: ${{ inputs.installation_id }}
+        private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        permissions: ${{ inputs.token_scope }}
+
+    - name: External pull request
+      <<: *ifExternalPullRequest
+      id: external_pr
+      env:
+        # auto token can be rw or ro depending on whether the PR is internal or external
+        # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+        AUTO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        # input token is provided via inputs, either an ephemeral token or a personal access token
+        INPUT_TOKEN: "${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}"
+      run: |
+        echo "untrusted=${AUTO_TOKEN}" >> $GITHUB_OUTPUT
+        echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
+
+    - name: Internal pull request
+      <<: *ifInternalPullRequest
+      id: internal_pr
+      env:
+        # auto token can be rw or ro depending on whether the PR is internal or external
+        # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+        AUTO_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        # input token is provided via inputs, either an ephemeral token or a personal access token
+        INPUT_TOKEN: "${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}"
+      run: |
+        echo "untrusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
+        echo "trusted=${INPUT_TOKEN}" >> $GITHUB_OUTPUT
+
   versioned_source:
     name: Versioned source
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -706,6 +730,7 @@ jobs:
     needs:
       - is_pr_open
       - is_pr_merged
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result != needs.is_pr_merged.result &&
@@ -718,8 +743,6 @@ jobs:
       semver: ${{ steps.versionist.outputs.semver }}
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
       - *checkoutMergeBranch
       - *checkoutSha
 
@@ -834,6 +857,7 @@ jobs:
     needs:
       - is_pushed_tag
       - is_pr_open
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pushed_tag.result != needs.is_pr_open.result &&
@@ -846,8 +870,6 @@ jobs:
       semver: ${{ steps.version_tag.outputs.semver }}
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
       - *checkoutSha
       - *getVersionTag
 
@@ -1535,6 +1557,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - npm_check
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -1544,15 +1567,12 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
-
       # https://github.com/dawidd6/action-download-artifact
       # TODO: what if this is a tag event and PR artifacts do not exist?
       - name: Download npm artifact from last run
         uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415 # v2
         with:
-          github_token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github_token: ${{ needs.github_tokens.outputs.trusted }}
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
@@ -1583,6 +1603,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - npm_check
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -1591,15 +1612,12 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
-
       # https://github.com/dawidd6/action-download-artifact
       # TODO: what if this is a tag event and PR artifacts do not exist?
       - name: Download npm docs artifact from last run
         uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415 # v2
         with:
-          github_token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github_token: ${{ needs.github_tokens.outputs.trusted }}
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
@@ -1613,7 +1631,7 @@ jobs:
       - name: Publish generated docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7 # v3
         with:
-          github_token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github_token: ${{ needs.github_tokens.outputs.trusted }}
           publish_dir: docs
           publish_branch: docs
 
@@ -1629,6 +1647,7 @@ jobs:
       - is_pr_open
       - docker_check
       - sanitize_inputs
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.docker_check.result == 'success' &&
@@ -1650,9 +1669,6 @@ jobs:
       - *downloadSourceArtifact
       - *extractSourceArtifact
       - *getVersionTag
-      - *checkSecrets
-      - *getEphemeralToken
-      - *filterGitHubTokens
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2
@@ -1734,8 +1750,8 @@ jobs:
           # inject github token pre-designated for untrusted code
           set: |
             *.platform=${{ matrix.platform }}
-            *.args.GITHUB_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}
-            *.args.GH_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}
+            *.args.GITHUB_TOKEN=${{ needs.github_tokens.outputs.untrusted }}
+            *.args.GH_TOKEN=${{ needs.github_tokens.outputs.untrusted }}
           load: true
 
       - name: Save image to file
@@ -1766,12 +1782,12 @@ jobs:
         run: |
           if ! grep -q '^GH_TOKEN=' .env
           then
-            echo "GH_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}" >> .env
+            echo "GH_TOKEN=${{ needs.github_tokens.outputs.untrusted }}" >> .env
           fi
           
           if ! grep -q '^GITHUB_TOKEN=' .env
           then
-            echo "GITHUB_TOKEN=${{ steps.gh_token_filter.outputs.untrusted }}" >> .env
+            echo "GITHUB_TOKEN=${{ needs.github_tokens.outputs.untrusted }}" >> .env
           fi
 
       # run docker compose tests and print the logs from all services
@@ -1843,9 +1859,6 @@ jobs:
       LOCAL_TAG: localhost:5000/sut:latest
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
-
       - name: Warn if tests skipped
         if: needs.docker_check.outputs.docker_compose_tests != 'true'
         run: echo "::warning::Publishing Docker images without docker compose tests!"
@@ -1935,8 +1948,6 @@ jobs:
         target: ${{ fromJSON(needs.sanitize_inputs.outputs.bake_targets) }}
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
       - *downloadSourceArtifact
       - *extractSourceArtifact
       - *getVersionTag
@@ -2213,14 +2224,13 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_closed
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_closed.result == 'success'
     <<: *rootWorkingDirectory
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
       - *deleteDraftGitHubRelease
 
   github_publish:
@@ -2232,6 +2242,7 @@ jobs:
       - cargo_publish
       - custom_publish
       - is_pr_open
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success'
@@ -2239,8 +2250,6 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
       - *deleteDraftGitHubRelease
 
       - name: Download all artifacts
@@ -2265,7 +2274,7 @@ jobs:
         if: steps.gh_artifacts.outputs.count != '0'
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
-          token: ${{ steps.gh_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ needs.github_tokens.outputs.trusted }}
           name: ${{ github.event.pull_request.head.ref }}
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
@@ -2282,6 +2291,7 @@ jobs:
       - is_pushed_tag
       - versioned_source
       - tagged_source
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result
@@ -2289,14 +2299,14 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
       - *getVersionTag
 
       # https://docs.github.com/en/rest/releases
       - name: Finalize GitHub release (if any)
+        env:
+          <<: *gitHubCliEnvironment
+          # elevate permissions for this request
+          GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
         run: |
           set -ea
           # prevent git from existing with 141
@@ -2666,6 +2676,7 @@ jobs:
       - github_publish
       - website_publish
       - custom_always
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2681,14 +2692,14 @@ jobs:
       BRANCH_PROTECTION_URI: repos/${{ github.repository }}/branches/${{ github.event.repository.default_branch }}/protection
 
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
       - *isDraftPullRequest
 
       - name: Get protection rules
         id: get_protection_rules
         env:
           <<: *gitHubCliEnvironment
+          # elevate permissions for this request
+          GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
         run: |
           result="$(gh api ${{ env.BRANCH_PROTECTION_URI }} || true)"
           message="$(echo "${result}" | jq -r .message)"
@@ -2707,6 +2718,8 @@ jobs:
         id: parse_prepare_protection_rules
         env:
           <<: *gitHubCliEnvironment
+          # elevate permissions for this request
+          GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
           # the regex matching will be case insensitive, so no need to account for that here
           policybot_re: "^policy-?bot"
           resinci_re: "^resinci"
@@ -2826,6 +2839,8 @@ jobs:
           fromJSON(steps.parse_prepare_protection_rules.outputs.old_required_approving_review_count) > fromJSON(inputs.required_approving_review_count)
         env:
           <<: *gitHubCliEnvironment
+          # elevate permissions for this request
+          GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
         run: |
           for pr in $(gh pr list --state=open --draft=false --json=number | jq -r '.[].number')
           do
@@ -2840,6 +2855,8 @@ jobs:
           steps.parse_prepare_protection_rules.outputs.result != ''
         env:
           <<: *gitHubCliEnvironment
+          # elevate permissions for this request
+          GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
         run: |
           result="$(echo '${{ fromJSON(steps.parse_prepare_protection_rules.outputs.result) }}' \
             | gh api --method PUT ${{ env.BRANCH_PROTECTION_URI }} --input -)"
@@ -2861,10 +2878,10 @@ jobs:
           echo "${result}" >> $GITHUB_OUTPUT
           echo "${DELIMITER}" >> $GITHUB_OUTPUT
 
-      # If auto-merge is enabled at the repository level,
-      # and this PR not a draft
-      # and required reviewers > 1 OR policy-bot is enabled,
-      # then toggle auto-merge to ON for this PR for convenience
+      # # If auto-merge is enabled at the repository level,
+      # # and this PR not a draft
+      # # and required reviewers > 1 OR policy-bot is enabled,
+      # # then toggle auto-merge to ON for this PR for convenience
       # - name: Enable PR auto-merge
       #   if: |
       #     steps.is_draft.outputs.dynamic != 'true' &&
@@ -2872,6 +2889,8 @@ jobs:
       #     steps.parse_prepare_protection_rules.outputs.policy_bot == 'true')
       #   env:
       #     <<: *gitHubCliEnvironment
+      #     # elevate permissions for this request
+      #     GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
       #   run: |
       #     if [[ $(gh api '/repos/${{ github.repository }}' | jq -r .allow_auto_merge) =~ true ]]; then
       #       gh pr merge ${{ github.event.pull_request.number }} --merge --auto
@@ -2887,17 +2906,17 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_merged
+      - github_tokens
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result == 'success' &&
       inputs.repo_config == true
     steps:
-      - *checkSecrets
-      - *getEphemeralToken
-
       - name: Configure repository
         env:
           <<: *gitHubCliEnvironment
+          # elevate permissions for this request
+          GH_TOKEN: "${{ needs.github_tokens.outputs.trusted }}"
         run: |
           # only change repository visibility if explicitly set to one of the permissible values
           visibility=''


### PR DESCRIPTION
Change-type: patch

According to the [docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-with-github-apps#authenticating-as-an-installation) tokens expire after 1 hour so this may not be viable.