### PR TITLE
Use docker secrets to inject GitHub tokens

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -532,6 +532,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -550,6 +551,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -692,6 +694,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -710,6 +713,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1402,6 +1406,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -1420,6 +1425,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1472,6 +1478,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -1490,6 +1497,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1564,6 +1572,7 @@ jobs:
           echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -1582,6 +1591,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1648,6 +1658,9 @@ jobs:
         if: github.event.repository.private
       - name: Docker bake
         uses: docker/bake-action@6c87dcca988e4e074e3ab1f976a70f63ec9673fb
+        env:
+          GITHUB_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
+          GH_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
         with:
           workdir: ${{ inputs.working_directory }}
           files: |
@@ -1656,8 +1669,8 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.platform=${{ matrix.platform }}
-            *.args.GITHUB_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}
-            *.args.GH_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}
+            *.secrets=id=GITHUB_TOKEN
+            *.secrets=id=GH_TOKEN
           load: true
       - name: Save image to file
         run: |
@@ -1679,15 +1692,18 @@ jobs:
             done < .env
           fi
       - name: Inject GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
+          GH_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
         run: |
           if ! grep -q '^GH_TOKEN=' .env
           then
-            echo "GH_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}" >> .env
+            echo "GH_TOKEN=${GH_TOKEN}" >> .env
           fi
 
           if ! grep -q '^GITHUB_TOKEN=' .env
           then
-            echo "GITHUB_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}" >> .env
+            echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> .env
           fi
       - name: Run docker compose tests
         if: needs.docker_check.outputs.docker_compose_tests == 'true'
@@ -1710,6 +1726,7 @@ jobs:
           docker compose ${args} config > "${COMPOSE_FILE}"
 
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
+
           yq . "${COMPOSE_FILE}"
 
           docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
@@ -2154,6 +2171,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -2172,6 +2190,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -2212,6 +2231,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -2230,6 +2250,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -2311,6 +2332,7 @@ jobs:
           echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -2329,6 +2351,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -2779,6 +2802,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -2797,6 +2821,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -3028,6 +3053,7 @@ jobs:
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
+        shell: bash
         run: |
           if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
           then
@@ -3046,6 +3072,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Map GitHub tokens to trusted/untrusted
         id: github_tokens
+        shell: bash
         env:
           IS_EXTERNAL: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           AUTO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -14,6 +14,7 @@
   - &checkGitHubAppPrivateKey
     name: Check for GitHub App private key
     id: gh_app_private_key
+    shell: bash
     run: |
       if [ -n '${{ secrets.GH_APP_PRIVATE_KEY }}' ]
       then
@@ -43,6 +44,7 @@
     # - trusted: input token (controlled via inputs)
     name: Map GitHub tokens to trusted/untrusted
     id: github_tokens
+    shell: bash
     env:
       # check if the PR is from a fork by comparing the repository name
       IS_EXTERNAL: "${{ github.event.pull_request.head.repo.full_name != github.repository }}"
@@ -1739,17 +1741,19 @@ jobs:
       # https://github.com/docker/bake-action
       - name: Docker bake
         uses: docker/bake-action@6c87dcca988e4e074e3ab1f976a70f63ec9673fb # v2
+        env:
+          GITHUB_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
+          GH_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
         with:
           workdir: ${{ inputs.working_directory }}
           files: |
             ${{ env.DOCKER_BAKE_FILE }}
             ${{ steps.meta.outputs.bake-file }}
           targets: ${{ matrix.target }}
-          # inject github token pre-designated for untrusted code
           set: |
             *.platform=${{ matrix.platform }}
-            *.args.GITHUB_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}
-            *.args.GH_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}
+            *.secrets=id=GITHUB_TOKEN
+            *.secrets=id=GH_TOKEN
           load: true
 
       - name: Save image to file
@@ -1777,15 +1781,18 @@ jobs:
 
       # inject github token pre-designated for untrusted code
       - name: Inject GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
+          GH_TOKEN: ${{ steps.github_tokens.outputs.untrusted }}
         run: |
           if ! grep -q '^GH_TOKEN=' .env
           then
-            echo "GH_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}" >> .env
+            echo "GH_TOKEN=${GH_TOKEN}" >> .env
           fi
           
           if ! grep -q '^GITHUB_TOKEN=' .env
           then
-            echo "GITHUB_TOKEN=${{ steps.github_tokens.outputs.untrusted || false }}" >> .env
+            echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> .env
           fi
 
       # run docker compose tests and print the logs from all services
@@ -1810,6 +1817,7 @@ jobs:
           docker compose ${args} config > "${COMPOSE_FILE}"
 
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"
+
           yq . "${COMPOSE_FILE}"
 
           docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }


### PR DESCRIPTION
Allow Docker projects to use secrets to access
GITHUB_TOKEN and GH_TOKEN via Dockerfiles.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>