### PR TITLE
Update balena-versionist to v0.14.13

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -601,7 +601,7 @@ jobs:
       - name: Install versionist
         if: inputs.disable_versioning != true
         run: |
-          npm install -g balena-versionist@0.14.12 versionist@6.9.2
+          npm install -g balena-versionist@0.14.13 versionist@6.10.0
       - name: Generate changelog
         if: inputs.disable_versioning != true
         env:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -971,7 +971,7 @@ jobs:
       - name: Install versionist
         if: inputs.disable_versioning != true
         run: |
-          npm install -g balena-versionist@0.14.12 versionist@6.9.2
+          npm install -g balena-versionist@0.14.13 versionist@6.10.0
 
       - name: Generate changelog
         if: inputs.disable_versioning != true


### PR DESCRIPTION
This also updates versionist to v6.10.0 to use lockfileVersion 2 with npm-shrinkwrap.json files

Change-type: patch
Relates-to: product-os/versionist#243