### PR TITLE
Add a manual workflow to bulk update repositories

### DIFF
--- a/.github/workflows/bulk-patch.yml
+++ b/.github/workflows/bulk-patch.yml
@@ -1,0 +1,212 @@
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+name: Bulk Patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      repositories:
+        description: A comma or newline-separated list of repositories to patch
+        required: true
+        type: string
+      patches_base64:
+        description: One or more patches encoded to base64
+        required: true
+        type: string
+      pr_branch:
+        description: Branch name of the pull request
+        required: false
+        type: string
+        default: user/bulk-patch
+      pr_title:
+        description: The title of the pull request
+        required: true
+        type: string
+      pr_body:
+        description: The body of the pull request
+        required: false
+        type: string
+      pr_labels:
+        description: A comma or newline-separated list of labels for the pull request
+        required: false
+        type: string
+        default: |
+          bulk-patch
+      pr_draft:
+        description: Whether to create the pull request as a draft
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: Whether to skip pushing changes to the remote repositories
+        required: false
+        type: boolean
+        default: true
+      token_app_id:
+        description: "GitHub App id to request a temporary token"
+        type: string
+        required: false
+        # https://github.com/organizations/product-os/settings/apps/flowzone-app
+        # https://github.com/organizations/product-os/settings/variables/actions/APP_ID
+        default: "291899"
+      token_installation_id:
+        description: "GitHub App installation id to request a temporary token"
+        type: string
+        required: false
+        # https://github.com/organizations/product-os/settings/installations
+        # https://github.com/organizations/product-os/settings/variables/actions/INSTALLATION_ID
+        default: "34040165"
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  process_inputs:
+    name: Process inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    defaults:
+      run:
+        working-directory: .
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    outputs:
+      repositories: ${{ steps.repositories_json.outputs.build }}
+
+    steps:
+      - name: Log GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "${GITHUB_CONTEXT}" || true
+
+      - name: Process repositories list
+        id: repositories_csv
+        env:
+          INPUT: ${{ inputs.repositories }}
+        run: |
+          IFS=$',\n'
+          while read -r item
+          do
+            if [ -n "${item}" ]
+            then
+              out="${out},${item}"
+            fi
+          done <<< "${INPUT}"
+          echo "build=${out:1}" >> $GITHUB_OUTPUT
+
+      # https://github.com/kanga333/json-array-builder
+      - name: Build JSON array
+        id: repositories_json
+        uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5 # v0.2.1
+        with:
+          str: ${{ steps.repositories_csv.outputs.build }}
+          separator: ","
+
+  patch_repo:
+    name: Patch repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: process_inputs
+
+    defaults:
+      run:
+        working-directory: .
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repository: ${{ fromJSON(needs.process_inputs.outputs.repositories) }}
+
+    env:
+      # https://cli.github.com/manual/gh_help_environment
+      GH_REPO: ${{ matrix.repository }}
+      GH_PROMPT_DISABLED: "true"
+      GH_DEBUG: "true"
+      GH_PAGER: "cat"
+
+    steps:
+      # https://github.com/tibdex/github-app-token
+      - name: Generate GitHub App token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        id: gh_token
+        with:
+          app_id: ${{ inputs.token_app_id }}
+          installation_id: ${{ inputs.token_installation_id }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repository: ${{ matrix.repository }}
+          permissions: >-
+            {
+              "actions": "read",
+              "administration": "write",
+              "checks": "read",
+              "contents": "write",
+              "members": "read",
+              "metadata": "read",
+              "pull_requests": "write",
+              "statuses": "read",
+              "workflows": "write"
+            }
+
+      # https://cli.github.com/manual/gh_api
+      - name: Get repository settings
+        id: repo
+        env:
+          GH_TOKEN: ${{ steps.gh_token.outputs.token }}
+        run: |
+          echo "default_branch=$(gh api repos/{owner}/{repo} --jq '.default_branch')" >> $GITHUB_OUTPUT
+
+      # https://github.com/actions/checkout
+      - name: Checkout base branch
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
+        with:
+          repository: ${{ matrix.repository }}
+          token: ${{ steps.gh_token.outputs.token }}
+          ref: ${{ steps.repo.outputs.default_branch }}
+
+      # https://github.com/crazy-max/ghaction-import-gpg
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      # https://git-scm.com/docs/git-am
+      - name: Apply patches
+        env:
+          PATCHES_B64: ${{ inputs.patches_base64 }}
+        run: |
+          echo "${{ env.PATCHES_B64 }}" | base64 -d | git am | cat | tee -a $GITHUB_STEP_SUMMARY
+
+      # https://github.com/peter-evans/create-pull-request
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
+        if: inputs.dry_run != true
+        id: cpr
+        with:
+          token: ${{ steps.gh_token.outputs.token }}
+          branch: ${{ inputs.pr_branch }}
+          title: ${{ inputs.pr_title }}
+          body: |
+            ${{ inputs.pr_body}}
+          labels: |
+            ${{ inputs.pr_labels }}
+          draft: ${{ inputs.pr_draft}}
+          delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.gh_token.outputs.token }}
+        run: |
+          echo "Pull Request Number: ${{ steps.cpr.outputs.pull-request-number }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Pull Request URL: ${{ steps.cpr.outputs.pull-request-url }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Pull Request Operation: ${{ steps.cpr.outputs.pull-request-operation }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "Pull Request Head SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}" | tee -a $GITHUB_STEP_SUMMARY
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --merge --auto || true

