### PR TITLE
patch: Remove packageManager property with wrangler-action 3.3.0

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2878,7 +2878,6 @@ jobs:
           wranglerVersion: 3.5.1
           preCommands: wrangler --version
           command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ | tee -a $GITHUB_STEP_SUMMARY
-          packageManager: npm
   github_clean:
     name: Clean GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2766,7 +2766,6 @@ jobs:
           wranglerVersion: "3.5.1" # latest - https://www.npmjs.com/package/wrangler
           preCommands: wrangler --version
           command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ | tee -a $GITHUB_STEP_SUMMARY
-          packageManager: npm
 
   ###################################################
   # GitHub


### PR DESCRIPTION
After discussing https://github.com/cloudflare/wrangler-action/issues/180, it turns out `packageManager` property is supposed to be optional. 
With the new wrangler-action, we no longer need this property.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
