### PR TITLE
Disable auto-merge by default

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -323,7 +323,7 @@ on:
         description: Set to false to disable toggling auto-merge on PRs.
         type: boolean
         required: false
-        default: true
+        default: false
 concurrency:
   group: flowzone-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != github.base_ref }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -835,7 +835,7 @@ on:
         description: "Set to false to disable toggling auto-merge on PRs."
         type: boolean
         required: false
-        default: true
+        default: false
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:


### PR DESCRIPTION
This seems to be blocking PR close events due to some kind of race condition.

Change-type: patch