### PR TITLE
Always check for the presence of custom actions

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1210,9 +1210,6 @@ jobs:
         env:
           INPUT: ${{ inputs.custom_finalize_matrix }}
       - name: Check for custom actions
-        if: |
-          github.event.pull_request.head.repo.full_name == github.repository ||
-          inputs.restrict_custom_actions == false
         id: custom
         run: |
           if [ -d .github/actions/test ]

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1694,10 +1694,6 @@ jobs:
           INPUT: ${{ inputs.custom_finalize_matrix }}
 
       - name: Check for custom actions
-        # skip custom actions for external contributions by default
-        if: |
-          github.event.pull_request.head.repo.full_name == github.repository ||
-          inputs.restrict_custom_actions == false
         id: custom
         run: |
           if [ -d .github/actions/test ]


### PR DESCRIPTION
If custom actions are not allowed, the workflow will be rejected by the custom actions job(s) and fail. With this condition in place it was silently skipping custom actions.

Change-type: patch