### PR TITLE
Disable SLSA Provenance attestation for now

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1759,6 +1759,7 @@ jobs:
             *.cache-to=type=gha,mode=min,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
             *.cache-from=type=gha,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
           load: true
+          provenance: false
       - name: Run docker compose tests
         if: needs.is_docker.outputs.docker_compose_tests == 'true'
         run: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1989,6 +1989,7 @@ jobs:
             *.cache-to=type=gha,mode=min,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
             *.cache-from=type=gha,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
           load: true
+          provenance: false
 
       # run docker compose tests and print the logs from all services
       - name: Run docker compose tests


### PR DESCRIPTION
Resolves: https://github.com/product-os/flowzone/issues/548
See: https://github.com/docker/bake-action/releases/tag/v3.0.0
See: https://slsa.dev/provenance/v0.2

We can re-enable in the future when support is more common.

Change-type: patch