### PR TITLE
For repo scoped tokens make sure we use the base repo

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1703,7 +1703,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
       - name: Sort node versions
         id: node_versions
         env:
@@ -2970,7 +2970,7 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
       - name: Delete draft GitHub release
         run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
         env:
@@ -3010,7 +3010,7 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
       - name: Delete draft GitHub release
         run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
         env:
@@ -4216,7 +4216,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
       - name: Get branch protection rules
         id: branch_protection
         shell: bash --noprofile --norc -eo pipefail -x {0}
@@ -4436,7 +4436,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
       - name: Configure repository
         env:
           GH_DEBUG: "true"
@@ -4592,7 +4592,7 @@ jobs:
               "metadata": "read",
               "pull_requests": "write"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
       - name: Get branch protection rules
         id: branch_protection
         shell: bash --noprofile --norc -eo pipefail -x {0}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2204,7 +2204,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
 
       - *sortNodeVersions
 
@@ -2861,7 +2861,7 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
 
       - *deleteDraftGitHubRelease
 
@@ -2891,7 +2891,7 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
 
       - *deleteDraftGitHubRelease
 
@@ -3759,7 +3759,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
 
       - *getBranchProtectionRules
       - *isDraftPullRequest
@@ -3908,7 +3908,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
 
       - name: Configure repository
         env:
@@ -4039,7 +4039,7 @@ jobs:
               "metadata": "read",
               "pull_requests": "write"
             }
-          repositories: '[ "${{ github.event.pull_request.head.repo.name }}" ]'
+          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
 
       - *getBranchProtectionRules
       - *isDraftPullRequest


### PR DESCRIPTION
External contributions were using head, the fork, as the repo name when it should have been using the base repo.

Change-type: patch