### PR TITLE
Run protect branch early in the workflow

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2963,14 +2963,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_open
-      - all_tests
-      - npm_publish
-      - docker_publish
-      - balena_publish
-      - website_publish
-      - github_publish
-      - cargo_publish
-      - custom_publish
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2783,14 +2783,6 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_open
-      - all_tests
-      - npm_publish
-      - docker_publish
-      - balena_publish
-      - website_publish
-      - github_publish
-      - cargo_publish
-      - custom_publish
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&


### PR DESCRIPTION
Since we don't rely on Protect Branch as a required check anymore it actually saves time to run it early in the workflow, before jobs like All Tests and All Jobs have queued.

Change-type: minor