### PR TITLE
Switch to latest skopeo testing image

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2068,7 +2068,7 @@ jobs:
             platform_tag="${LOCAL_TAG}-${platform}"
 
             docker run --rm --network host -v "${tar}:${tar}:ro" \
-              quay.io/skopeo/stable:v1.13.0 \
+              quay.io/skopeo/testing:latest \
               copy --all "docker-archive:${tar}" "docker://${platform_tag}" --dest-tls-verify=false
 
             docker buildx imagetools create -t ${LOCAL_TAG} --append "${platform_tag}" || \

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2356,7 +2356,7 @@ jobs:
             platform_tag="${LOCAL_TAG}-${platform}"
 
             docker run --rm --network host -v "${tar}:${tar}:ro" \
-              quay.io/skopeo/stable:v1.13.0 \
+              quay.io/skopeo/testing:latest \
               copy --all "docker-archive:${tar}" "docker://${platform_tag}" --dest-tls-verify=false
 
             docker buildx imagetools create -t ${LOCAL_TAG} --append "${platform_tag}" || \


### PR DESCRIPTION
The stable images have been deleted, possibly by mistake, but this is blocking merges.

https://quay.io/repository/containers/skopeo?tab=history

We should install the skopeo binary in our self-hosted images going forward.

Change-type: patch