### PR TITLE
Make protect branch depend on versioned source

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3747,6 +3747,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_merged
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result == 'success' &&

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3543,6 +3543,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_open
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3309,6 +3309,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_open
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_open.result == 'success' &&

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3443,6 +3443,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_pr_merged
+      - versioned_source
     if: |
       !failure() && !cancelled() &&
       needs.is_pr_merged.result == 'success' &&


### PR DESCRIPTION
If only to make sure we don't apply new branch protections when the commits don't pass the scrutiny of versionist and rebase requirements.

Change-type: patch