### PR TITLE
Revert to using installed skopeo binaries

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2067,9 +2067,7 @@ jobs:
 
             platform_tag="${LOCAL_TAG}-${platform}"
 
-            docker run --rm --network host -v "${tar}:${tar}:ro" \
-              quay.io/skopeo/testing:latest \
-              copy --all "docker-archive:${tar}" "docker://${platform_tag}" --dest-tls-verify=false
+            skopeo copy --all "docker-archive:${tar}" "docker://${platform_tag}" --dest-tls-verify=false
 
             docker buildx imagetools create -t ${LOCAL_TAG} --append "${platform_tag}" || \
               docker buildx imagetools create -t ${LOCAL_TAG} "${platform_tag}"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2355,9 +2355,7 @@ jobs:
 
             platform_tag="${LOCAL_TAG}-${platform}"
 
-            docker run --rm --network host -v "${tar}:${tar}:ro" \
-              quay.io/skopeo/testing:latest \
-              copy --all "docker-archive:${tar}" "docker://${platform_tag}" --dest-tls-verify=false
+            skopeo copy --all "docker-archive:${tar}" "docker://${platform_tag}" --dest-tls-verify=false
 
             docker buildx imagetools create -t ${LOCAL_TAG} --append "${platform_tag}" || \
               docker buildx imagetools create -t ${LOCAL_TAG} "${platform_tag}"


### PR DESCRIPTION
Our self-hosted runners include this package in v3.2.4

Change-type: patch
Reverts: https://github.com/product-os/flowzone/pull/706/commits/68ead8bc4793e8588794bef7f61c58259a2dcc8d
Depends-on: https://github.com/product-os/self-hosted-runners/pull/78