### PR TITLE
BREAKING: switch to official actions/create-github-app-token

### DIFF
--- a/.github/actions/always/action.yml
+++ b/.github/actions/always/action.yml
@@ -27,14 +27,3 @@ runs:
         echo "${INPUTS}"
         echo "${SECRETS}"
         echo "${VARIABLES}"
-
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/clean/action.yml
+++ b/.github/actions/clean/action.yml
@@ -27,14 +27,3 @@ runs:
         echo "${INPUTS}"
         echo "${SECRETS}"
         echo "${VARIABLES}"
-
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/finalize/action.yml
+++ b/.github/actions/finalize/action.yml
@@ -27,14 +27,3 @@ runs:
         echo "${INPUTS}"
         echo "${SECRETS}"
         echo "${VARIABLES}"
-
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,14 +39,3 @@ runs:
         echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
         echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
         echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -120,25 +120,7 @@ on:
         description: GitHub App id to impersonate
         type: string
         required: false
-        default: ${{ vars.APP_ID || '291899' }}
-      installation_id:
-        description: GitHub App installation id
-        type: string
-        required: false
-        default: ${{ vars.INSTALLATION_ID || '34040165' }}
-      token_scope:
-        description: Ephemeral token scope(s)
-        type: string
-        required: false
-        default: |-
-          {
-            "administration": "write",
-            "contents": "write",
-            "metadata": "read",
-            "packages": "write",
-            "pages": "write",
-            "pull_requests": "read"
-          }
+        default: ${{ vars.FLOWZONE_APP_ID || vars.APP_ID }}
       jobs_timeout_minutes:
         description: Timeout for the job(s).
         type: number
