### PR TITLE
Add nodejs 21, remove nodejs 12/14 from the nodejs test matrix

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -661,30 +661,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 12.x
-        if: steps.npm.outputs.enabled == 'true'
-      - name: Check engine
-        if: steps.npm.outputs.enabled == 'true'
-        run: |
-          if npx -q -y -- check-engine
-          then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["12.x"]')" >> $GITHUB_ENV
-          fi
-      - name: Setup Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: 14.x
-        if: steps.npm.outputs.enabled == 'true'
-      - name: Check engine
-        if: steps.npm.outputs.enabled == 'true'
-        run: |
-          if npx -q -y -- check-engine
-          then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["14.x"]')" >> $GITHUB_ENV
-          fi
-      - name: Setup Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
           node-version: 16.x
         if: steps.npm.outputs.enabled == 'true'
       - name: Check engine

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -694,6 +694,18 @@ jobs:
           then
             echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["20.x"]')" >> $GITHUB_ENV
           fi
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version: 21.x
+        if: steps.npm.outputs.enabled == 'true'
+      - name: Check engine
+        if: steps.npm.outputs.enabled == 'true'
+        run: |
+          if npx -q -y -- check-engine
+          then
+            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["21.x"]')" >> $GITHUB_ENV
+          fi
       - name: Set Node.js versions
         if: steps.npm.outputs.enabled == 'true'
         id: node_versions

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1259,32 +1259,6 @@ jobs:
       - <<: *setupNode
         if: steps.npm.outputs.enabled == 'true'
         with:
-          node-version: 12.x
-
-      - name: Check engine
-        if: steps.npm.outputs.enabled == 'true'
-        run: |
-          if npx -q -y -- check-engine
-          then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["12.x"]')" >> $GITHUB_ENV
-          fi
-
-      - <<: *setupNode
-        if: steps.npm.outputs.enabled == 'true'
-        with:
-          node-version: 14.x
-
-      - name: Check engine
-        if: steps.npm.outputs.enabled == 'true'
-        run: |
-          if npx -q -y -- check-engine
-          then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["14.x"]')" >> $GITHUB_ENV
-          fi
-
-      - <<: *setupNode
-        if: steps.npm.outputs.enabled == 'true'
-        with:
           node-version: 16.x
 
       - name: Check engine

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1295,6 +1295,19 @@ jobs:
             echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["20.x"]')" >> $GITHUB_ENV
           fi
 
+      - <<: *setupNode
+        if: steps.npm.outputs.enabled == 'true'
+        with:
+          node-version: 21.x
+
+      - name: Check engine
+        if: steps.npm.outputs.enabled == 'true'
+        run: |
+          if npx -q -y -- check-engine
+          then
+            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["21.x"]')" >> $GITHUB_ENV
+          fi
+
       # default to the current LTS version if none were matched
       # by the engine checks above
       - name: Set Node.js versions


### PR DESCRIPTION
Remove nodejs 12 and 14 versions from the potential nodejs test matrix
as those versions have been EOL for a significant period and continuing to
include them in the potential test matrix provides negligible benefit.
We continue to include nodejs 16 however even though it is also EOL as
of 2023-09-11

Add nodejs 21 as it is the latest version and allows for testing if we support the
latest nodejs version and subsequently whether we are likely to support
the next LTS release out of the box, and if not apply fixes in the
meantime

Change-type: patch