### PR TITLE
Enable pseudo-tty allocation on test steps

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1338,6 +1338,7 @@ jobs:
       - name: Run build
         run: npm run build --if-present
       - name: Run tests
+        shell: script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"
         run: npm test
       - name: Run pack
         if: needs.is_npm.outputs.npm_private != 'true' && steps.node_versions.outputs.max == matrix.node_version
@@ -2439,6 +2440,7 @@ jobs:
         run: |
           poetry run pydocstyle
       - name: Test with pytest
+        shell: script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"
         run: |
           poetry run pytest tests/
   python_publish:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1701,6 +1701,7 @@ jobs:
         run: npm run build --if-present
 
       - name: Run tests
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"'
         run: npm test
 
       - name: Run pack
@@ -2352,6 +2353,7 @@ jobs:
           poetry run pydocstyle
 
       - name: Test with pytest
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"'
         run: |
           poetry run pytest tests/
 


### PR DESCRIPTION
This wraps the shell in the steps that run `npm run test`
and `poetry run pytest` in a `script -q -e -c` to allow tests that
require pseudo-tty (e.g. for applications that work with terminal colors)
to be able to operate as they would in a local dev environment.

Change-type: minor