### PR TITLE
Remove deprecated tests_run_on input

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -213,11 +213,6 @@ on:
         type: number
         required: false
         default: 1
-      tests_run_on:
-        description: Deprecated, use 'custom_runs_on' input instead.
-        type: string
-        required: false
-        default: ""
       runs_on:
         description: JSON array of runner label strings for default jobs.
         type: string
@@ -3220,7 +3215,7 @@ jobs:
       fail-fast: false
       matrix:
         value: ${{ fromJSON(needs.is_custom.outputs.custom_test_matrix) }}
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     steps:
       - name: Reject external custom actions
         if: |
@@ -3286,7 +3281,7 @@ jobs:
       fail-fast: false
       matrix:
         value: ${{ fromJSON(needs.is_custom.outputs.custom_publish_matrix) }}
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     steps:
       - name: Reject external custom actions
         if: |
@@ -3346,7 +3341,7 @@ jobs:
       fail-fast: false
       matrix:
         value: ${{ fromJSON(needs.is_custom.outputs.custom_finalize_matrix) }}
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     steps:
       - name: Reject external custom actions
         if: |
@@ -3394,7 +3389,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_custom
@@ -3445,7 +3440,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - custom_test

--- a/README.md
+++ b/README.md
@@ -299,11 +299,6 @@ jobs:
       # Required: false
       checkout_fetch_depth: 1
 
-      # Deprecated, use 'custom_runs_on' input instead.
-      # Type: string
-      # Required: false
-      tests_run_on: 
-
       # JSON array of runner label strings for default jobs.
       # Type: string
       # Required: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -844,11 +844,6 @@ on:
         type: number
         required: false
         default: 1
-      tests_run_on:
-        description: "Deprecated, use 'custom_runs_on' input instead."
-        type: string
-        required: false
-        default: ""
       runs_on:
         description: "JSON array of runner label strings for default jobs."
         type: string
@@ -2987,7 +2982,7 @@ jobs:
       fail-fast: false
       matrix:
         value: ${{ fromJSON(needs.is_custom.outputs.custom_test_matrix) }}
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
 
     steps:
       - *rejectExternalCustomActions
@@ -3035,7 +3030,7 @@ jobs:
       fail-fast: false
       matrix:
         value: ${{ fromJSON(needs.is_custom.outputs.custom_publish_matrix) }}
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
 
     steps:
       - *rejectExternalCustomActions
@@ -3077,7 +3072,7 @@ jobs:
       fail-fast: false
       matrix:
         value: ${{ fromJSON(needs.is_custom.outputs.custom_finalize_matrix) }}
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
 
     steps:
       - *rejectExternalCustomActions
@@ -3109,7 +3104,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - is_custom
@@ -3143,7 +3138,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ${{ fromJSON(inputs.tests_run_on || inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
+        os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - custom_test


### PR DESCRIPTION
The `custom_runs_on` array supports multiple runner labels in nested arrays.

The new input also allows the use of self-hosted runners as they require multiple labels to identify.

Change-type: major