### PR TITLE
Quote validated Python versions

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1036,7 +1036,7 @@ jobs:
             echo "Setting up Python $version"
             error_check=`(poetry env use $version 2>&1 || true)`
             if ! grep -q "Please choose a compatible version" <<< $error_check; then
-              versions+=("$version")
+              versions+=("\"$version\"")
             else
               echo "Python $version does not meet project requirements."
             fi

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1564,7 +1564,7 @@ jobs:
             echo "Setting up Python $version"
             error_check=`(poetry env use $version 2>&1 || true)`
             if ! grep -q "Please choose a compatible version" <<< $error_check; then
-              versions+=("$version")
+              versions+=("\"$version\"")
             else
               echo "Python $version does not meet project requirements."
             fi


### PR DESCRIPTION
Fixes a regression where dependencies pick up an array of numbers, causing the annoying 3.10=3.1 bug.
Now the quoted values will always we interpreted as strings.