### PR TITLE
Create versioned commit objects via GitHub API

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -601,6 +601,15 @@ jobs:
     outputs:
       tag: ${{ steps.versionist.outputs.tag || steps.version_tag.outputs.tag }}
       semver: ${{ steps.versionist.outputs.semver || steps.version_tag.outputs.semver }}
+      sha: ${{ steps.create_commit.outputs.sha || github.sha }}
+    env:
+      GH_DEBUG: "true"
+      GH_PAGER: cat
+      GH_PROMPT_DISABLED: "true"
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PARENT_COMMIT_SHA: ${{ github.sha }}
+      BRANCH_NAME: flowzone/pr/${{ github.event.number }}
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
@@ -636,6 +645,13 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Get version from tags
+        id: version_tag
+        run: |
+          tag="$(git tag --points-at HEAD | tail -n1)"
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
+          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Reject merge commits
         run: |
           if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]
@@ -685,20 +701,13 @@ jobs:
 
           echo "semver=${semver}" >> $GITHUB_OUTPUT
           echo "tag=v${semver}" >> $GITHUB_OUTPUT
-      - name: Create signed commit
-        env:
-          GH_DEBUG: "true"
-          GH_PAGER: cat
-          GH_PROMPT_DISABLED: "true"
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          PARENT_COMMIT_SHA: ${{ github.sha }}
-          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
-          BRANCH_NAME: flowzone/pr/${{ github.event.number }}
+      - name: Create tree with changes
+        if: inputs.disable_versioning != true
+        id: create_tree
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         run: |
-          base_tree_sha=$(git show -s --format=%T $PARENT_COMMIT_SHA) # Get the SHA of the tree the parent commit points to
-
           # Temporary array to hold our new tree objects
           declare -a tree_array
 
@@ -727,6 +736,9 @@ jobs:
             tree_array+=("{\"path\":\"$file\",\"mode\":\"100644\",\"type\":\"blob\",\"sha\":\"$blob_sha\"}")
           done
 
+          # Get the SHA of the tree the parent commit points to
+          base_tree_sha=$(git show -s --format=%T $PARENT_COMMIT_SHA)
+
           # Create JSON array for tree creation
           tree_json=$(printf ",%s" "${tree_array[@]}")
           tree_json=${tree_json:1}
@@ -741,27 +753,51 @@ jobs:
             -d @-)
 
           echo "$response" | jq .
-          tree_sha=$(echo $response | jq -r .sha)
+          echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
+          echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
+      - name: Create versioned commit
+        if: inputs.disable_versioning != true
+        id: create_commit
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
+        run: |
+          response=$(gh api -X POST /repos/$GH_REPO/git/commits \
+            -F "message=$COMMIT_MESSAGE" \
+            -F "tree=${{ steps.create_tree.outputs.sha }}" \
+            -F "parents[]=$PARENT_COMMIT_SHA")
 
