### PR TITLE
Only provide automatic GITHUB_TOKEN to compose vars

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1838,11 +1838,10 @@ jobs:
               echo "::add-mask::${secret}"
             done < ${COMPOSE_ENV_FILE}
           fi
-      - name: Add GITHUB_TOKEN to compose env file
-        if: github.event.pull_request.head.repo.full_name == github.repository
+      - name: Add automatic GITHUB_TOKEN to compose env file
         env:
-          GITHUB_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if ! grep -q '^GH_TOKEN=' ${COMPOSE_ENV_FILE}
           then

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2193,11 +2193,10 @@ jobs:
             done < ${COMPOSE_ENV_FILE}
           fi
 
-      - name: Add GITHUB_TOKEN to compose env file
-        <<: *ifInternalPullRequest
+      - name: Add automatic GITHUB_TOKEN to compose env file
         env:
-          GITHUB_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if ! grep -q '^GH_TOKEN=' ${COMPOSE_ENV_FILE}
           then


### PR DESCRIPTION
The docker compose tests are one of the few places where we are providing elevated secrets to untrusted user code beyond the workflow itself.

In the case of a GitHub token appended to compose vars, we should use the automatic GHA token if possible and avoid leaking a privileged PAT or ephemeral app token, even when restricted to internal PRs.

Change-type: minor
See: https://github.com/product-os/self-hosted-runners/pull/75