### PR TITLE
Allow wildcards in the GH release artifact names

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -28,21 +28,18 @@ runs:
         echo "${SECRETS}"
         echo "${VARIABLES}"
 
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}
+    - name: Create artifact
+      id: artifact
+      shell: bash
+      run: |
+        path="$(mktemp)"
+        echo "Hello, World!" > "${path}"
+        echo "path=${path}" >> "${GITHUB_OUTPUT}"
 
     # Test publishing release artifacts to github
     - name: Upload generated flowzone.yml
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4
       with:
         name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}-${{ strategy.job-index }}
-        path: .github/workflows/flowzone.yml
+        path: ${{ steps.artifact.outputs.path }}
         retention-days: 1

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3034,7 +3034,7 @@ jobs:
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
           prerelease: true
-          files: ${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}/*
+          files: ${{ runner.temp }}/gh-release-*/*
   github_finalize:
     name: Finalize GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3262,7 +3262,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392
         with:
-          name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}-${{ strategy.job-index }}
           path: ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.zst
           retention-days: 1
   cargo_finalize:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3098,7 +3098,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
+          name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}-${{ strategy.job-index }}
           path: ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.zst
           retention-days: 1
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2912,8 +2912,8 @@ jobs:
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
           prerelease: true
-          # Publish anything added to with the gh-release name
-          files: ${{ runner.temp }}/gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}/*
+          # Publish anything added to with the gh-release- prefix
+          files: ${{ runner.temp }}/gh-release-*/*
 
   github_finalize:
     name: Finalize GitHub release


### PR DESCRIPTION
Since the release of upload/download artifact v4, artifact names must be unique. As such we must allow additional qualifiers at the end of the artifact name.

Change-type: minor