### PR TITLE
Fix concurrency for external contributions and non-syncronize events

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -393,8 +393,8 @@ on:
         required: false
         default: false
 concurrency:
-  group: flowzone-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != github.base_ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 env:
   NPM_REGISTRY: https://registry.npmjs.org
   CARGO_REGISTRY: crates.io

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1002,9 +1002,9 @@ on:
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
-  group: flowzone-${{ github.ref }}
-  # cancel jobs in progress as long as it's not a merged PR
-  cancel-in-progress: ${{ github.ref != github.base_ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  # cancel jobs in progress for updated PRs, but not merge or tag events
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org"


### PR DESCRIPTION
Use the PR number for uniqueness when determining concurrency, and only cancel in progress jobs if the PR is open.

Change-type: patch