### PR TITLE
Fetch and checkout merge ref when resetting github directory

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -522,22 +522,22 @@ jobs:
               "metadata": "read",
               "pull_requests": "read"
             }
-      - name: Checkout merge ref
-        if: github.event.pull_request.state == 'open'
+      - name: Checkout refs/pull/${{ github.event.number }}/merge
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
           submodules: recursive
           ref: refs/pull/${{ github.event.number }}/merge
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Checkout event sha
-        if: github.event.pull_request.state != 'open'
+        if: github.event.pull_request.state == 'open'
+      - name: Checkout ${{ github.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
           submodules: recursive
           ref: ${{ github.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        if: github.event.pull_request.state != 'open'
       - name: Reject merge commits
         if: github.event.pull_request.state == 'open'
         run: |
@@ -741,7 +741,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -876,7 +876,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1003,7 +1003,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1100,7 +1100,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1154,7 +1154,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1213,7 +1213,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1222,7 +1222,8 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Reset .github directory to ${{ github.ref }}
         run: |
-          git checkout ${{ github.sha }} -- .github
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD -- .github
       - id: custom_test_matrix
         name: Build JSON array from comma-separated list
         uses: kanga333/json-array-builder@c7cd9d3a8b17cd368e9c2210bc3c16b0e2714ce5
@@ -1298,7 +1299,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1345,7 +1346,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1461,7 +1462,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -1761,7 +1762,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -2263,7 +2264,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -2491,7 +2492,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -2579,7 +2580,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -2664,7 +2665,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -2750,7 +2751,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -2824,7 +2825,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -2879,7 +2880,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3057,7 +3058,7 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3141,7 +3142,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3219,7 +3220,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3281,7 +3282,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3333,7 +3334,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3342,7 +3343,8 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Reset .github directory to ${{ github.ref }}
         run: |
-          git checkout ${{ github.sha }} -- .github
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD -- .github
       - name: Create local refs
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3397,7 +3399,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3406,7 +3408,8 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Reset .github directory to ${{ github.ref }}
         run: |
-          git checkout ${{ github.sha }} -- .github
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD -- .github
       - name: Create local refs
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3455,7 +3458,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3464,7 +3467,8 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Reset .github directory to ${{ github.ref }}
         run: |
-          git checkout ${{ github.sha }} -- .github
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD -- .github
       - name: Set the matrix value env var
         run: |
           echo "matrix_value=${{ matrix.value }}" >> $GITHUB_ENV
@@ -3509,7 +3513,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3518,7 +3522,8 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Reset .github directory to ${{ github.ref }}
         run: |
-          git checkout ${{ github.sha }} -- .github
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD -- .github
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -3562,7 +3567,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -3571,7 +3576,8 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Reset .github directory to ${{ github.ref }}
         run: |
-          git checkout ${{ github.sha }} -- .github
+          git fetch origin ${{ github.ref }}
+          git checkout FETCH_HEAD -- .github
       - uses: ./.github/actions/always
         with:
           json: ${{ toJSON(inputs) }}
@@ -3618,7 +3624,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -4005,7 +4011,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
@@ -4111,7 +4117,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned sha
+      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -106,8 +106,32 @@
             -d "{\"note\":${release_notes}}"
       fi
 
-  - &checkoutVersionedSha
-    name: Checkout versioned sha
+  - &checkoutMergeRef
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+    # https://github.com/actions/checkout
+    name: Checkout refs/pull/${{ github.event.number }}/merge
+    uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    with:
+      fetch-depth: 0
+      submodules: "recursive"
+      ref: "refs/pull/${{ github.event.number }}/merge"
+      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
+  - &checkoutEventSha
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+    # https://github.com/actions/checkout
+    name: Checkout ${{ github.sha }}
+    uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    with:
+      fetch-depth: 0
+      submodules: "recursive"
+      ref: ${{ github.sha }}
+      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
+  - &checkoutVersionedSha # https://github.com/actions/checkout
+    name: Checkout ${{ needs.versioned_source.outputs.sha }}
     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     with:
       fetch-depth: 0
@@ -116,11 +140,13 @@
       token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
   - &resetGitHubDirectory
-    # checkout the tip of BASE if the PR is from a fork,
-    # otherwise checkout the merge commit
+    # checkout the tip of BASE if the PR is from a fork
+    # or the merge commit if the PR is internal
     name: Reset .github directory to ${{ github.ref }}
+    # <<: *ifExternalPullRequest
     run: |
-      git checkout ${{ github.sha }} -- .github
+      git fetch origin ${{ github.ref }}
+      git checkout FETCH_HEAD -- .github
 
   - &describeGitState # Resolve tag, semver, sha, and description of current git working copy.
     name: Describe git state
@@ -1111,27 +1137,13 @@ jobs:
               "pull_requests": "read"
             }
 
-      # checkout merge ref for open PRs
-      # https://github.com/actions/checkout
-      - name: Checkout merge ref
+      # Checkout the merge ref for open PRs
+      - <<: *checkoutMergeRef
         if: github.event.pull_request.state == 'open'
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-          submodules: "recursive"
-          ref: "refs/pull/${{ github.event.number }}/merge"
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
-      # otherwise use the event sha
-      # https://github.com/actions/checkout
-      - name: Checkout event sha
+      # Checkout the event sha for closed PRs
+      - <<: *checkoutEventSha
         if: github.event.pull_request.state != 'open'
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-          submodules: "recursive"
-          ref: ${{ github.sha }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
       # fail on merge commits (ones with more than one parent)
       - name: Reject merge commits


### PR DESCRIPTION
Don't assume that github.sha is the same as github.ref or even
exists in the clone. Instead fetch and checkout github.ref directly.

Change-type: patch