--- a/BULK-PATCH.md
+++ b/BULK-PATCH.md
@@ -1,0 +1,36 @@
+# Bulk Patch
+
+Open pull requests on a list of repositories with changes from one or more patch files via
+[workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).
+
+## Usage
+
+Using an example repository, generate a set of patches to be applied and encode them with base64.
+
+```bash
+# https://git-scm.com/docs/git-format-patch
+git format-patch -k --stdout origin/master | base64 > /tmp/patches.b64
+```
+
+Execute the workflow via the [web browser](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow?tool=webui),
+or via the [GitHub CLI](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow?tool=cli).
+
+## Developing
+
+Running a workflow manually via the web browser can only use the workflow from the default branch.
+
+In order to test changes to this workflow in a branch,
+you must [use the GitHub CLI](https://cli.github.com/manual/gh_workflow_run) with the `--ref` option.
+
+```bash
+# https://cli.github.com/manual/gh_workflow_run
+gh workflow run bulk-patch.yml \
+    --ref "kyle/bulk-pull-requests" \
+    -f patches_base64="$(cat /tmp/patches.b64)" \
+    -f repositories="balena-os/balena-raspberrypi" \
+    -f token_installation_id="34046907" \
+    -f pr_branch="kyle/bulk-patch" \
+    -f pr_title="Prevent duplicate Flowzone workflow executions" \
+    -f pr_body="[skip ci]" \
+    -f dry_run=true
+```


### PR DESCRIPTION
Change-type: minor
See: https://github.com/product-os/flowzone/issues/549

This manually triggered workflow removes most of the friction when patching many repositories with the same changes.

### Limitations

- changes must be formatted as patches, and some repos will have merge conflicts, or need a different set of patches
- since this is using the ephemeral GitHub App tokens, a valid installation ID must be provided on each run

### Tests

```bash
gh workflow run bulk-patch.yml \
    --ref "kyle/bulk-pull-requests" \
    -f patches_base64="$(cat /tmp/patches.b64)" \
    -f repositories="balena-os/balena-raspberrypi" \
    -f token_installation_id="34046907" \
    -f pr_branch="kyle/bulk-patch" \
    -f pr_title="Prevent duplicate Flowzone workflow executions" \
    -f pr_body="[skip ci]" \
    -f dry_run=false
```

https://github.com/product-os/flowzone/actions/runs/4431918864/attempts/1#summary-12036132481
> Applying: flowzone: Prevent duplicate workflow executions
> Pull Request Number: 1002
> Pull Request URL: https://github.com/balena-os/balena-raspberrypi/pull/1002
> Pull Request Operation: created
> Pull Request Head SHA: c933a6a26840f07fefe48f2941e24ab3bf3de328
