### PR TITLE
Revert "Convert artifact compression to zstd"

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -683,12 +683,12 @@ jobs:
           # the tag successfully but not the main branch and breaks future versioning attempts
           git push origin "refs/tags/${{ steps.versionist.outputs.tag }}"
       - name: Compress source
-        run: tar --auto-compress -cvf ${{ runner.temp }}/source.tar.zst .
+        run: tar -acvf ${{ runner.temp }}/source.tgz .
       - name: Upload artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}/source.tar.zst
+          path: ${{ runner.temp }}/source.tgz
           retention-days: 1
   is_npm:
     name: Is npm
@@ -719,7 +719,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Check for package.json
         id: npm
         run: |
@@ -833,7 +833,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - id: docker_images_json
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -945,7 +945,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Check for Python Poetry pyproject.toml
         id: python_poetry
         run: |
@@ -1073,7 +1073,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - id: cargo_targets
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1118,7 +1118,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - id: balena_slugs
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1168,7 +1168,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - id: custom_test_matrix
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1242,7 +1242,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Check for README for building a website
         id: has_readme
         run: |
@@ -1287,7 +1287,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Sort node versions
         id: node_versions
         env:
@@ -1369,13 +1369,13 @@ jobs:
         run: npm run doc
       - name: Compress docs
         if: needs.is_npm.outputs.npm_docs == 'true' && steps.node_versions.outputs.max == matrix.node_version
-        run: tar --auto-compress -cvf ${{ runner.temp }}/docs.tar.zst ./docs
+        run: tar -acvf ${{ runner.temp }}/docs.tgz ./docs
       - name: Upload artifact
         if: needs.is_npm.outputs.npm_docs == 'true' && steps.node_versions.outputs.max == matrix.node_version
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
-          path: ${{ runner.temp }}/docs.tar.zst
+          path: ${{ runner.temp }}/docs.tgz
           retention-days: 90
   npm_publish:
     name: Publish npm
@@ -1549,7 +1549,7 @@ jobs:
           name: docs-${{ github.event.pull_request.head.sha }}-${{ steps.node_versions.outputs.max }}
       - name: Extract docs artifact
         run: |
-          docs="$(ls ${{ runner.temp }}/*.tar.zst | sort -t- -n -k3 | tail -n1)"
+          docs="$(ls ${{ runner.temp }}/*.tgz | sort -t- -n -k3 | tail -n1)"
           tar -xvf "${docs}"
       - name: Publish generated docs to GitHub Pages
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847
@@ -1587,7 +1587,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Get version from tags
         id: version_tag
         run: |
@@ -1818,13 +1818,13 @@ jobs:
         if: join(fromJSON(needs.is_docker.outputs.docker_images)) != ''
         run: |
           docker save ${{ join(fromJSON(steps.test_meta.outputs.json).tags,' ') }} -o ${DOCKER_TAR}
-          zstd -v ${DOCKER_TAR}
+          gzip -v ${DOCKER_TAR}
       - name: Upload artifacts
         if: join(fromJSON(needs.is_docker.outputs.docker_images)) != ''
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: docker-${{ github.event.pull_request.head.sha }}-${{ steps.strings.outputs.target }}-${{ steps.strings.outputs.platform }}
-          path: ${{ env.DOCKER_TAR }}.zst
+          path: ${{ env.DOCKER_TAR }}.gz
           retention-days: 1
   docker_publish:
     name: Publish docker
@@ -1952,9 +1952,9 @@ jobs:
           path: ${{ runner.temp }}
       - name: Decompress artifacts
         run: |
-          for gz in ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ steps.strings.outputs.target }}-*/docker.tar.zst
+          for gz in ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ steps.strings.outputs.target }}-*/docker.tar.gz
           do
-            zstd -vd "${gz}"
+            gzip -vd "${gz}"
           done
       - name: Create local manifest
         run: |
@@ -2069,7 +2069,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2264,7 +2264,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - uses: balena-io/deploy-to-balena-action@e7041b7ca6dd85f47a3eb5ce141178bf77d85920
         id: balena_deploy
         with:
@@ -2339,7 +2339,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - uses: balena-io/deploy-to-balena-action@e7041b7ca6dd85f47a3eb5ce141178bf77d85920
         id: balena_deploy
         with:
@@ -2413,7 +2413,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2486,7 +2486,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Set up Python
         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
         with:
@@ -2543,7 +2543,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Set up Python
         uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b
         with:
@@ -2584,7 +2584,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
           node-version: 18
@@ -2756,7 +2756,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2855,7 +2855,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2923,7 +2923,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -2939,7 +2939,7 @@ jobs:
         run: llvm-strip target/${{ matrix.target }}/release/${{ needs.cargo_test.outputs.package }}
       - name: Compress
         run: |
