### PR TITLE
Only install python when poetry projects are detected

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1044,6 +1044,7 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c
         with:
           python-version: ${{ env.SUPPORTED_VERSIONS }}
+        if: steps.python_poetry.outputs.enabled == 'true'
       - name: Setup poetry
         if: steps.setup-python.outputs.python-version != ''
         uses: abatilo/actions-poetry@192395c0d10c082a7c62294ab5d9a9de40e48974

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1657,6 +1657,7 @@ jobs:
           fi
 
       - <<: *setupPython
+        if: steps.python_poetry.outputs.enabled == 'true'
         with:
           python-version: ${{ env.SUPPORTED_VERSIONS }}
 


### PR DESCRIPTION
This should avoid failures where compatible python releases are not available on some os/arch combinations but the project is not a python composition anyway.

Change-type: patch
See: https://github.com/balena-io/environment-production/actions/runs/7278860684/job/19833988183?pr=1902