### PR TITLE
Allows each repo to customize extend-ignore rules on python

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2398,7 +2398,7 @@ jobs:
           fi
       - name: Lint with flake8
         run: |
-          poetry run flake8 --max-line-length=120 --benchmark --extend-ignore=E203
+          poetry run flake8 --max-line-length=120 --benchmark
       - name: Lint with pydocstyle
         run: |
           poetry run pydocstyle

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2310,7 +2310,7 @@ jobs:
 
       - name: Lint with flake8
         run: |
-          poetry run flake8 --max-line-length=120 --benchmark --extend-ignore=E203
+          poetry run flake8 --max-line-length=120 --benchmark
 
       - name: Lint with pydocstyle
         run: |


### PR DESCRIPTION
Change-type: patch

Similar to ts-linter in Python we can use flake8 to lint our code. The problem is that we currently pass the extend-ignore by parameter, which blocks each repo of ignoring its own rules (ideally we want to use all flake8 rules but in reality each repo may sometimes want to ignore particular rules, to do so, one can simply add a flake8 rule to the poetry file or a .flake8 file which will be used)