### PR TITLE
Use `docker compose run` for testing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1910,7 +1910,7 @@ jobs:
       - name: Run docker compose tests
         if: needs.is_docker.outputs.docker_compose_tests == 'true'
         run: |
-          docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
+          docker compose run sut || { docker compose logs ; exit 1 ; }
           docker compose logs
       - name: Upload artifacts
         if: join(fromJSON(needs.is_docker.outputs.docker_images)) != ''

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2274,7 +2274,7 @@ jobs:
       - name: Run docker compose tests
         if: needs.is_docker.outputs.docker_compose_tests == 'true'
         run: |
-          docker compose up sut --exit-code-from sut || { docker compose logs ; exit 1 ; }
+          docker compose run sut || { docker compose logs ; exit 1 ; }
           docker compose logs
 
       # https://github.com/actions/upload-artifact


### PR DESCRIPTION
From docker compose documentation:

> The `docker compose run` command is for running "one-off" or "adhoc" tasks. It requires the service name you want to run and only starts containers for services that the running service depends on. Use run to run tests or perform an administrative task such as removing or adding data to a data volume container. The `run` command acts like `docker run -ti` in that it opens an interactive terminal to the container and returns an exit status matching the exit status of the process in the container.

Using `docker compose up` may lead to a false negative test if one of the other services (i.e. not the `sut` service), terminate before the service gets a chance to finish.

Change-type: patch