### PR TITLE
Write `script` output to /tmp

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1338,7 +1338,7 @@ jobs:
       - name: Run build
         run: npm run build --if-present
       - name: Run tests
-        shell: script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"
+        shell: script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}" /tmp/test-session
         run: npm test
       - name: Run pack
         if: needs.is_npm.outputs.npm_private != 'true' && steps.node_versions.outputs.max == matrix.node_version
@@ -2440,7 +2440,7 @@ jobs:
         run: |
           poetry run pydocstyle
       - name: Test with pytest
-        shell: script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"
+        shell: script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}" /tmp/test-session
         run: |
           poetry run pytest tests/
   python_publish:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1701,7 +1701,7 @@ jobs:
         run: npm run build --if-present
 
       - name: Run tests
-        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"'
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}" /tmp/test-session'
         run: npm test
 
       - name: Run pack
@@ -2353,7 +2353,7 @@ jobs:
           poetry run pydocstyle
 
       - name: Test with pytest
-        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}"'
+        shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail -x {0}" /tmp/test-session'
         run: |
           poetry run pytest tests/
 


### PR DESCRIPTION
The `script` command used for pseudo-tty during testing writes to `typescript` in the current directory by default. This may cause issues with some projects that do not expect new files to be generated. This changes the location of that file to the `/tmp` directory to avoid any issues.

Change-type: patch