-          echo "Creating commit..."
-          response=$(curl -s -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/$GH_REPO/git/commits" \
-            -d "{\"message\": \"$COMMIT_MESSAGE\",\"tree\": \"$tree_sha\",\"parents\": [\"$PARENT_COMMIT_SHA\"]}")
-
-          echo "$response" | jq .
-          new_commit_sha=$(echo $response | jq -r .sha)
-
+          echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
+          echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
+      - name: Create versioned branch
+        if: inputs.disable_versioning != true && needs.is_pr_open.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
           # Try to delete the branch (ignore any error if it does not exist)
           gh api -X DELETE /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME || true
 
-          echo "Creating branch..."
-          response=$(gh api -X POST /repos/$GH_REPO/git/refs \
+          gh api -X POST /repos/$GH_REPO/git/refs \
             -F ref=refs/heads/$BRANCH_NAME \
-            -F sha=$new_commit_sha)
-
-          echo "$response" | jq .
+            -F sha='${{ steps.create_commit.outputs.sha }}'
+      - name: Update base branch
+        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
+          gh api -X PATCH /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME \
+            -F sha='${{ steps.create_commit.outputs.sha }}' \
+            -F force='true'
+      - name: Push versioned tag
+        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
+          gh api -X POST repos/$GH_REPO/git/tags \
+            -F tag='${{ steps.versionist.outputs.tag }}' \
+            -F message='${{ steps.versionist.outputs.tag }}' \
+            -F object='${{ steps.create_commit.outputs.sha }}' \
+            -F type='commit'
   is_npm:
     name: Is npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -746,6 +746,8 @@ jobs:
           tree_json="{\"tree\": $tree_json, \"base_tree\": \"$base_tree_sha\"}"
 
           echo "Creating tree..."
+          echo "$tree_json" | jq .
+
           response=$(echo $tree_json | curl -s -X POST \
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
@@ -1403,6 +1405,7 @@ jobs:
     needs:
       - is_npm
       - is_pr_open
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -1705,6 +1708,7 @@ jobs:
     needs:
       - is_pr_open
       - is_docker
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_docker.result == 'success' &&
@@ -2178,6 +2182,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_docker
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_docker.result == 'success' &&
@@ -2366,6 +2371,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
@@ -2439,6 +2445,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_balena
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
@@ -2511,6 +2518,7 @@ jobs:
     needs:
       - is_pr_open
       - is_python
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2578,6 +2586,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.python_test.result == 'success' &&
@@ -2633,6 +2642,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_python
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -2678,6 +2688,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_website.result == 'success'
@@ -2923,6 +2934,7 @@ jobs:
     needs:
       - is_pr_open
       - is_cargo
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2988,6 +3000,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.cargo_test.result == 'success' &&
@@ -3038,6 +3051,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_cargo
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -3071,6 +3085,7 @@ jobs:
     needs:
       - is_pr_open
       - is_custom
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -3117,6 +3132,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -3159,6 +3175,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_custom
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -3204,6 +3221,7 @@ jobs:
     needs:
       - is_pr_closed
       - is_custom
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_closed.result == 'success' &&
@@ -3243,6 +3261,7 @@ jobs:
       - custom_finalize
       - custom_clean
       - is_custom
+      - versioned_source
     if: |
       always() &&
       needs.is_custom.outputs.custom_always == 'true'
@@ -3278,6 +3297,7 @@ jobs:
     needs:
       - is_pr_open
       - is_cloudformation
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -702,20 +702,83 @@ jobs:
 
           echo "semver=${semver}" >> $GITHUB_OUTPUT
           echo "tag=v${semver}" >> $GITHUB_OUTPUT
-      - name: Create versioned commit
-        if: inputs.disable_versioning != true
+      - name: Create signed commit
         env:
-          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          TAG: ${{ steps.versionist.outputs.tag }}
+          GH_DEBUG: "true"
+          GH_PAGER: cat
+          GH_PROMPT_DISABLED: "true"
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          PARENT_COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
+          BRANCH_NAME: flowzone/pr/${{ github.event.number }}
+        shell: bash
         run: |
-          git add --all
-          git commit -m "${TAG}"
-          git tag -a "${TAG}" -m "${TAG}" -f
-          git show -1
-          git log -n 2
+          base_tree_sha=$(git show -s --format=%T $PARENT_COMMIT_SHA) # Get the SHA of the tree the parent commit points to
+
+          # Temporary array to hold our new tree objects
+          declare -a tree_array
+
+          # Use git status to check for modified files
+          modified_files=$(git diff --name-only)
+
+          # Extract changes
+          for file in $modified_files; do
+            echo "Processing file $file..."
+
+            # Create blob
+            content=$(cat "$file" | base64)
+            echo "{\"content\": \"$content\", \"encoding\": \"base64\"}" > blob.json
+
+            echo "Creating blob..."
+            response=$(curl -s -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/$GH_REPO/git/blobs" \
+              -d @blob.json)
+
+            echo "$response" | jq .
+            blob_sha=$(echo $response | jq -r .sha)
+
+            # Add blob to our tree
+            tree_array+=("{\"path\":\"$file\",\"mode\":\"100644\",\"type\":\"blob\",\"sha\":\"$blob_sha\"}")
+          done
+
+          # Create JSON array for tree creation
+          tree_json=$(printf ",%s" "${tree_array[@]}")
+          tree_json=${tree_json:1}
+          tree_json="[$tree_json]"
+          tree_json="{\"tree\": $tree_json, \"base_tree\": \"$base_tree_sha\"}"
+
+          echo "Creating tree..."
+          response=$(echo $tree_json | curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$GH_REPO/git/trees" \
+            -d @-)
+
+          echo "$response" | jq .
+          tree_sha=$(echo $response | jq -r .sha)
+
+          echo "Creating commit..."
+          response=$(curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$GH_REPO/git/commits" \
+            -d "{\"message\": \"$COMMIT_MESSAGE\",\"tree\": \"$tree_sha\",\"parents\": [\"$PARENT_COMMIT_SHA\"]}")
+
+          echo "$response" | jq .
+          new_commit_sha=$(echo $response | jq -r .sha)
+
+          # Try to delete the branch (ignore any error if it does not exist)
+          gh api -X DELETE /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME || true
+
+          echo "Creating branch..."
+          response=$(gh api -X POST /repos/$GH_REPO/git/refs \
+            -F ref=refs/heads/$BRANCH_NAME \
+            -F sha=$new_commit_sha)
+
+          echo "$response" | jq .
       - name: Get version from tags
         id: version_tag
         run: |

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -701,7 +701,7 @@ jobs:
 
           echo "semver=${semver}" >> $GITHUB_OUTPUT
           echo "tag=v${semver}" >> $GITHUB_OUTPUT
-      - name: Create tree with changes
+      - name: Create blobs and tree objects
         if: inputs.disable_versioning != true
         id: create_tree
         shell: bash
@@ -755,39 +755,55 @@ jobs:
           echo "$response" | jq .
           echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
           echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
-      - name: Create versioned commit
+      - name: Create commit object
         if: inputs.disable_versioning != true
         id: create_commit
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
+          MESSAGE: ${{ steps.versionist.outputs.tag }}
         run: |
           response=$(gh api -X POST /repos/$GH_REPO/git/commits \
-            -F "message=$COMMIT_MESSAGE" \
+            -F "message=$MESSAGE" \
             -F "tree=${{ steps.create_tree.outputs.sha }}" \
             -F "parents[]=$PARENT_COMMIT_SHA")
 
           echo "$response" | jq .
           echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
           echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
-      - name: Push commit to base
-        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+      - name: Create tag object
+        if: inputs.disable_versioning != true
+        id: create_tag
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          TAG: ${{ steps.versionist.outputs.tag }}
+          MESSAGE: ${{ steps.versionist.outputs.tag }}
+        run: |
+          response=$(gh api -X POST repos/$GH_REPO/git/tags \
+            -F "tag=${TAG}" \
+            -F "message=${MESSAGE}" \
+            -F "object=${{ steps.create_commit.outputs.sha }}" \
+            -F "type=commit")
+
+          echo "$response" | jq .
+          echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
+          echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
+      - name: Create commit reference
+        if: needs.is_pr_merged.result == 'success' && steps.create_commit.outputs.sha != ''
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         run: |
           gh api -X PATCH /repos/$GH_REPO/git/refs/heads/${{ github.base_ref }} \
             -F sha='${{ steps.create_commit.outputs.sha }}' \
             -F force='true'
-      - name: Push tag to base
-        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+      - name: Create tag reference
+        if: needs.is_pr_merged.result == 'success' && steps.create_tag.outputs.sha != ''
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          TAG: ${{ steps.versionist.outputs.tag }}
         run: |
-          gh api -X POST repos/$GH_REPO/git/tags \
-            -F tag='${{ steps.versionist.outputs.tag }}' \
-            -F message='${{ steps.versionist.outputs.tag }}' \
-            -F object='${{ steps.create_commit.outputs.sha }}' \
-            -F type='commit'
+          gh api -X POST /repos/$GH_REPO/git/refs \
+            -f "ref=refs/tags/${TAG}" \
+            -f "sha=${{ steps.create_tag.outputs.sha }}"
   is_npm:
     name: Is npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -609,7 +609,6 @@ jobs:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PARENT_COMMIT_SHA: ${{ github.sha }}
-      BRANCH_NAME: flowzone/pr/${{ github.event.number }}
     steps:
       - name: Check for GitHub App private key
         id: gh_app_private_key
@@ -630,28 +629,22 @@ jobs:
           installation_id: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout merge branch
-        if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+      - name: Checkout merge ref
+        if: needs.is_pr_open.result == 'success'
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.number }}/merge
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Checkout sha
-        if: github.event_name != 'pull_request_target' || github.event.action == 'closed'
+      - name: Checkout event sha
+        if: needs.is_pr_open.result != 'success'
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
+          ref: ${{ github.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Get version from tags
-        id: version_tag
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Reject merge commits
         run: |
           if [ "$(git cat-file -p ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | grep '^parent ' | wc -l)" -gt 1 ]
@@ -659,6 +652,13 @@ jobs:
             echo "::error::Latest commit appears to be a merge, which is currently unsupported. Try a rebase instead."
             exit 1
           fi
+      - name: Get current tag
+        id: version_tag
+        run: |
+          tag="$(git tag --points-at HEAD | tail -n1)"
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
+          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Install versionist
         if: inputs.disable_versioning != true
         run: |
@@ -767,28 +767,18 @@ jobs:
             -F "tree=${{ steps.create_tree.outputs.sha }}" \
             -F "parents[]=$PARENT_COMMIT_SHA")
 
+          echo "$response" | jq .
           echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
           echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
-      - name: Create versioned branch
-        if: inputs.disable_versioning != true && needs.is_pr_open.result == 'success'
-        env:
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-        run: |
-          # Try to delete the branch (ignore any error if it does not exist)
-          gh api -X DELETE /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME || true
-
-          gh api -X POST /repos/$GH_REPO/git/refs \
-            -F ref=refs/heads/$BRANCH_NAME \
-            -F sha='${{ steps.create_commit.outputs.sha }}'
-      - name: Update base branch
+      - name: Push commit to base
         if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         run: |
-          gh api -X PATCH /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME \
+          gh api -X PATCH /repos/$GH_REPO/git/refs/heads/${{ github.base_ref }} \
             -F sha='${{ steps.create_commit.outputs.sha }}' \
             -F force='true'
-      - name: Push versioned tag
+      - name: Push tag to base
         if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -819,12 +809,12 @@ jobs:
       node_versions: ${{ steps.node_versions.outputs.json }}
       npm_access: ${{ steps.access.outputs.access }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Check for package.json
         id: npm
@@ -931,12 +921,12 @@ jobs:
       docker_bake_json: ${{ steps.docker_bake.outputs.json }}
       docker_test_matrix: ${{ steps.docker_test.outputs.build }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: docker_images_json
         name: Build JSON array from comma-separated list
@@ -1041,12 +1031,12 @@ jobs:
       python_versions: ${{ steps.python_versions.outputs.json }}
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Check for Python Poetry pyproject.toml
         id: python_poetry
@@ -1167,12 +1157,12 @@ jobs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: cargo_targets
         name: Build JSON array from comma-separated list
@@ -1210,12 +1200,12 @@ jobs:
       balena_slugs: ${{ steps.balena_slugs.outputs.build }}
       balena_yml: ${{ steps.balena_yml.outputs.enabled }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: balena_slugs
         name: Build JSON array from comma-separated list
@@ -1258,12 +1248,12 @@ jobs:
       custom_publish_matrix: ${{ steps.custom_publish_matrix.outputs.build }}
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.build }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: custom_test_matrix
         name: Build JSON array from comma-separated list
@@ -1332,12 +1322,12 @@ jobs:
     outputs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Check for README for building a website
         id: has_readme
@@ -1368,12 +1358,12 @@ jobs:
       cloudformation: ${{ steps.validate_json.outputs.enabled }}
       stacks: ${{ steps.cloudformation_stacks.outputs.deploy }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Validate CloudFormation input
         id: validate_json
@@ -1416,12 +1406,12 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Sort node versions
         id: node_versions
@@ -1714,20 +1704,13 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Get version from tags
-        id: version_tag
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Check for GitHub App private key
         id: gh_app_private_key
         shell: bash
@@ -1816,7 +1799,7 @@ jobs:
             localhost:5000/sut
             ${{ needs.is_docker.outputs.docker_images_crlf }}
           labels: |
-            org.opencontainers.image.version=${{ steps.version_tag.outputs.semver }}
+            org.opencontainers.image.version=${{ needs.versioned_source.outputs.semver }}
             org.opencontainers.image.ref.name=${{ matrix.target }}
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
@@ -2058,7 +2041,7 @@ jobs:
           images: |
             ${{ matrix.image }}
           labels: |
-            org.opencontainers.image.version=${{ steps.version_tag.outputs.semver }}
+            org.opencontainers.image.version=${{ needs.versioned_source.outputs.semver }}
             org.opencontainers.image.ref.name=${{ matrix.target }}
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
@@ -2194,20 +2177,13 @@ jobs:
         image: ${{ fromJSON(needs.is_docker.outputs.docker_images) }}
         target: ${{ fromJSON(needs.is_docker.outputs.bake_targets) }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Get version from tags
-        id: version_tag
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Sanitize docker strings
         id: strings
         env:
@@ -2275,14 +2251,14 @@ jobs:
           images: |
             ${{ matrix.image }}
           labels: |
-            org.opencontainers.image.version=${{ steps.version_tag.outputs.semver }}
+            org.opencontainers.image.version=${{ needs.versioned_source.outputs.semver }}
             org.opencontainers.image.ref.name=${{ matrix.target }}
           tags: |
             type=raw,value=${{ github.base_ref || github.ref_name }}
-            type=raw,value=${{ steps.version_tag.outputs.tag }}
-            type=raw,value=${{ steps.version_tag.outputs.semver }}
+            type=raw,value=${{ needs.versioned_source.outputs.tag }}
+            type=raw,value=${{ needs.versioned_source.outputs.semver }}
           flavor: |
-            latest=${{ steps.version_tag.outputs.semver != '' }}
+            latest=${{ needs.versioned_source.outputs.semver != '' }}
             prefix=${{ steps.strings.outputs.prefix }},onlatest=true
             suffix=${{ steps.strings.outputs.suffix }},onlatest=true
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c
@@ -2387,12 +2363,12 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: balena-io/deploy-to-balena-action@e7041b7ca6dd85f47a3eb5ce141178bf77d85920
         id: balena_deploy
@@ -2460,12 +2436,12 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: balena-io/deploy-to-balena-action@e7041b7ca6dd85f47a3eb5ce141178bf77d85920
         id: balena_deploy
@@ -2532,20 +2508,13 @@ jobs:
       matrix:
         python-version: ${{ fromJSON(needs.is_python.outputs.python_versions) }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Get version from tags
-        id: version_tag
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
         with:
@@ -2603,12 +2572,12 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
@@ -2658,12 +2627,12 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
@@ -2697,12 +2666,12 @@ jobs:
       !failure() && !cancelled() &&
       needs.is_website.result == 'success'
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
@@ -2867,20 +2836,13 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Get version from tags
-        id: version_tag
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Check for GitHub App private key
         id: gh_app_private_key
         shell: bash
@@ -2923,13 +2885,13 @@ jobs:
           if gh release view '${{ github.event.pull_request.head.ref }}'; then
             gh release edit '${{ github.event.pull_request.head.ref }}' \
               --notes-file '${{ steps.release_notes.outputs.file }}' \
-              --title '${{ steps.version_tag.outputs.tag }}' \
-              --tag '${{ steps.version_tag.outputs.tag }}' \
+              --title '${{ needs.versioned_source.outputs.tag }}' \
+              --tag '${{ needs.versioned_source.outputs.tag }}' \
               --prerelease='${{ inputs.github_prerelease }}' \
               --draft=false
 
             if [[ ${{ inputs.github_prerelease }} =~ false ]]; then
-                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/${{ steps.version_tag.outputs.tag }}" \
+                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/${{ needs.versioned_source.outputs.tag }}" \
                   -H 'Accept: application/vnd.github+json' | jq -r .id)"
                 gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
                   -H 'Accept: application/vnd.github+json' \
@@ -2964,20 +2926,13 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Get version from tags
-        id: version_tag
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -2996,7 +2951,7 @@ jobs:
         id: meta
         run: |
           package="$(grep '^name = \"' Cargo.toml | awk -F[\"\"] '{print $2}')"
-          version="${{ steps.version_tag.outputs.semver }}"
+          version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo '${{ github.event.pull_request.head.ref }}' | sed 's/[^[:alnum:]]/-/g')"
           sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
           version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
@@ -3030,12 +2985,12 @@ jobs:
       matrix:
         target: ${{ fromJSON(needs.is_cargo.outputs.cargo_targets) }}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
@@ -3076,12 +3031,12 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@stable
@@ -3118,12 +3073,12 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set the matrix value env var
         run: |
@@ -3164,12 +3119,12 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set the matrix value env var
         run: |
@@ -3206,12 +3161,12 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set the matrix value env var
         run: |
@@ -3246,12 +3201,12 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: ./.github/actions/clean
         with:
@@ -3284,12 +3239,12 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: ./.github/actions/always
         with:
@@ -3316,12 +3271,12 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Checkout versioned source
+      - name: Checkout versioned sha
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: flowzone/pr/${{ github.event.number }}
+          ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: aws-actions/configure-aws-credentials@5727f247b64f324ec403ac56ae05e220fd02b65f
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -623,7 +623,6 @@ jobs:
           permissions: ${{ inputs.token_scope }}
       - name: Checkout merge branch
         if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
-        id: checkout_merge
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
           fetch-depth: 0
@@ -763,30 +762,6 @@ jobs:
             -F sha=$new_commit_sha)
 
           echo "$response" | jq .
-      - name: Get version from tags
-        id: version_tag
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
-      - name: Push versioned commit
-        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
-        continue-on-error: true
-        run: |
-          git push origin HEAD:refs/heads/${{ github.base_ref }}
-          # We push the tag separately so that it is only pushed if the commit push succeed, this avoids
-          # issues if something else updates the main branch whilst we're running and causes us to push
-          # the tag successfully but not the main branch and breaks future versioning attempts
-          git push origin "refs/tags/${{ steps.versionist.outputs.tag }}"
-      - name: Compress source
-        run: tar --auto-compress -cvf ${{ runner.temp }}/source.tar.zst .
-      - name: Upload artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-        with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}/source.tar.zst
-          retention-days: 1
   is_npm:
     name: Is npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -808,17 +783,13 @@ jobs:
       node_versions: ${{ steps.node_versions.outputs.json }}
       npm_access: ${{ steps.access.outputs.access }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Check for package.json
         id: npm
         run: |
@@ -924,17 +895,13 @@ jobs:
       docker_bake_json: ${{ steps.docker_bake.outputs.json }}
       docker_test_matrix: ${{ steps.docker_test.outputs.build }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: docker_images_json
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1038,17 +1005,13 @@ jobs:
       python_versions: ${{ steps.python_versions.outputs.json }}
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Check for Python Poetry pyproject.toml
         id: python_poetry
         run: |
@@ -1168,17 +1131,13 @@ jobs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: cargo_targets
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1215,17 +1174,13 @@ jobs:
       balena_slugs: ${{ steps.balena_slugs.outputs.build }}
       balena_yml: ${{ steps.balena_yml.outputs.enabled }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: balena_slugs
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1267,17 +1222,13 @@ jobs:
       custom_publish_matrix: ${{ steps.custom_publish_matrix.outputs.build }}
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.build }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - id: custom_test_matrix
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1345,17 +1296,13 @@ jobs:
     outputs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Check for README for building a website
         id: has_readme
         run: |
@@ -1385,17 +1332,13 @@ jobs:
       cloudformation: ${{ steps.validate_json.outputs.enabled }}
       stacks: ${{ steps.cloudformation_stacks.outputs.deploy }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Validate CloudFormation input
         id: validate_json
         run: |
@@ -1437,17 +1380,13 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Sort node versions
         id: node_versions
         env:
@@ -1739,17 +1678,13 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2223,17 +2158,13 @@ jobs:
         image: ${{ fromJSON(needs.is_docker.outputs.docker_images) }}
         target: ${{ fromJSON(needs.is_docker.outputs.bake_targets) }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2420,17 +2351,13 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: balena-io/deploy-to-balena-action@e7041b7ca6dd85f47a3eb5ce141178bf77d85920
         id: balena_deploy
         with:
@@ -2497,17 +2424,13 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: balena-io/deploy-to-balena-action@e7041b7ca6dd85f47a3eb5ce141178bf77d85920
         id: balena_deploy
         with:
@@ -2573,17 +2496,13 @@ jobs:
       matrix:
         python-version: ${{ fromJSON(needs.is_python.outputs.python_versions) }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Get version from tags
         id: version_tag
         run: |
@@ -2648,17 +2567,13 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
         with:
@@ -2707,17 +2622,13 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
         with:
@@ -2750,17 +2661,13 @@ jobs:
       !failure() && !cancelled() &&
       needs.is_website.result == 'success'
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
           node-version: 18
@@ -2924,17 +2831,13 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Get version from tags
         id: version_tag
         run: |
@@ -3025,17 +2928,13 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Get version from tags
         id: version_tag
         run: |
@@ -3095,17 +2994,13 @@ jobs:
       matrix:
         target: ${{ fromJSON(needs.is_cargo.outputs.cargo_targets) }}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -3145,17 +3040,13 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crate to ${{ env.CARGO_REGISTRY }}
@@ -3191,17 +3082,13 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3241,17 +3128,13 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3287,17 +3170,13 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3331,17 +3210,13 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -3373,17 +3248,13 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: ./.github/actions/always
         with:
           json: ${{ toJSON(inputs) }}
@@ -3409,17 +3280,13 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Download source artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - name: Checkout versioned source
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}
-      - name: Extract source artifact
-        shell: pwsh
-        working-directory: .
-        run: |
-          tar --version
-          tar -xf ${{ runner.temp }}/source.tar.zst
+          fetch-depth: 0
+          submodules: recursive
+          ref: flowzone/pr/${{ github.event.number }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: aws-actions/configure-aws-credentials@5727f247b64f324ec403ac56ae05e220fd02b65f
         if: github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -9,12 +9,6 @@ on:
       FLOWZONE_TOKEN:
         description: .. or Personal Access Token (PAT) with admin/owner permissions in the org.
         required: false
-      GPG_PRIVATE_KEY:
-        description: GPG private key exported with `gpg --armor --export-secret-keys ...` to sign commits
-        required: false
-      GPG_PASSPHRASE:
-        description: Passphrase to decrypt GPG private key
-        required: false
       NPM_TOKEN:
         description: The npm auth token to use for publishing
         required: false
@@ -650,16 +644,6 @@ jobs:
             echo "::error::Latest commit appears to be a merge, which is currently unsupported. Try a rebase instead."
             exit 1
           fi
-      - name: Import GPG key for signing commits
-        if: inputs.disable_versioning != true
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
       - name: Install versionist
         if: inputs.disable_versioning != true
         run: |

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
     - [Secrets](#secrets)
       - [`GH_APP_PRIVATE_KEY`](#gh_app_private_key)
       - [`FLOWZONE_TOKEN`](#flowzone_token)
-      - [`GPG_PRIVATE_KEY`](#gpg_private_key)
-      - [`GPG_PASSPHRASE`](#gpg_passphrase)
       - [`NPM_TOKEN`](#npm_token)
       - [`DOCKERHUB_USER`](#dockerhub_user)
       - [`DOCKERHUB_TOKEN`](#dockerhub_token)
@@ -92,8 +90,6 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
       - [`docusaurus_website`](#docusaurus_website)
       - [`toggle_auto_merge`](#toggle_auto_merge)
   - [Testing](#testing)
-  - [Maintenance](#maintenance)
-    - [Generate GPG keys](#generate-gpg-keys)
   - [Help](#help)
   - [Contributing](#contributing)
 
@@ -169,8 +165,6 @@ jobs:
       )
     secrets:
       FLOWZONE_TOKEN: ${{ secrets.FLOWZONE_TOKEN }}
-      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -371,20 +365,6 @@ Not required, but preferred.
 #### `FLOWZONE_TOKEN`
 
 Personal access token (PAT) for the GitHub service account with admin/owner permissions.
-
-Required if `GH_APP_PRIVATE_KEY` is not used.
-
-#### `GPG_PRIVATE_KEY`
-
-GPG private key exported with `gpg --armor --export-secret-keys ...` to sign commits.
-
-Required for [versioned](#versioning) projects.
-
-#### `GPG_PASSPHRASE`
-
-Passphrase to decrypt GPG private key.
-
-Required for [versioned](#versioning) projects.
 
 #### `NPM_TOKEN`
 
@@ -882,32 +862,6 @@ Default: true
 There is a dispatch workflow to test development branches of Flowzone with a range of repositories to ensure breaking changes aren't introduced.
 
 See [docs/workflow-dispatch.md#e2e](docs/workflow-dispatch.md#e2e) for more information.
-
-## Maintenance
-
-### Generate GPG keys
-
-[Managing commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)
-
-1. generate new GPG key signing ensuring the name matches an existing GitHub user/identity
-
-   ```bash
-   gpg --full-generate-key
-   ```
-
-2. get the key id
-
-   ```bash
-   gpg --list-secret-keys --keyid-format=long
-   ```
-
-3. export the key to be stored in `GPG_PRIVATE_KEY` GitHub organisation secret
-
-   ```bash
-   gpg --armor --export-secret-keys {{secret_key_id}}
-   ```
-
-4. set `GPG_PASSPHRASE` and `GPG_PRIVATE_KEY` GitHub organisation secrets
 
 ## Help
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -148,6 +148,15 @@
       ref: "flowzone/pr/${{ github.event.number }}"
       token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
+  - &checkoutTaggedSource
+    name: Checkout tagged source
+    uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+    with:
+      fetch-depth: 0
+      submodules: "recursive"
+      ref: "${{ github.ref }}" # TODO: does this work for all event types?
+      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
   - &loginWithDockerHub
     name: Login to Docker Hub
     continue-on-error: true
@@ -1010,12 +1019,19 @@ jobs:
     outputs:
       tag: ${{ steps.versionist.outputs.tag || steps.version_tag.outputs.tag }}
       semver: ${{ steps.versionist.outputs.semver || steps.version_tag.outputs.semver }}
+      sha: ${{ steps.create_commit.outputs.sha || github.sha }}
+
+    env:
+      <<: *gitHubCliEnvironment
+      PARENT_COMMIT_SHA: ${{ github.sha }} # TODO: does this work for other events?
+      BRANCH_NAME: flowzone/pr/${{ github.event.number }}
 
     steps:
       - *checkGitHubAppPrivateKey
       - *getGitHubAppToken
       - *checkoutMergeBranch
       - *checkoutSha
+      - *getVersionTag
 
       # fail on merge commits (ones with more than one parent)
       - name: Reject merge commits
@@ -1074,20 +1090,15 @@ jobs:
           echo "semver=${semver}" >> $GITHUB_OUTPUT
           echo "tag=v${semver}" >> $GITHUB_OUTPUT
 
-      # create a commit blob via the GH API so it can be automatically verified as an app
       # https://github.com/orgs/community/discussions/50055
       # https://www.levibotelho.com/development/commit-a-file-with-the-github-api/
-      - name: Create signed commit
-        env:
-          <<: *gitHubCliEnvironment
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          PARENT_COMMIT_SHA: ${{ github.sha }} # TODO: does this work for other events?
-          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
-          BRANCH_NAME: flowzone/pr/${{ github.event.number }}
+      - name: Create tree with changes
+        if: inputs.disable_versioning != true
+        id: create_tree
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         run: |
-          base_tree_sha=$(git show -s --format=%T $PARENT_COMMIT_SHA) # Get the SHA of the tree the parent commit points to
-
           # Temporary array to hold our new tree objects
           declare -a tree_array
 
@@ -1116,6 +1127,9 @@ jobs:
             tree_array+=("{\"path\":\"$file\",\"mode\":\"100644\",\"type\":\"blob\",\"sha\":\"$blob_sha\"}")
           done
 
+          # Get the SHA of the tree the parent commit points to
+          base_tree_sha=$(git show -s --format=%T $PARENT_COMMIT_SHA)
+
           # Create JSON array for tree creation
           tree_json=$(printf ",%s" "${tree_array[@]}")
           tree_json=${tree_json:1}
@@ -1128,29 +1142,57 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/$GH_REPO/git/trees" \
             -d @-)
-
+          
           echo "$response" | jq .
-          tree_sha=$(echo $response | jq -r .sha)
+          echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
+          echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
 
-          echo "Creating commit..."
-          response=$(curl -s -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/$GH_REPO/git/commits" \
-            -d "{\"message\": \"$COMMIT_MESSAGE\",\"tree\": \"$tree_sha\",\"parents\": [\"$PARENT_COMMIT_SHA\"]}")
+      - name: Create versioned commit
+        if: inputs.disable_versioning != true
+        id: create_commit
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
+        run: |
+          response=$(gh api -X POST /repos/$GH_REPO/git/commits \
+            -F "message=$COMMIT_MESSAGE" \
+            -F "tree=${{ steps.create_tree.outputs.sha }}" \
+            -F "parents[]=$PARENT_COMMIT_SHA")
 
-          echo "$response" | jq .
-          new_commit_sha=$(echo $response | jq -r .sha)
+          echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
+          echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
 
+      - name: Create versioned branch
+        if: inputs.disable_versioning != true && needs.is_pr_open.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
           # Try to delete the branch (ignore any error if it does not exist)
           gh api -X DELETE /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME || true
 
-          echo "Creating branch..."
-          response=$(gh api -X POST /repos/$GH_REPO/git/refs \
+          gh api -X POST /repos/$GH_REPO/git/refs \
             -F ref=refs/heads/$BRANCH_NAME \
-            -F sha=$new_commit_sha)
+            -F sha='${{ steps.create_commit.outputs.sha }}'
 
-          echo "$response" | jq .
+      - name: Update base branch
+        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
+          gh api -X PATCH /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME \
+            -F sha='${{ steps.create_commit.outputs.sha }}' \
+            -F force='true'
+      
+      - name: Push versioned tag
+        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        run: |
+          gh api -X POST repos/$GH_REPO/git/tags \
+            -F tag='${{ steps.versionist.outputs.tag }}' \
+            -F message='${{ steps.versionist.outputs.tag }}' \
+            -F object='${{ steps.create_commit.outputs.sha }}' \
+            -F type='commit'
 
   # check if the repository has a package.json file and which engine versions are supported
   is_npm:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1099,21 +1099,83 @@ jobs:
           echo "semver=${semver}" >> $GITHUB_OUTPUT
           echo "tag=v${semver}" >> $GITHUB_OUTPUT
 
-      # create a versioned commit
-      - name: Create versioned commit
-        if: inputs.disable_versioning != true
+      # create a commit blob via the GH API so it can be automatically verified as an app
+      # https://github.com/orgs/community/discussions/50055
+      # https://www.levibotelho.com/development/commit-a-file-with-the-github-api/
+      - name: Create signed commit
         env:
-          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
-          TAG: ${{ steps.versionist.outputs.tag }}
+          <<: *gitHubCliEnvironment
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          PARENT_COMMIT_SHA: ${{ github.sha }} # TODO: does this work for other events?
+          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
+          BRANCH_NAME: flowzone/pr/${{ github.event.number }}
+        shell: bash
         run: |
-          git add --all
-          git commit -m "${TAG}"
-          git tag -a "${TAG}" -m "${TAG}" -f
-          git show -1
-          git log -n 2
+          base_tree_sha=$(git show -s --format=%T $PARENT_COMMIT_SHA) # Get the SHA of the tree the parent commit points to
+
+          # Temporary array to hold our new tree objects
+          declare -a tree_array
+
+          # Use git status to check for modified files
+          modified_files=$(git diff --name-only)
+
+          # Extract changes
+          for file in $modified_files; do
+            echo "Processing file $file..."
+
+            # Create blob
+            content=$(cat "$file" | base64)
+            echo "{\"content\": \"$content\", \"encoding\": \"base64\"}" > blob.json
+
+            echo "Creating blob..."
+            response=$(curl -s -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/$GH_REPO/git/blobs" \
+              -d @blob.json)
+
+            echo "$response" | jq .
+            blob_sha=$(echo $response | jq -r .sha)
+
+            # Add blob to our tree
+            tree_array+=("{\"path\":\"$file\",\"mode\":\"100644\",\"type\":\"blob\",\"sha\":\"$blob_sha\"}")
+          done
+
+          # Create JSON array for tree creation
+          tree_json=$(printf ",%s" "${tree_array[@]}")
+          tree_json=${tree_json:1}
+          tree_json="[$tree_json]"
+          tree_json="{\"tree\": $tree_json, \"base_tree\": \"$base_tree_sha\"}"
+
+          echo "Creating tree..."
+          response=$(echo $tree_json | curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$GH_REPO/git/trees" \
+            -d @-)
+
+          echo "$response" | jq .
+          tree_sha=$(echo $response | jq -r .sha)
+
+          echo "Creating commit..."
+          response=$(curl -s -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$GH_REPO/git/commits" \
+            -d "{\"message\": \"$COMMIT_MESSAGE\",\"tree\": \"$tree_sha\",\"parents\": [\"$PARENT_COMMIT_SHA\"]}")
+
+          echo "$response" | jq .
+          new_commit_sha=$(echo $response | jq -r .sha)
+
+          # Try to delete the branch (ignore any error if it does not exist)
+          gh api -X DELETE /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME || true
+
+          echo "Creating branch..."
+          response=$(gh api -X POST /repos/$GH_REPO/git/refs \
+            -F ref=refs/heads/$BRANCH_NAME \
+            -F sha=$new_commit_sha)
+
+          echo "$response" | jq .
 
       - *getVersionTag
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -43,22 +43,6 @@
       # https://github.com/orgs/community/discussions/26636#discussioncomment-3252664
       mask-aws-account-id: false
 
-  - &downloadSourceArtifact
-    name: Download source artifact
-    uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
-    with:
-      name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-      path: ${{ runner.temp }}
-
-  - &extractSourceArtifact
-    name: Extract source artifact
-    # tar: Cannot connect to D: resolve failed
-    shell: pwsh
-    working-directory: .
-    run: |
-      tar --version
-      tar -xf ${{ runner.temp }}/source.tar.zst
-
   - &getVersionTag
     name: Get version from tags
     id: version_tag
@@ -139,7 +123,6 @@
     # because the default checkout ref is the tip of the main/master branch
     name: Checkout merge branch
     if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
-    id: checkout_merge
     uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
     with:
       fetch-depth: 0
@@ -154,6 +137,15 @@
     with:
       fetch-depth: 0
       submodules: "recursive"
+      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
+  - &checkoutVersionedSource
+    name: Checkout versioned source
+    uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+    with:
+      fetch-depth: 0
+      submodules: "recursive"
+      ref: "flowzone/pr/${{ github.event.number }}"
       token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
   - &loginWithDockerHub
@@ -1160,30 +1152,6 @@ jobs:
 
           echo "$response" | jq .
 
-      - *getVersionTag
-
-      # push the versioned commit only if the PR is merged
-      - name: Push versioned commit
-        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
-        continue-on-error: true
-        run: |
-          git push origin HEAD:refs/heads/${{ github.base_ref }}
-          # We push the tag separately so that it is only pushed if the commit push succeed, this avoids
-          # issues if something else updates the main branch whilst we're running and causes us to push
-          # the tag successfully but not the main branch and breaks future versioning attempts
-          git push origin "refs/tags/${{ steps.versionist.outputs.tag }}"
-
-      # https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
-      - name: Compress source
-        run: tar --auto-compress -cvf ${{ runner.temp }}/source.tar.zst .
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
-        with:
-          name: source-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-          path: ${{ runner.temp }}/source.tar.zst
-          retention-days: 1
-
   # check if the repository has a package.json file and which engine versions are supported
   is_npm:
     name: Is npm
@@ -1206,8 +1174,7 @@ jobs:
       npm_access: ${{ steps.access.outputs.access }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Check for package.json
         id: npm
@@ -1328,8 +1295,7 @@ jobs:
       docker_test_matrix: ${{ steps.docker_test.outputs.build }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - id: docker_images_json
         <<: *jsonArrayBuilder
@@ -1432,8 +1398,7 @@ jobs:
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Check for Python Poetry pyproject.toml
         id: python_poetry
@@ -1569,8 +1534,7 @@ jobs:
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - id: cargo_targets
         <<: *jsonArrayBuilder
@@ -1607,8 +1571,7 @@ jobs:
       balena_yml: ${{ steps.balena_yml.outputs.enabled }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - id: balena_slugs
         <<: *jsonArrayBuilder
@@ -1651,8 +1614,7 @@ jobs:
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.build }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - id: custom_test_matrix
         <<: *jsonArrayBuilder
@@ -1714,8 +1676,7 @@ jobs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       # Check if we have at least a README to build a website from
       - name: Check for README for building a website
@@ -1748,8 +1709,7 @@ jobs:
       stacks: ${{ steps.cloudformation_stacks.outputs.deploy }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Validate CloudFormation input
         id: validate_json
@@ -1799,8 +1759,7 @@ jobs:
       version_tag: ${{ steps.meta.outputs.version_tag }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *sortNodeVersions
 
       - name: Setup Node.js - Cached
@@ -2080,8 +2039,7 @@ jobs:
       DOCKER_BUILDKIT: "1"
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *getVersionTag
       - *checkGitHubAppPrivateKey
       - *getGitHubAppToken
@@ -2363,8 +2321,7 @@ jobs:
         target: ${{ fromJSON(needs.is_docker.outputs.bake_targets) }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *getVersionTag
       - *sanitizeDockerStrings
       - *dockerFinalMetadata
@@ -2425,8 +2382,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *deployToBalenaAction
       - *getReleaseNotes
       - *updateBalenaReleaseNotes
@@ -2452,8 +2408,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *deployToBalenaAction
       - *getReleaseNotes
       - *updateBalenaReleaseNotes
@@ -2482,8 +2437,7 @@ jobs:
         python-version: ${{ fromJSON(needs.is_python.outputs.python_versions) }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *getVersionTag
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -2550,8 +2504,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
@@ -2593,8 +2546,7 @@ jobs:
 
     <<: *customWorkingDirectory
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
@@ -2636,8 +2588,7 @@ jobs:
       needs.is_website.result == 'success'
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
@@ -2765,8 +2716,7 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *getVersionTag
       - *checkGitHubAppPrivateKey
       - *getGitHubAppToken
@@ -2830,8 +2780,7 @@ jobs:
       version_tag: ${{ steps.meta.outputs.version_tag }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *getVersionTag
 
       - name: Set up toolchain ${{ matrix.target }}
@@ -2892,8 +2841,7 @@ jobs:
         target: ${{ fromJSON(needs.is_cargo.outputs.cargo_targets) }}
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
@@ -2940,8 +2888,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@stable
@@ -2979,8 +2926,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Set the matrix value env var
         run: |
@@ -3018,8 +2964,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Set the matrix value env var
         run: |
@@ -3053,8 +2998,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - name: Set the matrix value env var
         run: |
@@ -3085,8 +3029,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - uses: ./.github/actions/clean
         with:
@@ -3114,8 +3057,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
 
       - uses: ./.github/actions/always
         with:
@@ -3146,8 +3088,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *downloadSourceArtifact
-      - *extractSourceArtifact
+      - *checkoutVersionedSource
       - *configureAWSCredentials
       - *getAWSCallerIdentity
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1123,12 +1123,14 @@ jobs:
           tree_json="{\"tree\": $tree_json, \"base_tree\": \"$base_tree_sha\"}"
 
           echo "Creating tree..."
+          echo "$tree_json" | jq .
+
           response=$(echo $tree_json | curl -s -X POST \
             -H "Authorization: token $GH_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/$GH_REPO/git/trees" \
             -d @-)
-          
+
           echo "$response" | jq .
           echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
           echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
@@ -1773,6 +1775,7 @@ jobs:
     needs:
       - is_npm
       - is_pr_open
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2057,6 +2060,7 @@ jobs:
     needs:
       - is_pr_open
       - is_docker
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_docker.result == 'success' &&
@@ -2339,6 +2343,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_docker
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_docker.result == 'success' &&
@@ -2401,6 +2406,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
@@ -2427,6 +2433,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_balena
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
@@ -2456,6 +2463,7 @@ jobs:
     needs:
       - is_pr_open
       - is_python
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2526,6 +2534,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.python_test.result == 'success' &&
@@ -2569,6 +2578,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_python
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -2614,6 +2624,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_website.result == 'success'
@@ -2790,6 +2801,7 @@ jobs:
     needs:
       - is_pr_open
       - is_cargo
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2857,6 +2869,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.cargo_test.result == 'success' &&
@@ -2909,6 +2922,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_cargo
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -2942,6 +2956,7 @@ jobs:
     needs:
       - is_pr_open
       - is_custom
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -2980,6 +2995,7 @@ jobs:
       - docker_test
       - cargo_test
       - python_test
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&
@@ -3014,6 +3030,7 @@ jobs:
       - is_pr_merged
       - is_pushed_tag
       - is_custom
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result != needs.is_pushed_tag.result &&
@@ -3051,6 +3068,7 @@ jobs:
     needs:
       - is_pr_closed
       - is_custom
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_closed.result == 'success' &&
@@ -3080,6 +3098,7 @@ jobs:
       - custom_finalize
       - custom_clean
       - is_custom
+      - versioned_source
     if: |
       always() &&
       needs.is_custom.outputs.custom_always == 'true'
@@ -3109,6 +3128,7 @@ jobs:
     needs:
       - is_pr_open
       - is_cloudformation
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -579,12 +579,6 @@ on:
       FLOWZONE_TOKEN:
         description: ".. or Personal Access Token (PAT) with admin/owner permissions in the org."
         required: false
-      GPG_PRIVATE_KEY:
-        description: "GPG private key exported with `gpg --armor --export-secret-keys ...` to sign commits"
-        required: false
-      GPG_PASSPHRASE:
-        description: "Passphrase to decrypt GPG private key"
-        required: false
       NPM_TOKEN:
         description: "The npm auth token to use for publishing"
         required: false
@@ -1039,17 +1033,6 @@ jobs:
             echo "::error::Latest commit appears to be a merge, which is currently unsupported. Try a rebase instead."
             exit 1
           fi
-
-      - name: Import GPG key for signing commits
-        if: inputs.disable_versioning != true
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
 
       - name: Install versionist
         if: inputs.disable_versioning != true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -43,15 +43,6 @@
       # https://github.com/orgs/community/discussions/26636#discussioncomment-3252664
       mask-aws-account-id: false
 
-  - &getVersionTag
-    name: Get version from tags
-    id: version_tag
-    run: |
-      tag="$(git tag --points-at HEAD | tail -n1)"
-      echo "tag=${tag}" >> $GITHUB_OUTPUT
-      echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-      echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
-
   - &generatePythonMetadata
     name: Generate Python metadata
     id: python_meta
@@ -118,43 +109,13 @@
             -d "{\"note\":${release_notes}}"
       fi
 
-  - &checkoutMergeBranch
-    # for pull_request_target events that are not closed we need to specify the merge branch manually
-    # because the default checkout ref is the tip of the main/master branch
-    name: Checkout merge branch
-    if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+  - &checkoutVersionedSha
+    name: Checkout versioned sha
     uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
     with:
       fetch-depth: 0
       submodules: "recursive"
-      ref: "refs/pull/${{ github.event.number }}/merge"
-      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-
-  - &checkoutSha # otherwise use the default checkout behaviour
-    name: Checkout sha
-    if: github.event_name != 'pull_request_target' || github.event.action == 'closed'
-    uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-    with:
-      fetch-depth: 0
-      submodules: "recursive"
-      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-
-  - &checkoutVersionedSource
-    name: Checkout versioned source
-    uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-    with:
-      fetch-depth: 0
-      submodules: "recursive"
-      ref: "flowzone/pr/${{ github.event.number }}"
-      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-
-  - &checkoutTaggedSource
-    name: Checkout tagged source
-    uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-    with:
-      fetch-depth: 0
-      submodules: "recursive"
-      ref: "${{ github.ref }}" # TODO: does this work for all event types?
+      ref: "${{ needs.versioned_source.outputs.sha }}"
       token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
   - &loginWithDockerHub
@@ -361,7 +322,7 @@
         localhost:5000/sut
         ${{ needs.is_docker.outputs.docker_images_crlf }}
       labels: |
-        org.opencontainers.image.version=${{ steps.version_tag.outputs.semver }}
+        org.opencontainers.image.version=${{ needs.versioned_source.outputs.semver }}
         org.opencontainers.image.ref.name=${{ matrix.target }}
       tags: |
         type=raw,value=${{ github.event.pull_request.head.sha }}
@@ -395,10 +356,10 @@
       # and version tag and semver will be empty
       tags: |
         type=raw,value=${{ github.base_ref || github.ref_name }}
-        type=raw,value=${{ steps.version_tag.outputs.tag }}
-        type=raw,value=${{ steps.version_tag.outputs.semver }}
+        type=raw,value=${{ needs.versioned_source.outputs.tag }}
+        type=raw,value=${{ needs.versioned_source.outputs.semver }}
       flavor: |
-        latest=${{ steps.version_tag.outputs.semver != '' }}
+        latest=${{ needs.versioned_source.outputs.semver != '' }}
         prefix=${{ steps.strings.outputs.prefix }},onlatest=true
         suffix=${{ steps.strings.outputs.suffix }},onlatest=true
 
@@ -1023,15 +984,31 @@ jobs:
 
     env:
       <<: *gitHubCliEnvironment
-      PARENT_COMMIT_SHA: ${{ github.sha }} # TODO: does this work for other events?
-      BRANCH_NAME: flowzone/pr/${{ github.event.number }}
+      PARENT_COMMIT_SHA: ${{ github.sha }}
 
     steps:
       - *checkGitHubAppPrivateKey
       - *getGitHubAppToken
-      - *checkoutMergeBranch
-      - *checkoutSha
-      - *getVersionTag
+
+      # checkout merge ref for open PRs
+      - name: Checkout merge ref
+        if: needs.is_pr_open.result == 'success'
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        with:
+          fetch-depth: 0
+          submodules: "recursive"
+          ref: "refs/pull/${{ github.event.number }}/merge"
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
+      # otherwise use the event sha
+      - name: Checkout event sha
+        if: needs.is_pr_open.result != 'success'
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        with:
+          fetch-depth: 0
+          submodules: "recursive"
+          ref: ${{ github.sha }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
       # fail on merge commits (ones with more than one parent)
       - name: Reject merge commits
@@ -1041,6 +1018,15 @@ jobs:
             echo "::error::Latest commit appears to be a merge, which is currently unsupported. Try a rebase instead."
             exit 1
           fi
+
+      # get current version from git tags as a fallback if versioning is disabled
+      - name: Get current tag
+        id: version_tag
+        run: |
+          tag="$(git tag --points-at HEAD | tail -n1)"
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
+          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
 
       - name: Install versionist
         if: inputs.disable_versioning != true
@@ -1159,31 +1145,20 @@ jobs:
             -F "tree=${{ steps.create_tree.outputs.sha }}" \
             -F "parents[]=$PARENT_COMMIT_SHA")
 
+          echo "$response" | jq .
           echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
           echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
 
-      - name: Create versioned branch
-        if: inputs.disable_versioning != true && needs.is_pr_open.result == 'success'
-        env:
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-        run: |
-          # Try to delete the branch (ignore any error if it does not exist)
-          gh api -X DELETE /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME || true
-
-          gh api -X POST /repos/$GH_REPO/git/refs \
-            -F ref=refs/heads/$BRANCH_NAME \
-            -F sha='${{ steps.create_commit.outputs.sha }}'
-
-      - name: Update base branch
+      - name: Push commit to base
         if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         run: |
-          gh api -X PATCH /repos/$GH_REPO/git/refs/heads/$BRANCH_NAME \
+          gh api -X PATCH /repos/$GH_REPO/git/refs/heads/${{ github.base_ref }} \
             -F sha='${{ steps.create_commit.outputs.sha }}' \
             -F force='true'
       
-      - name: Push versioned tag
+      - name: Push tag to base
         if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1216,7 +1191,7 @@ jobs:
       npm_access: ${{ steps.access.outputs.access }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Check for package.json
         id: npm
@@ -1337,7 +1312,7 @@ jobs:
       docker_test_matrix: ${{ steps.docker_test.outputs.build }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - id: docker_images_json
         <<: *jsonArrayBuilder
@@ -1440,7 +1415,7 @@ jobs:
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Check for Python Poetry pyproject.toml
         id: python_poetry
@@ -1576,7 +1551,7 @@ jobs:
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - id: cargo_targets
         <<: *jsonArrayBuilder
@@ -1613,7 +1588,7 @@ jobs:
       balena_yml: ${{ steps.balena_yml.outputs.enabled }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - id: balena_slugs
         <<: *jsonArrayBuilder
@@ -1656,7 +1631,7 @@ jobs:
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.build }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - id: custom_test_matrix
         <<: *jsonArrayBuilder
@@ -1718,7 +1693,7 @@ jobs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       # Check if we have at least a README to build a website from
       - name: Check for README for building a website
@@ -1751,7 +1726,7 @@ jobs:
       stacks: ${{ steps.cloudformation_stacks.outputs.deploy }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Validate CloudFormation input
         id: validate_json
@@ -1801,7 +1776,7 @@ jobs:
       version_tag: ${{ steps.meta.outputs.version_tag }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
       - *sortNodeVersions
 
       - name: Setup Node.js - Cached
@@ -2081,8 +2056,7 @@ jobs:
       DOCKER_BUILDKIT: "1"
 
     steps:
-      - *checkoutVersionedSource
-      - *getVersionTag
+      - *checkoutVersionedSha
       - *checkGitHubAppPrivateKey
       - *getGitHubAppToken
       - *sanitizeDockerStrings
@@ -2363,8 +2337,7 @@ jobs:
         target: ${{ fromJSON(needs.is_docker.outputs.bake_targets) }}
 
     steps:
-      - *checkoutVersionedSource
-      - *getVersionTag
+      - *checkoutVersionedSha
       - *sanitizeDockerStrings
       - *dockerFinalMetadata
       - *setupCrane
@@ -2424,7 +2397,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
       - *deployToBalenaAction
       - *getReleaseNotes
       - *updateBalenaReleaseNotes
@@ -2450,7 +2423,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
       - *deployToBalenaAction
       - *getReleaseNotes
       - *updateBalenaReleaseNotes
@@ -2479,8 +2452,7 @@ jobs:
         python-version: ${{ fromJSON(needs.is_python.outputs.python_versions) }}
 
     steps:
-      - *checkoutVersionedSource
-      - *getVersionTag
+      - *checkoutVersionedSha
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
@@ -2546,7 +2518,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
@@ -2588,7 +2560,7 @@ jobs:
 
     <<: *customWorkingDirectory
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
@@ -2630,7 +2602,7 @@ jobs:
       needs.is_website.result == 'success'
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
@@ -2758,8 +2730,7 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - *checkoutVersionedSource
-      - *getVersionTag
+      - *checkoutVersionedSha
       - *checkGitHubAppPrivateKey
       - *getGitHubAppToken
       - *getReleaseNotes
@@ -2775,13 +2746,13 @@ jobs:
           if gh release view '${{ github.event.pull_request.head.ref }}'; then
             gh release edit '${{ github.event.pull_request.head.ref }}' \
               --notes-file '${{ steps.release_notes.outputs.file }}' \
-              --title '${{ steps.version_tag.outputs.tag }}' \
-              --tag '${{ steps.version_tag.outputs.tag }}' \
+              --title '${{ needs.versioned_source.outputs.tag }}' \
+              --tag '${{ needs.versioned_source.outputs.tag }}' \
               --prerelease='${{ inputs.github_prerelease }}' \
               --draft=false
 
             if [[ ${{ inputs.github_prerelease }} =~ false ]]; then
-                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/${{ steps.version_tag.outputs.tag }}" \
+                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/${{ needs.versioned_source.outputs.tag }}" \
                   -H 'Accept: application/vnd.github+json' | jq -r .id)"
                 gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
                   -H 'Accept: application/vnd.github+json' \
@@ -2822,8 +2793,7 @@ jobs:
       version_tag: ${{ steps.meta.outputs.version_tag }}
 
     steps:
-      - *checkoutVersionedSource
-      - *getVersionTag
+      - *checkoutVersionedSha
 
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
@@ -2848,7 +2818,7 @@ jobs:
         id: meta
         run: |
           package="$(grep '^name = \"' Cargo.toml | awk -F[\"\"] '{print $2}')"
-          version="${{ steps.version_tag.outputs.semver }}"
+          version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo '${{ github.event.pull_request.head.ref }}' | sed 's/[^[:alnum:]]/-/g')"
           sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
           version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
@@ -2883,7 +2853,7 @@ jobs:
         target: ${{ fromJSON(needs.is_cargo.outputs.cargo_targets) }}
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
@@ -2930,7 +2900,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@stable
@@ -2968,7 +2938,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Set the matrix value env var
         run: |
@@ -3006,7 +2976,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Set the matrix value env var
         run: |
@@ -3040,7 +3010,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - name: Set the matrix value env var
         run: |
@@ -3071,7 +3041,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - uses: ./.github/actions/clean
         with:
@@ -3099,7 +3069,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
 
       - uses: ./.github/actions/always
         with:
@@ -3130,7 +3100,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *checkoutVersionedSource
+      - *checkoutVersionedSha
       - *configureAWSCredentials
       - *getAWSCallerIdentity
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1078,7 +1078,7 @@ jobs:
 
       # https://github.com/orgs/community/discussions/50055
       # https://www.levibotelho.com/development/commit-a-file-with-the-github-api/
-      - name: Create tree with changes
+      - name: Create blobs and tree objects
         if: inputs.disable_versioning != true
         id: create_tree
         shell: bash
@@ -1133,15 +1133,15 @@ jobs:
           echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
           echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
 
-      - name: Create versioned commit
+      - name: Create commit object
         if: inputs.disable_versioning != true
         id: create_commit
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          COMMIT_MESSAGE: ${{ steps.versionist.outputs.tag }}
+          MESSAGE: ${{ steps.versionist.outputs.tag }}
         run: |
           response=$(gh api -X POST /repos/$GH_REPO/git/commits \
-            -F "message=$COMMIT_MESSAGE" \
+            -F "message=$MESSAGE" \
             -F "tree=${{ steps.create_tree.outputs.sha }}" \
             -F "parents[]=$PARENT_COMMIT_SHA")
 
@@ -1149,25 +1149,42 @@ jobs:
           echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
           echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
 
-      - name: Push commit to base
-        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+      - name: Create tag object
+        if: inputs.disable_versioning != true
+        id: create_tag
+        env:
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          TAG: ${{ steps.versionist.outputs.tag }}
+          MESSAGE: ${{ steps.versionist.outputs.tag }}
+        run: |
+          response=$(gh api -X POST repos/$GH_REPO/git/tags \
+            -F "tag=${TAG}" \
+            -F "message=${MESSAGE}" \
+            -F "object=${{ steps.create_commit.outputs.sha }}" \
+            -F "type=commit")
+
+          echo "$response" | jq .
+          echo "sha=$(echo $response | jq -r .sha)" >> $GITHUB_OUTPUT
+          echo "json=$(echo $response | jq -n .)" >> $GITHUB_OUTPUT
+
+      - name: Create commit reference
+        if: needs.is_pr_merged.result == 'success' && steps.create_commit.outputs.sha != ''
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         run: |
           gh api -X PATCH /repos/$GH_REPO/git/refs/heads/${{ github.base_ref }} \
             -F sha='${{ steps.create_commit.outputs.sha }}' \
             -F force='true'
-      
-      - name: Push tag to base
-        if: inputs.disable_versioning != true && needs.is_pr_merged.result == 'success'
+
+      - name: Create tag reference
+        if: needs.is_pr_merged.result == 'success' && steps.create_tag.outputs.sha != ''
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          TAG: ${{ steps.versionist.outputs.tag }}
         run: |
-          gh api -X POST repos/$GH_REPO/git/tags \
-            -F tag='${{ steps.versionist.outputs.tag }}' \
-            -F message='${{ steps.versionist.outputs.tag }}' \
-            -F object='${{ steps.create_commit.outputs.sha }}' \
-            -F type='commit'
+          gh api -X POST /repos/$GH_REPO/git/refs \
+            -f "ref=refs/tags/${TAG}" \
+            -f "sha=${{ steps.create_tag.outputs.sha }}"
 
   # check if the repository has a package.json file and which engine versions are supported
   is_npm:


### PR DESCRIPTION
These commit objects will be automatically signed and verified
if using GitHub app tokens for authentication.

This also removes the need for versioned source artifacts
as each job can clone the versioned commit directly.

Change-type: major
Signed-off-by: Kyle Harding <kyle@balena.io>