-          tar --auto-compress -cvf ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.zst -C target/${{ matrix.target }}/release ${{ needs.cargo_test.outputs.package }}
+          tar -czvf ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release ${{ needs.cargo_test.outputs.package }}
       - name: Upload artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
@@ -2971,7 +2971,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crate to ${{ env.CARGO_REGISTRY }}
@@ -3015,7 +3015,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3063,7 +3063,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3107,7 +3107,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3149,7 +3149,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -3189,7 +3189,7 @@ jobs:
       - name: Extract source artifact
         shell: pwsh
         working-directory: .
-        run: tar -xf ${{ runner.temp }}/source.tar.zst
+        run: tar -xf ${{ runner.temp }}/source.tgz
       - uses: ./.github/actions/always
         with:
           json: ${{ toJSON(inputs) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -43,7 +43,7 @@
     # tar: Cannot connect to D: resolve failed
     shell: pwsh
     working-directory: .
-    run: tar -xf ${{ runner.temp }}/source.tar.zst
+    run: tar -xf ${{ runner.temp }}/source.tgz
 
   - &getVersionTag
     name: Get version from tags
@@ -1059,13 +1059,13 @@ jobs:
 
       # https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Compress source
-        run: tar --auto-compress -cvf ${{ runner.temp }}/source.tar.zst .
+        run: tar -acvf ${{ runner.temp }}/source.tgz .
 
       - name: Upload artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}/source.tar.zst
+          path: ${{ runner.temp }}/source.tgz
           retention-days: 1
 
   # check if the repository has a package.json file and which engine versions are supported
@@ -1737,14 +1737,14 @@ jobs:
 
       - name: Compress docs
         if: needs.is_npm.outputs.npm_docs == 'true' && steps.node_versions.outputs.max == matrix.node_version
-        run: tar --auto-compress -cvf ${{ runner.temp }}/docs.tar.zst ./docs
+        run: tar -acvf ${{ runner.temp }}/docs.tgz ./docs
 
       - name: Upload artifact
         if: needs.is_npm.outputs.npm_docs == 'true' && steps.node_versions.outputs.max == matrix.node_version
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
-          path: ${{ runner.temp }}/docs.tar.zst
+          path: ${{ runner.temp }}/docs.tgz
           retention-days: 90
 
   npm_publish:
@@ -1886,7 +1886,7 @@ jobs:
 
       - name: Extract docs artifact
         run: |
-          docs="$(ls ${{ runner.temp }}/*.tar.zst | sort -t- -n -k3 | tail -n1)"
+          docs="$(ls ${{ runner.temp }}/*.tgz | sort -t- -n -k3 | tail -n1)"
           tar -xvf "${docs}"
 
       - name: Publish generated docs to GitHub Pages
@@ -2052,7 +2052,7 @@ jobs:
         if: join(fromJSON(needs.is_docker.outputs.docker_images)) != ''
         run: |
           docker save ${{ join(fromJSON(steps.test_meta.outputs.json).tags,' ') }} -o ${DOCKER_TAR}
-          zstd -v ${DOCKER_TAR}
+          gzip -v ${DOCKER_TAR}
 
       # https://github.com/actions/upload-artifact
       - name: Upload artifacts
@@ -2061,7 +2061,7 @@ jobs:
         with:
           # this docker-{sha}-{target}-{platform} naming scheme is used by docker_publish to find the correct artifact
           name: docker-${{ github.event.pull_request.head.sha }}-${{ steps.strings.outputs.target }}-${{ steps.strings.outputs.platform }}
-          path: ${{ env.DOCKER_TAR }}.zst
+          path: ${{ env.DOCKER_TAR }}.gz
           retention-days: 1
 
   docker_publish:
@@ -2115,9 +2115,9 @@ jobs:
 
       - name: Decompress artifacts
         run: |
-          for gz in ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ steps.strings.outputs.target }}-*/docker.tar.zst
+          for gz in ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ steps.strings.outputs.target }}-*/docker.tar.gz
           do
-            zstd -vd "${gz}"
+            gzip -vd "${gz}"
           done
 
       - name: Create local manifest
@@ -2758,7 +2758,7 @@ jobs:
 
       - name: Compress
         run: |
-          tar --auto-compress -cvf ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.zst -C target/${{ matrix.target }}/release ${{ needs.cargo_test.outputs.package }}
+          tar -czvf ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release ${{ needs.cargo_test.outputs.package }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3


### PR DESCRIPTION
Reverts product-os/flowzone#635

Jenkins Runners don't have zstd installed and aarch64 runners are stuck on old releases, so that they don't pick up the changes made on the jenkins-runners latest release
