### PR TITLE
inject AWS session credentials (OIDC)

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -58,6 +58,16 @@ on:
         description: Optional secret for using with custom jobs
         required: false
     inputs:
+      aws_region:
+        description: AWS region with GitHub OIDC provider IAM configuration
+        type: string
+        required: false
+        default: ${{ vars.AWS_REGION || '' }}
+      aws_iam_role:
+        description: AWS IAM role ARN to assume with GitHub OIDC provider
+        type: string
+        required: false
+        default: ${{ vars.AWS_IAM_ROLE || '' }}
       app_id:
         description: GitHub App id to impersonate
         type: string
@@ -1576,6 +1586,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.is_docker.outputs.docker_test_matrix) }}
+    permissions:
+      id-token: write
     env:
       DOCKER_BUILDKIT: "1"
     steps:
@@ -1758,6 +1770,45 @@ jobs:
           if ! grep -q '^GITHUB_TOKEN=' ${COMPOSE_ENV_FILE}
           then
             echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> ${COMPOSE_ENV_FILE}
+          fi
+      - uses: aws-actions/configure-aws-credentials@v2
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        with:
+          role-to-assume: ${{ inputs.aws_iam_role }}
+          role-session-name: github-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: ${{ inputs.aws_region }}
+      - name: Add AWS ephemeral credentials to compose env file
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+          AWS_REGION: ${{ inputs.aws_region }}
+        run: |
+          if [[ -n "${AWS_REGION}" ]] && [[ -n '${{ inputs.aws_iam_role }}' ]]; then
+              if [[ -n '${{ env.AWS_ACCESS_KEY_ID }}' ]] \
+                && [[ -n '${{ env.AWS_SECRET_ACCESS_KEY }}' ]] \
+                && [[ -n '${{ env.AWS_SESSION_TOKEN }}' ]]; then
+
+                  if ! grep -q '^AWS_REGION=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_REGION=${AWS_REGION}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_DEFAULT_REGION=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_ACCESS_KEY_ID=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_SECRET_ACCESS_KEY=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_SESSION_TOKEN=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" >> ${COMPOSE_ENV_FILE}
+                  fi
+              fi
           fi
       - name: Write docker bake file
         run: |

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [`CUSTOM_JOB_SECRET_2`](#custom_job_secret_2)
     - [`CUSTOM_JOB_SECRET_3`](#custom_job_secret_3)
   - [Inputs](#inputs)
+    - [`aws_region`](#aws_region)
+    - [`aws_iam_role`](#aws_iam_role)
     - [`app_id`](#app_id)
     - [`installation_id`](#installation_id)
     - [`token_scope`](#token_scope)
@@ -445,6 +447,22 @@ Optional secret for use with [Custom](#custom) jobs.
 
 These inputs are all optional and include some opinionated defaults.
 They can also be found at the top of [flowzone.yml](./.github/workflows/flowzone.yml).
+
+#### `aws_region`
+
+AWS region with GitHub OIDC provider IAM configuration.
+
+Type: _string_
+
+Default: `"${{ vars.AWS_REGION || '' }}"`
+
+#### `aws_iam_role`
+
+AWS IAM role ARN to assume with GitHub OIDC provider.
+
+Type: _string_
+
+Default: `"${{ vars.AWS_IAM_ROLE || '' }}"`
 
 #### `app_id`
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -568,6 +568,16 @@ on:
         required: false
 
     inputs:
+      aws_region:
+        description: "AWS region with GitHub OIDC provider IAM configuration"
+        type: string
+        required: false
+        default: "${{ vars.AWS_REGION || '' }}"
+      aws_iam_role:
+        description: "AWS IAM role ARN to assume with GitHub OIDC provider"
+        type: string
+        required: false
+        default: "${{ vars.AWS_IAM_ROLE || '' }}"
       app_id:
         description: "GitHub App id to impersonate"
         type: string
@@ -1919,6 +1929,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.is_docker.outputs.docker_test_matrix) }}
 
+    # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+    permissions:
+     id-token: write
+
     env:
       DOCKER_BUILDKIT: "1"
 
@@ -1984,6 +1998,48 @@ jobs:
           if ! grep -q '^GITHUB_TOKEN=' ${COMPOSE_ENV_FILE}
           then
             echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> ${COMPOSE_ENV_FILE}
+          fi
+
+      # optionally attempt to get AWS login short-lived session credentials over OIDC
+      - uses: aws-actions/configure-aws-credentials@v2
+        <<: *ifInternalPullRequest
+        continue-on-error: true
+        with:
+          role-to-assume: ${{ inputs.aws_iam_role }}
+          role-session-name: github-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Add AWS ephemeral credentials to compose env file
+        <<: *ifInternalPullRequest
+        env:
+          AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+          AWS_REGION: ${{ inputs.aws_region }}
+        run: |
+          if [[ -n "${AWS_REGION}" ]] && [[ -n '${{ inputs.aws_iam_role }}' ]]; then
+              if [[ -n '${{ env.AWS_ACCESS_KEY_ID }}' ]] \
+                && [[ -n '${{ env.AWS_SECRET_ACCESS_KEY }}' ]] \
+                && [[ -n '${{ env.AWS_SESSION_TOKEN }}' ]]; then
+
+                  if ! grep -q '^AWS_REGION=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_REGION=${AWS_REGION}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_DEFAULT_REGION=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_ACCESS_KEY_ID=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_SECRET_ACCESS_KEY=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" >> ${COMPOSE_ENV_FILE}
+                  fi
+
+                  if ! grep -q '^AWS_SESSION_TOKEN=' ${COMPOSE_ENV_FILE}; then
+                    echo "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" >> ${COMPOSE_ENV_FILE}
+                  fi
+              fi
           fi
 
       - name: Write docker bake file


### PR DESCRIPTION
* optionally add AWS auth to .env compose file to enable aws-cli operations in docker compose workflows
* requires IAM configuration (e.g. https://github.com/product-os/environment-production/pull/553)

Tested: https://github.com/product-os/environment-production/actions/runs/5060183471/jobs/9083089191

change-type: patch