### PR TITLE
Create local refs for orphaned commit and tag objects

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -28,6 +28,18 @@ runs:
         echo "${SECRETS}"
         echo "${VARIABLES}"
 
+    # Resolve tag, semver, sha, and description of current git working copy.
+    - name: Describe git state
+      id: git_describe
+      shell: bash
+      run: |
+        set -x
+        tag="$(git tag --points-at HEAD | tail -n1)"
+        echo "tag=${tag}" >> $GITHUB_OUTPUT
+        echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
+        echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
+        echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
     - name: Check for GitHub App private key
       id: gh_app_private_key
       shell: bash

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -658,7 +658,9 @@ jobs:
     outputs:
       tag: ${{ steps.versionist.outputs.tag || steps.git_describe.outputs.tag }}
       semver: ${{ steps.versionist.outputs.semver || steps.git_describe.outputs.semver }}
-      sha: ${{ steps.create_commit.outputs.sha || steps.git_describe.outputs.sha }}
+      sha: ${{ steps.create_tag.outputs.sha || steps.git_describe.outputs.sha }}
+      commit_sha: ${{ steps.create_commit.outputs.sha }}
+      tag_sha: ${{ steps.create_tag.outputs.sha }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -708,7 +710,7 @@ jobs:
             echo "::error::Latest commit appears to be a merge, which is currently unsupported. Try a rebase instead."
             exit 1
           fi
-      - name: Inspect git state
+      - name: Describe git state
         id: git_describe
         run: |
           tag="$(git tag --points-at HEAD | tail -n1)"
@@ -1544,6 +1546,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Sort node versions
         id: node_versions
         env:
@@ -1843,6 +1849,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Check for GitHub App private key
         id: gh_app_private_key
         shell: bash
@@ -2504,6 +2514,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - uses: balena-io/deploy-to-balena-action@e7041b7ca6dd85f47a3eb5ce141178bf77d85920
         id: balena_deploy
         with:
@@ -2651,6 +2665,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
         with:
@@ -2716,6 +2734,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0
         with:
@@ -2812,6 +2834,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
           node-version: 18
@@ -3073,6 +3099,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -3133,6 +3163,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -3223,6 +3257,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3270,6 +3308,10 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Create local refs
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -121,6 +121,26 @@
       ref: "${{ needs.versioned_source.outputs.sha }}"
       token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
+  - &describeGitState
+    # Resolve tag, semver, sha, and description of current git working copy.
+    name: Describe git state
+    id: git_describe
+    run: |
+      tag="$(git tag --points-at HEAD | tail -n1)"
+      echo "tag=${tag}" >> $GITHUB_OUTPUT
+      echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
+      echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
+      echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+  
+  - &createLocalRefs
+    # Create a local reference for the versioned tag so that it
+    # may be consumed by build steps that need to know the version of the source.
+    # These refs should already exist on merge/finalize.
+    name: Create local refs
+    if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+    run: |
+      git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
+
   - &loginWithDockerHub
     name: Login to Docker Hub
     continue-on-error: true
@@ -1087,10 +1107,12 @@ jobs:
     outputs:
       tag: ${{ steps.versionist.outputs.tag || steps.git_describe.outputs.tag }}
       semver: ${{ steps.versionist.outputs.semver || steps.git_describe.outputs.semver }}
-      # note that this is NOT the same sha we use for draft artifact tagging,
-      # for that we use github.event.pull_request.head.sha which aligns with the tip of the HEAD branch
-      # whereas this will be the merge commit sha for PRs or the tagged commit sha for tags
-      sha: ${{ steps.create_commit.outputs.sha || steps.git_describe.outputs.sha }}
+      # Note that this is NOT the same sha we use for draft artifact tagging!
+      # For that we use github.event.pull_request.head.sha which aligns with the tip of the HEAD branch
+      # whereas this will be the merge commit sha for PRs or the tagged commit sha for tags.
+      sha: ${{ steps.create_tag.outputs.sha || steps.git_describe.outputs.sha }}
+      commit_sha: ${{ steps.create_commit.outputs.sha }}
+      tag_sha: ${{ steps.create_tag.outputs.sha }}
 
     env:
       <<: *gitHubCliEnvironment
@@ -1128,17 +1150,9 @@ jobs:
             exit 1
           fi
 
-      # get tag, semver, sha, and description of current git working copy
-      # these will be used as the parent sha for the versioned commit
-      # or as default tag & semver if versioning is disabled
-      - name: Inspect git state
-        id: git_describe
-        run: |
-          tag="$(git tag --points-at HEAD | tail -n1)"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-          echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      # The current commit sha is needed as the parent sha for the versioned commit
+      # and/or as default tag & semver if versioning is disabled.
+      - *describeGitState
 
       - name: Install versionist
         if: inputs.disable_versioning != true
@@ -1966,6 +1980,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
       - *sortNodeVersions
 
       - name: Setup Node.js - Cached
@@ -2247,6 +2262,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
       - *checkGitHubAppPrivateKey
       - *getGitHubAppToken
       - *sanitizeDockerStrings
@@ -2590,6 +2606,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
       - *deployToBalenaAction
       - *getReleaseNotes
       - *updateBalenaReleaseNotes
@@ -2647,6 +2664,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
@@ -2714,6 +2732,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
 
       - name: Set up Python
         uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
@@ -2800,6 +2819,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
 
       - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3
         with:
@@ -2992,6 +3012,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
 
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
@@ -3053,6 +3074,7 @@ jobs:
 
     steps:
       - *checkoutVersionedSha
+      - *createLocalRefs
 
       - name: Set up toolchain ${{ matrix.target }}
         uses: dtolnay/rust-toolchain@master
@@ -3140,6 +3162,7 @@ jobs:
     steps:
       - *rejectExternalCustomActions
       - *checkoutVersionedSha
+      - *createLocalRefs
 
       - name: Set the matrix value env var
         run: |
@@ -3179,6 +3202,7 @@ jobs:
     steps:
       - *rejectExternalCustomActions
       - *checkoutVersionedSha
+      - *createLocalRefs
 
       - name: Set the matrix value env var
         run: |


### PR DESCRIPTION
For open pull requests, the versioned commit and tag
objects are created but are intentionally not referenced
anywhere in the git tree.

As such, command line tools like git describe do not return
the current versioned tag which is sometimes used in build scripts.

So before build, test, and publish jobs we can create the references
to the orphaned objects locally. These references should already
exist on merge/finalize.

Change-type: minor