### PR TITLE
Add write permission for npm run docs finalize step

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1689,7 +1689,7 @@ jobs:
           permissions: |-
             {
               "pages": "write",
-              "contents": "read",
+              "contents": "write",
               "metadata": "read"
             }
           repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2039,11 +2039,11 @@ jobs:
       - <<: *getGitHubAppToken
         with:
           <<: *getGitHubAppTokenWith
-          # need permissions to publish to github pages
+          # need permissions to push to docs branch and publish to github pages
           permissions: >-
             {
               "pages": "write",
-              "contents": "read",
+              "contents": "write",
               "metadata": "read"
             }
           repositories: '[ "${{ github.event.pull_request.base.repo.name }}" ]'


### PR DESCRIPTION
Npm run docs finalize step has been failing due to lack of relevant permissions. Fixed that to generate docs from `npm run docs` command again. 

Zulip: https://balena.zulipchat.com/#narrow/stream/348930-balena-io.2Fflowzone/topic/Permission.20denied.20when.20running.20npm.20run.20docs

Change-type: patch
Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
