### PR TITLE
Pass vars context to custom*

### DIFF
--- a/.github/actions/always/action.yml
+++ b/.github/actions/always/action.yml
@@ -9,16 +9,21 @@ inputs:
   secrets:
     description: "JSON stringified object containing all the secrets from the calling workflow"
     required: true
+  variables:
+    description: "JSON stringified object containing all the variables from the calling workflow"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Dump context
       shell: bash
       env:
+        GITHUB: ${{ toJSON(github) }}
         INPUTS: ${{ inputs.json }}
         SECRETS: ${{ inputs.secrets }}
-        GITHUB: ${{ toJSON(github) }}
+        VARIABLES: ${{ toJSON(inputs.variables) }}
       run: |
+        echo "${GITHUB}"
         echo "${INPUTS}"
         echo "${SECRETS}"
-        echo "${GITHUB}"
+        echo "${VARIABLES}"

--- a/.github/actions/clean/action.yml
+++ b/.github/actions/clean/action.yml
@@ -9,16 +9,21 @@ inputs:
   secrets:
     description: "JSON stringified object containing all the secrets from the calling workflow"
     required: true
+  variables:
+    description: "JSON stringified object containing all the variables from the calling workflow"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Dump context
       shell: bash
       env:
+        GITHUB: ${{ toJSON(github) }}
         INPUTS: ${{ inputs.json }}
         SECRETS: ${{ inputs.secrets }}
-        GITHUB: ${{ toJSON(github) }}
+        VARIABLES: ${{ toJSON(inputs.variables) }}
       run: |
+        echo "${GITHUB}"
         echo "${INPUTS}"
         echo "${SECRETS}"
-        echo "${GITHUB}"
+        echo "${VARIABLES}"

--- a/.github/actions/finalize/action.yml
+++ b/.github/actions/finalize/action.yml
@@ -9,16 +9,21 @@ inputs:
   secrets:
     description: "JSON stringified object containing all the secrets from the calling workflow"
     required: true
+  variables:
+    description: "JSON stringified object containing all the variables from the calling workflow"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Dump context
       shell: bash
       env:
+        GITHUB: ${{ toJSON(github) }}
         INPUTS: ${{ inputs.json }}
         SECRETS: ${{ inputs.secrets }}
-        GITHUB: ${{ toJSON(github) }}
+        VARIABLES: ${{ toJSON(inputs.variables) }}
       run: |
+        echo "${GITHUB}"
         echo "${INPUTS}"
         echo "${SECRETS}"
-        echo "${GITHUB}"
+        echo "${VARIABLES}"

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -9,19 +9,24 @@ inputs:
   secrets:
     description: "JSON stringified object containing all the secrets from the calling workflow"
     required: true
+  variables:
+    description: "JSON stringified object containing all the variables from the calling workflow"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Dump context
       shell: bash
       env:
+        GITHUB: ${{ toJSON(github) }}
         INPUTS: ${{ inputs.json }}
         SECRETS: ${{ inputs.secrets }}
-        GITHUB: ${{ toJSON(github) }}
+        VARIABLES: ${{ toJSON(inputs.variables) }}
       run: |
+        echo "${GITHUB}"
         echo "${INPUTS}"
         echo "${SECRETS}"
-        echo "${GITHUB}"
+        echo "${VARIABLES}"
 
     # Test publishing release artifacts to github
     - name: Upload generated flowzone.yml

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -9,16 +9,21 @@ inputs:
   secrets:
     description: "JSON stringified object containing all the secrets from the calling workflow"
     required: true
+  variables:
+    description: "JSON stringified object containing all the variables from the calling workflow"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Dump context
       shell: bash
       env:
+        GITHUB: ${{ toJSON(github) }}
         INPUTS: ${{ inputs.json }}
         SECRETS: ${{ inputs.secrets }}
-        GITHUB: ${{ toJSON(github) }}
+        VARIABLES: ${{ toJSON(inputs.variables) }}
       run: |
+        echo "${GITHUB}"
         echo "${INPUTS}"
         echo "${SECRETS}"
-        echo "${GITHUB}"
+        echo "${VARIABLES}"

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2657,6 +2657,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
   custom_publish:
     name: Publish custom
     runs-on: ${{ matrix.os }}
@@ -2705,6 +2706,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
   custom_finalize:
     name: Finalize custom
     runs-on: ${{ matrix.os }}
@@ -2749,6 +2751,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
   custom_clean:
     name: Clean custom
     runs-on: ${{ matrix.os }}
@@ -2786,6 +2789,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
   custom_always:
     name: Always custom
     runs-on: ${{ matrix.os }}
@@ -2825,6 +2829,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
   protect_branch:
     name: Protect branch
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2580,6 +2580,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
 
   custom_publish:
     name: Publish custom
@@ -2619,6 +2620,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
 
   custom_finalize:
     name: Finalize custom
@@ -2654,6 +2656,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
 
   custom_clean:
     name: Clean custom
@@ -2680,6 +2683,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
 
   custom_always:
     name: Always custom
@@ -2708,6 +2712,7 @@ jobs:
         with:
           json: ${{ toJSON(inputs) }}
           secrets: ${{ toJSON(secrets) }}
+          variables: ${{ toJSON(vars) }}
 
   ###################################################
   ## protect branch


### PR DESCRIPTION
Blocking: https://github.com/balena-io/remote-builders/pull/9

Any concern about custom actions affected in other repos can be easily fixed by pinning flowzone version in workflow.yml, or by updating the custom actions to include the new input. 