### PR TITLE
Create empty .env file if no COMPOSE_VARS exist

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1916,6 +1916,7 @@ jobs:
             fi
           done
 
+          touch ${COMPOSE_ENV_FILE}
           docker compose --env-file="${COMPOSE_ENV_FILE}" --project-directory="$(pwd)" ${args} config > "${COMPOSE_FILE}"
 
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2309,6 +2309,7 @@ jobs:
             fi
           done
 
+          touch ${COMPOSE_ENV_FILE}
           docker compose --env-file="${COMPOSE_ENV_FILE}" --project-directory="$(pwd)" ${args} config > "${COMPOSE_FILE}"
 
           yq '(.services.* | select(.build != null)).platform |= "${{ matrix.platform }}"' -i "${COMPOSE_FILE}"


### PR DESCRIPTION
This should prevent failing docker compose tests due to a missing env file.

See: docker/compose#10995
Change-type: patch