### PR TITLE
Disable GPT reviews for Flowzone self-tests for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,4 +54,4 @@ jobs:
           ["windows-2022"]
         ]
       # enable GPT review for self-tests
-      enable_gpt_review: true
+      enable_gpt_review: false


### PR DESCRIPTION
There are some outstanding issues that should be resolved before enabling this feature anywhere.

Change-type: patch