### PR TITLE
Workaround: Pipe Cloudflare command output in Summary

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2935,8 +2935,8 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: 3.5.1
-          preCommands: wrangler --version
-          command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/
+          command: --version
+          postCommands: npx pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ | tee -a $GITHUB_STEP_SUMMARY
   github_clean:
     name: Clean GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2835,8 +2835,8 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: "3.5.1" # latest - https://www.npmjs.com/package/wrangler
-          preCommands: wrangler --version
-          command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/
+          command: --version
+          postCommands: npx pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ | tee -a $GITHUB_STEP_SUMMARY
 
   ###################################################
   # GitHub


### PR DESCRIPTION
Add a postCommand to still have the command output as a GitHub Step Summary as maintainers of wrangler-action setup outputs for this action. 


Change-type: patch
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
