### PR TITLE
Use buildx as a more reliable check of platform support

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1839,16 +1839,15 @@ jobs:
           echo "prefix=${prefix_slug}" >> $GITHUB_OUTPUT
           echo "suffix=${suffix_slug}" >> $GITHUB_OUTPUT
           echo "dockerhub=${dockerhub_slug}" >> $GITHUB_OUTPUT
-      - name: Get supported platforms
-        id: supported_platforms
-        env:
-          BINFMT_VERSION: qemu-v8.0.4-33
-        run: |
-          json="$(docker run --rm --privileged tonistiigi/binfmt:${{ env.BINFMT_VERSION }} | jq . -c)"
-          echo "json=$json" >> $GITHUB_OUTPUT
+      - name: Setup buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+        with:
+          driver-opts: network=host
+          install: true
+        id: buildx
       - name: Setup QEMU
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3
-        if: contains(fromJSON(steps.supported_platforms.outputs.json).supported, matrix.platform) != true
+        if: contains(steps.buildx.outputs.platforms, matrix.platform) != true
         env:
           LOG_LEVEL: debug
           BINFMT_VERSION: qemu-v8.0.4-33

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -492,20 +492,19 @@
         Please consult the documentation for more information."
       exit 1
 
-  - &getSupportedPlatforms
-    name: Get supported platforms
-    id: supported_platforms
-    env:
-      BINFMT_VERSION: qemu-v8.0.4-33 # renovate: datasource=docker depName=binfmt packageName=tonistiigi/binfmt
-    run: |
-      json="$(docker run --rm --privileged tonistiigi/binfmt:${{ env.BINFMT_VERSION }} | jq . -c)"
-      echo "json=$json" >> $GITHUB_OUTPUT
+  - &setupBuildx # https://github.com/docker/setup-buildx-action
+    name: Setup buildx
+    uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+    with:
+      driver-opts: network=host
+      install: true
 
   - &setupQemuBinfmt # https://github.com/docker/setup-qemu-action
     name: Setup QEMU
     uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
     # only register qemu binfmt if the target platform is not supported by the host
-    if: contains(fromJSON(steps.supported_platforms.outputs.json).supported, matrix.platform) != true
+    if: contains(steps.buildx.outputs.platforms, matrix.platform) != true
+    # FIXME: the if condition above will match substrings of other platforms
     env:
       LOG_LEVEL: debug
       BINFMT_VERSION: qemu-v8.0.4-33 # renovate: datasource=docker depName=binfmt packageName=tonistiigi/binfmt
@@ -513,13 +512,6 @@
       platforms: ${{ matrix.platform }}
       # https://hub.docker.com/r/tonistiigi/binfmt
       image: tonistiigi/binfmt:${{ env.BINFMT_VERSION }}
-
-  - &setupBuildx # https://github.com/docker/setup-buildx-action
-    name: Setup buildx
-    uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-    with:
-      driver-opts: network=host
-      install: true
 
   - &setupNode # https://github.com/actions/setup-node
     name: Setup Node.js
@@ -2269,7 +2261,9 @@ jobs:
       - *checkoutVersionedSha
       - *createLocalRefs
       - *sanitizeDockerStrings
-      - *getSupportedPlatforms
+
+      - <<: *setupBuildx
+        id: buildx
       - *setupQemuBinfmt
       - *setupBuildx
 


### PR DESCRIPTION
When running binfmt in a guest docker daemon on arm64 the native support for arm/v6 and arm/v7 is not reflected.

However buildx detects support for those platforms just fine.

Change-type: patch