### PR TITLE
Pass the build target when invoking clippy

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3175,7 +3175,7 @@ jobs:
       - name: Install cross
         run: cargo install cross --locked
       - name: Lint with clippy
-        run: cross -v clippy --all-targets --all-features -- -D warnings
+        run: cross -v clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
       - name: Run tests for toolchain ${{ matrix.target }}
         run: cross -v test --target ${{ matrix.target }}
       - name: Generate metadata

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2865,7 +2865,7 @@ jobs:
         run: cargo install cross --locked
 
       - name: Lint with clippy
-        run: cross -v clippy --all-targets --all-features -- -D warnings
+        run: cross -v clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
 
       - name: Run tests for toolchain ${{ matrix.target }}
         run: cross -v test --target ${{ matrix.target }}


### PR DESCRIPTION
The motivation for this change was to allow us to properly request the C
Runtime (CRT) to be statically linked.

In summary, each target defaults to either static or dynamic CRT
linking, but we can request static linking regardless of defaults by
using the `crt-static` target feature. The usual way to achieve that is
setting the `RUSTFLAGS="-C target-feature=+crt-static"` environment
variable. (See
https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes)

Rust projects using Flowzone can already do that by using `cross` for
building and setting the environment variable in a `Cross.toml` file
(see
https://github.com/cross-rs/cross/blob/main/docs/environment_variables.md#environment-variable-passthrough).

So far so good. The problem is, the `--target` option is required when
using `crt-static`, and Flowzone was not passing it to `cargo clippy`.
(See
https://msfjarvis.dev/posts/building-static-rust-binaries-for-linux/ for
an overview of the issue, and
https://github.com/rust-lang/rust/issues/78210#issuecomment-714776007
for some more specific details.)