### PR TITLE
Do not toggle automerge for PRs authored by github apps

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4273,7 +4273,8 @@ jobs:
       - protect_branch
     if: |
       github.event.pull_request.state == 'open' &&
-      inputs.toggle_auto_merge == true
+      inputs.toggle_auto_merge == true &&
+      contains(github.event.pull_request.user.login, '[bot]') == false
     env:
       BRANCH_PROTECTION_URI: repos/${{ github.repository }}/branches/${{ github.event.pull_request.base.ref }}/protection
     steps:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3825,7 +3825,8 @@ jobs:
       - protect_branch
     if: |
       github.event.pull_request.state == 'open' &&
-      inputs.toggle_auto_merge == true
+      inputs.toggle_auto_merge == true &&
+      contains(github.event.pull_request.user.login, '[bot]') == false
 
     env:
       BRANCH_PROTECTION_URI: repos/${{ github.repository }}/branches/${{ github.event.pull_request.base.ref }}/protection


### PR DESCRIPTION
GitHub apps should have their own automerge policies, like Renovate.

Change-type: patch