### PR TITLE
BREAKING: Change default docker tag format to {tag}-{variant}

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -108,6 +108,11 @@ on:
         type: string
         required: false
         default: default
+      docker_invert_tags:
+        description: Invert the tags for the Docker images (e.g. `{tag}-{variant}` becomes `{variant}-{tag}`)
+        type: boolean
+        required: false
+        default: false
       balena_environment:
         description: balenaCloud environment
         type: string
@@ -1653,8 +1658,12 @@ jobs:
 
           if [ "${target}" != 'default' ]
           then
-            echo "prefix=${target}-" >> $GITHUB_OUTPUT
-            echo "suffix=-${target}" >> $GITHUB_OUTPUT
+            if [ "${{ inputs.docker_invert_tags }}" = "true" ]
+            then
+              echo "prefix=${target}-" >> $GITHUB_OUTPUT
+            else
+              echo "suffix=-${target}" >> $GITHUB_OUTPUT
+            fi
           fi
 
           if [ -n "${raw_platform}" ]
@@ -1842,8 +1851,12 @@ jobs:
 
           if [ "${target}" != 'default' ]
           then
-            echo "prefix=${target}-" >> $GITHUB_OUTPUT
-            echo "suffix=-${target}" >> $GITHUB_OUTPUT
+            if [ "${{ inputs.docker_invert_tags }}" = "true" ]
+            then
+              echo "prefix=${target}-" >> $GITHUB_OUTPUT
+            else
+              echo "suffix=-${target}" >> $GITHUB_OUTPUT
+            fi
           fi
 
           if [ -n "${raw_platform}" ]
@@ -1868,6 +1881,7 @@ jobs:
           flavor: |
             latest=false
             prefix=${{ steps.strings.outputs.prefix }}
+            suffix=${{ steps.strings.outputs.suffix }}
       - name: Create manifest
         id: manifest
         run: |
@@ -1960,8 +1974,12 @@ jobs:
 
           if [ "${target}" != 'default' ]
           then
-            echo "prefix=${target}-" >> $GITHUB_OUTPUT
-            echo "suffix=-${target}" >> $GITHUB_OUTPUT
+            if [ "${{ inputs.docker_invert_tags }}" = "true" ]
+            then
+              echo "prefix=${target}-" >> $GITHUB_OUTPUT
+            else
+              echo "suffix=-${target}" >> $GITHUB_OUTPUT
+            fi
           fi
 
           if [ -n "${raw_platform}" ]
@@ -1981,6 +1999,7 @@ jobs:
           flavor: |
             latest=${{ steps.version_tag.outputs.semver != '' }}
             prefix=${{ steps.strings.outputs.prefix }},onlatest=true
+            suffix=${{ steps.strings.outputs.suffix }},onlatest=true
       - name: Login to GitHub Container Registry
         continue-on-error: true
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
@@ -1998,7 +2017,7 @@ jobs:
       - name: Publish final tags
         uses: akhilerm/tag-push-action@85bf542f43f5f2060ef76262a67ee3607cb6db37
         with:
-          src: ${{ matrix.image }}:${{ steps.strings.outputs.prefix }}${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          src: ${{ matrix.image }}:${{ steps.strings.outputs.prefix }}${{ github.event.pull_request.head.sha || github.event.head_commit.id }}${{ steps.strings.outputs.suffix }}
           dst: |
             ${{ steps.meta.outputs.tags }}
       - name: Strip docker.io prefix

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`working_directory`](#working_directory)
     - [`docker_images`](#docker_images)
     - [`bake_targets`](#bake_targets)
+    - [`docker_invert_tags`](#docker_invert_tags)
     - [`balena_environment`](#balena_environment)
     - [`balena_slugs`](#balena_slugs)
     - [`cargo_targets`](#cargo_targets)
@@ -525,6 +526,14 @@ Comma-delimited string of Docker buildx bake targets to publish (skipped if empt
 Type: _string_
 
 Default: `default`
+
+#### `docker_invert_tags`
+
+Invert the tags for the Docker images (e.g. `{tag}-{variant}` becomes `{variant}-{tag}`)
+
+Type: _boolean_
+
+Default: `false`
 
 #### `balena_environment`
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -305,8 +305,12 @@
 
       if [ "${target}" != 'default' ]
       then
-        echo "prefix=${target}-" >> $GITHUB_OUTPUT
-        echo "suffix=-${target}" >> $GITHUB_OUTPUT
+        if [ "${{ inputs.docker_invert_tags }}" = "true" ]
+        then
+          echo "prefix=${target}-" >> $GITHUB_OUTPUT
+        else
+          echo "suffix=-${target}" >> $GITHUB_OUTPUT
+        fi
       fi
 
       if [ -n "${raw_platform}" ]
@@ -460,6 +464,11 @@ on:
         type: string
         required: false
         default: "default"
+      docker_invert_tags:
+        description: "Invert the tags for the Docker images (e.g. `{tag}-{variant}` becomes `{variant}-{tag}`)"
+        type: boolean
+        required: false
+        default: false
       balena_environment:
         description: "balenaCloud environment"
         type: string
@@ -1999,6 +2008,7 @@ jobs:
           flavor: |
             latest=false
             prefix=${{ steps.strings.outputs.prefix }}
+            suffix=${{ steps.strings.outputs.suffix }}
 
       - name: Create manifest
         id: manifest
@@ -2078,6 +2088,7 @@ jobs:
           flavor: |
             latest=${{ steps.version_tag.outputs.semver != '' }}
             prefix=${{ steps.strings.outputs.prefix }},onlatest=true
+            suffix=${{ steps.strings.outputs.suffix }},onlatest=true
 
       - *loginWithGitHubContainerRegistry
       - *loginWithDockerHub
@@ -2086,7 +2097,7 @@ jobs:
       - name: Publish final tags
         uses: akhilerm/tag-push-action@85bf542f43f5f2060ef76262a67ee3607cb6db37 # v2.1.0
         with:
-          src: ${{ matrix.image }}:${{ steps.strings.outputs.prefix }}${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          src: ${{ matrix.image }}:${{ steps.strings.outputs.prefix }}${{ github.event.pull_request.head.sha || github.event.head_commit.id }}${{ steps.strings.outputs.suffix }}
           dst: |
             ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
This is a breaking change for any repositories expecting
image tags in the format `{variant}-{tag}`.

The new default aligns with [docker versioning](https://docs.renovatebot.com/modules/versioning/#docker-versioning).

The old behaviour can be restored with `docker_invert_tags: true`

Change-type: major

open-balena-base PR: https://github.com/balena-io-modules/open-balena-base/pull/271