### PR TITLE
Update parameters for tibdex/github-app-token v2

### DIFF
--- a/.github/actions/always/action.yml
+++ b/.github/actions/always/action.yml
@@ -28,24 +28,13 @@ runs:
         echo "${SECRETS}"
         echo "${VARIABLES}"
 
-    - name: Check for GitHub App private key
-      id: gh_app_private_key
-      shell: bash
-      run: |
-        if [ -n '${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}' ]
-        then
-          echo 'found=true' >> $GITHUB_OUTPUT
-        else
-          echo 'found=false' >> $GITHUB_OUTPUT
-        fi
-
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
-      if: steps.gh_app_private_key.outputs.found == 'true'
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_id: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: id
+        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/clean/action.yml
+++ b/.github/actions/clean/action.yml
@@ -28,24 +28,13 @@ runs:
         echo "${SECRETS}"
         echo "${VARIABLES}"
 
-    - name: Check for GitHub App private key
-      id: gh_app_private_key
-      shell: bash
-      run: |
-        if [ -n '${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}' ]
-        then
-          echo 'found=true' >> $GITHUB_OUTPUT
-        else
-          echo 'found=false' >> $GITHUB_OUTPUT
-        fi
-
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
-      if: steps.gh_app_private_key.outputs.found == 'true'
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_id: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: id
+        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/finalize/action.yml
+++ b/.github/actions/finalize/action.yml
@@ -28,24 +28,13 @@ runs:
         echo "${SECRETS}"
         echo "${VARIABLES}"
 
-    - name: Check for GitHub App private key
-      id: gh_app_private_key
-      shell: bash
-      run: |
-        if [ -n '${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}' ]
-        then
-          echo 'found=true' >> $GITHUB_OUTPUT
-        else
-          echo 'found=false' >> $GITHUB_OUTPUT
-        fi
-
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
-      if: steps.gh_app_private_key.outputs.found == 'true'
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_id: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: id
+        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -28,25 +28,14 @@ runs:
         echo "${SECRETS}"
         echo "${VARIABLES}"
 
-    - name: Check for GitHub App private key
-      id: gh_app_private_key
-      shell: bash
-      run: |
-        if [ -n '${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}' ]
-        then
-          echo 'found=true' >> $GITHUB_OUTPUT
-        else
-          echo 'found=false' >> $GITHUB_OUTPUT
-        fi
-
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
-      if: steps.gh_app_private_key.outputs.found == 'true'
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_id: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: id
+        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}
 

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -40,24 +40,13 @@ runs:
         echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
         echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-    - name: Check for GitHub App private key
-      id: gh_app_private_key
-      shell: bash
-      run: |
-        if [ -n '${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}' ]
-        then
-          echo 'found=true' >> $GITHUB_OUTPUT
-        else
-          echo 'found=false' >> $GITHUB_OUTPUT
-        fi
-
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-      if: steps.gh_app_private_key.outputs.found == 'true'
+      uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_id: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: id
+        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -535,7 +535,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout merge ref
@@ -741,7 +742,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -859,7 +861,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -981,7 +984,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -1073,7 +1077,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -1122,7 +1127,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -1176,7 +1182,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -1253,7 +1260,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -1295,7 +1303,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -1406,7 +1415,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -1585,7 +1595,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Sort node versions
@@ -1635,7 +1646,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Sort node versions
@@ -1689,7 +1701,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2165,7 +2178,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2367,7 +2381,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2450,7 +2465,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2530,7 +2546,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2611,7 +2628,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2680,7 +2698,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2730,7 +2749,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2793,7 +2813,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Delete draft GitHub release
@@ -2827,7 +2848,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Delete draft GitHub release
@@ -2890,7 +2912,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -2969,7 +2992,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3042,7 +3066,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3099,7 +3124,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3150,7 +3176,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3210,7 +3237,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3264,7 +3292,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3314,7 +3343,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3363,7 +3393,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3411,7 +3442,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3791,7 +3823,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3891,7 +3924,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned sha
@@ -3974,7 +4008,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Get branch protection rules
@@ -4158,7 +4193,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Configure repository
@@ -4306,7 +4342,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Get branch protection rules
@@ -4376,7 +4413,8 @@ jobs:
         id: non_admin_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -128,9 +128,10 @@ jobs:
         id: gh_token
         with:
           app_id: ${{ inputs.token_app_id }}
-          installation_id: ${{ inputs.token_installation_id || matrix.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.token_installation_id || matrix.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          repository: ${{ matrix.repository }}
+          repositories: ${{ matrix.repository }}
           permissions: >-
             {
               "contents": "write",

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -18,7 +18,8 @@
     id: gh_app_token
     with:
       app_id: ${{ inputs.app_id }}
-      installation_id: ${{ inputs.installation_id }}
+      installation_retrieval_mode: id
+      installation_retrieval_payload: ${{ inputs.installation_id }}
       private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       permissions: ${{ inputs.token_scope }}
 
@@ -3841,7 +3842,8 @@ jobs:
         id: non_admin_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_id: ${{ inputs.installation_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: >-
             {


### PR DESCRIPTION
Change-type: patch
See: https://github.com/product-os/flowzone/pull/743
See: https://github.com/tibdex/github-app-token/releases/tag/v2.0.0

```yaml
  installation_retrieval_mode:
    description: >-
      The mode used to retrieve the installation for which the token will be requested.

      One of:
      - id: use the installation with the specified ID.
      - organization: use an organization installation (https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-organization-installation-for-the-authenticated-app).
      - repository: use a repository installation (https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-a-repository-installation-for-the-authenticated-app).
      - user: use a user installation (https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-a-user-installation-for-the-authenticated-app).
    default: repository
  installation_retrieval_payload:
    description: >-
      The payload used to retrieve the installation.

      Examples for each retrieval mode:
      - id: 1337
      - organization: github
      - repository: tibdex/github-app-token
      - user: tibdex
```