### PR TITLE
Use `--locked` flag when installing cross

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2989,7 +2989,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
       - name: Install cross
-        run: cargo install cross
+        run: cargo install cross --locked
       - name: Lint with clippy
         run: cross -v clippy --all-targets --all-features -- -D warnings
       - name: Run tests for toolchain ${{ matrix.target }}
@@ -3059,7 +3059,7 @@ jobs:
           toolchain: ${{ inputs.rust_toolchain }}
           targets: ${{ matrix.target }}
       - name: Install cross
-        run: cargo install cross
+        run: cargo install cross --locked
       - name: Build release for toolchain ${{ matrix.target }}
         run: cross -v build --release --target ${{ matrix.target }}
       - name: Install LLVM

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2924,7 +2924,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Install cross
-        run: cargo install cross
+        run: cargo install cross --locked
 
       - name: Lint with clippy
         run: cross -v clippy --all-targets --all-features -- -D warnings
@@ -2984,7 +2984,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install cross
-        run: cargo install cross
+        run: cargo install cross --locked
 
       - name: Build release for toolchain ${{ matrix.target }}
         run: cross -v build --release --target ${{ matrix.target }}


### PR DESCRIPTION
This is to prevent bugs from dependencies from breaking the build.

See: https://github.com/balena-io-modules/node-systemd/actions/runs/5740095381/job/15557192112
Caused by: https://github.com/bytecodealliance/rustix/issues/767

Change-type: patch