### PR TITLE
Ignore KVM setup failure

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1884,6 +1884,7 @@ jobs:
           zstd -v ${DOCKER_TAR}
       - name: Enable KVM group perms
         if: contains(matrix.runs_on,'ubuntu-latest') || contains(matrix.runs_on,'ubuntu-22.04')
+        continue-on-error: true
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2204,6 +2204,7 @@ jobs:
       # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
       - name: Enable KVM group perms
         if: contains(matrix.runs_on,'ubuntu-latest') || contains(matrix.runs_on,'ubuntu-22.04')
+        continue-on-error: true
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules


### PR DESCRIPTION
We've seen cases where the KVM device is not found on ubuntu-22.04 runners, so continue on error for now.

Failed to open the device 'kvm': No such file or directory

Change-type: patch