@@ -411,22 +393,14 @@ jobs:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "administration": "write",
-              "contents": "write",
-              "metadata": "read",
-              "pull_requests": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout refs/pull/${{ github.event.number }}/merge
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -632,20 +606,14 @@ jobs:
       node_versions: ${{ steps.node_versions.outputs.json }}
       npm_access: ${{ steps.access.outputs.access }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -767,20 +735,14 @@ jobs:
       docker_bake_json: ${{ steps.docker_bake.outputs.json }}
       docker_test_matrix: ${{ steps.docker_test.outputs.build }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -895,20 +857,14 @@ jobs:
       python_versions: ${{ steps.python_versions.outputs.json }}
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -993,20 +949,14 @@ jobs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -1047,20 +997,14 @@ jobs:
       balena_slugs: ${{ steps.balena_slugs.outputs.build }}
       balena_yml: ${{ steps.balena_yml.outputs.enabled }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -1106,20 +1050,14 @@ jobs:
       custom_publish_matrix: ${{ steps.custom_publish_matrix.outputs.build }}
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.build }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -1192,20 +1130,14 @@ jobs:
     outputs:
       has_readme: ${{ steps.has_readme.outputs.enabled }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -1239,20 +1171,14 @@ jobs:
       stacks: ${{ steps.cloudformation_stacks.outputs.matrix }}
       includes: ${{ steps.cloudformation_stacks.outputs.includes }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -1355,20 +1281,14 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -1539,20 +1459,14 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Sort node versions
         id: node_versions
         env:
@@ -1594,22 +1508,14 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "pages": "write",
-              "contents": "read",
-              "metadata": "read"
-            }
-          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Sort node versions
         id: node_versions
         env:
@@ -1655,20 +1561,14 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2177,20 +2077,14 @@ jobs:
         image: ${{ fromJSON(needs.is_docker.outputs.docker_images) }}
         target: ${{ fromJSON(needs.is_docker.outputs.bake_targets) }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2405,20 +2299,14 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2493,20 +2381,14 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2578,20 +2460,14 @@ jobs:
       matrix:
         python-version: ${{ fromJSON(needs.is_python.outputs.python_versions) }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2664,20 +2540,14 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2738,20 +2608,14 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2793,20 +2657,14 @@ jobs:
       (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
       needs.is_website.result == 'success'
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -2862,21 +2720,14 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "write",
-              "metadata": "read"
-            }
-          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Delete draft GitHub release
         run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
         env:
@@ -2902,21 +2753,14 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "write",
-              "metadata": "read"
-            }
-          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Delete draft GitHub release
         run: gh release delete --yes '${{ github.event.pull_request.head.ref }}' || true
         env:
@@ -2962,20 +2806,14 @@ jobs:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "write",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3046,20 +2884,14 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3124,20 +2956,14 @@ jobs:
       matrix:
         target: ${{ fromJSON(needs.is_cargo.outputs.cargo_targets) }}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3186,20 +3012,14 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3242,16 +3062,14 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3307,16 +3125,14 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3366,16 +3182,14 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3421,16 +3235,14 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3475,16 +3287,14 @@ jobs:
           echo "::error::Custom actions are disabled for external contributors and will be skipped. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3528,20 +3338,14 @@ jobs:
       ATTEMPTS: 5
       TIMEOUT: 3
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -3915,20 +3719,14 @@ jobs:
       KUBE_NAMESPACE: ${{ vars.KUBE_NAMESPACE }}
       LOCK_TIMEOUT: 300s
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -4021,20 +3819,14 @@ jobs:
       KUBE_NAMESPACE: ${{ vars.KUBE_NAMESPACE }}
       LOCK_TIMEOUT: 300s
     steps:
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+      - name: Create GitHub App installation token
+        uses: actions/create-github-app-token@v1.6.2
+        if: inputs.app_id != ''
         id: gh_app_token
         with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: |-
-            {
-              "contents": "read",
-              "metadata": "read"
-            }
+          app-id: ${{ inputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout ${{ needs.versioned_source.outputs.sha }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
@@ -4186,8 +3978,8 @@ jobs:
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {

--- a/README.md
+++ b/README.md
@@ -204,25 +204,7 @@ jobs:
       # GitHub App id to impersonate
       # Type: string
       # Required: false
-      app_id: ${{ vars.APP_ID || '291899' }}
-
-      # GitHub App installation id
-      # Type: string
-      # Required: false
-      installation_id: ${{ vars.INSTALLATION_ID || '34040165' }}
-
-      # Ephemeral token scope(s)
-      # Type: string
-      # Required: false
-      token_scope: >
-        {
-          "administration": "write",
-          "contents": "write",
-          "metadata": "read",
-          "packages": "write",
-          "pages": "write",
-          "pull_requests": "read"
-        }
+      app_id: ${{ vars.FLOWZONE_APP_ID || vars.APP_ID }}
 
       # Timeout for the job(s).
       # Type: number

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -11,22 +11,16 @@
   - &ifPublicRepository
     if: github.event.repository.private != true
 
-  - &getGitHubAppToken # https://github.com/marketplace/actions/github-app-token
-    name: Generate GitHub App installation token
-    uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-    continue-on-error: true
+  - &getGitHubAppToken # https://github.com/actions/create-github-app-token
+    name: Create GitHub App installation token
+    uses: actions/create-github-app-token@v1.6.2
+    if: inputs.app_id != ''
     id: gh_app_token
-    with: &getGitHubAppTokenWith
-      app_id: ${{ inputs.app_id }}
-      installation_retrieval_mode: id
-      installation_retrieval_payload: ${{ inputs.installation_id }}
-      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      # permissions: ${{ inputs.token_scope }}
-      permissions: >-
-        {
-          "contents": "read",
-          "metadata": "read"
-        }
+    with:
+      app-id: ${{ inputs.app_id }}
+      private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      # Create a token for all repositories in the current owner's installation
+      owner: ${{ github.repository_owner }}
 
   # optionally attempt to get AWS login short-lived session credentials over OIDC
   - &configureAWSCredentials # https://github.com/aws-actions/configure-aws-credentials
@@ -812,32 +806,7 @@ on:
         description: "GitHub App id to impersonate"
         type: string
         required: false
-        # https://github.com/organizations/product-os/settings/apps/flowzone-app
-        # https://github.com/organizations/product-os/settings/variables/actions/APP_ID
-        default: "${{ vars.APP_ID || '291899' }}"
-      # not needed if installed on this current org/repo
-      installation_id:
-        description: "GitHub App installation id"
-        type: string
-        required: false
-        # https://github.com/organizations/product-os/settings/installations
-        # https://github.com/organizations/product-os/settings/variables/actions/INSTALLATION_ID
-        default: "${{ vars.INSTALLATION_ID || '34040165' }}"
-      token_scope:
-        description: "Ephemeral token scope(s)"
-        type: string
-        required: false
-        # https://github.com/organizations/product-os/settings/installations/34040165
-        # https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-a-scoped-access-token
-        default: >-
-          {
-            "administration": "write",
-            "contents": "write",
-            "metadata": "read",
-            "packages": "write",
-            "pages": "write",
-            "pull_requests": "read"
-          }
+        default: "${{ vars.FLOWZONE_APP_ID || vars.APP_ID }}"
       jobs_timeout_minutes:
         description: "Timeout for the job(s)."
         type: number
@@ -1066,17 +1035,8 @@ jobs:
       <<: *gitHubCliEnvironment
 
     steps:
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # admin permission is currently required to bypass branch protection rules
-          permissions: >-
-            {
-              "administration": "write",
-              "contents": "write",
-              "metadata": "read",
-              "pull_requests": "read"
-            }
+      # currently requires repo:admin:write to bypass branch protection
+      - *getGitHubAppToken
 
       # Checkout the merge ref for open PRs
       - <<: *checkoutMergeRef
@@ -2100,18 +2060,7 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # need permissions to publish to github pages
-          permissions: >-
-            {
-              "pages": "write",
-              "contents": "read",
-              "metadata": "read"
-            }
-          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
-
+      - *getGitHubAppToken
       - *sortNodeVersions
 
       # https://github.com/dawidd6/action-download-artifact
@@ -2756,19 +2705,11 @@ jobs:
     if: |
       github.event.action == 'closed' &&
       github.event.pull_request.merged == false
-    <<: *rootWorkingDirectory
-    steps:
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # contents:write permissions for managing releases
-          permissions: >-
-            {
-              "contents": "write",
-              "metadata": "read"
-            }
-          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
 
+    <<: *rootWorkingDirectory
+
+    steps:
+      - *getGitHubAppToken
       - *deleteDraftGitHubRelease
 
   github_publish:
@@ -2788,17 +2729,7 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # contents:write permissions for managing releases
-          permissions: >-
-            {
-              "contents": "write",
-              "metadata": "read"
-            }
-          repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'
-
+      - *getGitHubAppToken
       - *deleteDraftGitHubRelease
 
       - name: Download all artifacts
@@ -2841,16 +2772,7 @@ jobs:
     <<: *rootWorkingDirectory
 
     steps:
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # contents:write permissions for managing releases
-          permissions: >-
-            {
-              "contents": "write",
-              "metadata": "read"
-            }
-
+      - *getGitHubAppToken
       - *checkoutVersionedSha
       - *getReleaseNotes
 
@@ -3060,12 +2982,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
+      - *getGitHubAppToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
       - *createLocalRefs
@@ -3107,13 +3024,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
+      - *getGitHubAppToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
       - *createLocalRefs
@@ -3148,13 +3059,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
+      - *getGitHubAppToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
 
@@ -3187,13 +3092,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
+      - *getGitHubAppToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
 
@@ -3224,13 +3123,7 @@ jobs:
 
     steps:
       - *rejectExternalCustomActions
-
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
+      - *getGitHubAppToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
 
@@ -3708,10 +3601,20 @@ jobs:
       BRANCH_PROTECTION_URI: repos/${{ github.repository }}/branches/${{ github.event.pull_request.base.ref }}/protection
 
     steps:
-      - <<: *getGitHubAppToken
+      # https://github.com/marketplace/actions/github-app-token
+      # FIXME: switch to actions/create-github-app-token as soon as custom permissions are supported
+      # https://github.com/actions/create-github-app-token/issues/3
+      - name: Generate GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        continue-on-error: true
+        id: gh_app_token
         with:
-          <<: *getGitHubAppTokenWith
-          # avoid providing any permissions here that are able to bypass branch protections!
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          # DO NOT include any permissions here that would bypass branch protections!
+          # e.g. admin:write would merge PRs before required checks have passed
           permissions: >-
             {
               "administration": "read",


### PR DESCRIPTION
This deprecates support for the token_scope input for custom actions which wasn't used anywhere anyway.

It also deprecates support for the installation_id input as the installation will be derived from the repo owner.

The old token action is still in use to enable auto-merge where custom token scopes were still required. This will be removed in the future when custom permissions are supported by the new action.

See: https://github.com/tibdex/github-app-token/issues/99
See: https://github.com/actions/create-github-app-token/issues/3
Resolves: https://github.com/product-os/flowzone/issues/790

Change-type: major