### PR TITLE
Do not fail releases on unmatched files

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3034,17 +3034,8 @@ jobs:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Download all artifacts
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
-        id: download
         with:
           path: ${{ runner.temp }}/artifacts
-      - name: Filter artifacts
-        id: filter
-        run: |
-          files="$(ls -1 ${{ runner.temp }}/artifacts/gh-release-*/* || true)"
-          DELIMITER=$(echo $RANDOM | md5sum | head -c 32)
-          echo "files<<${DELIMITER}" >> $GITHUB_OUTPUT
-          echo "${files}" >> $GITHUB_OUTPUT
-          echo "${DELIMITER}" >> $GITHUB_OUTPUT
       - name: Publish draft release
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
@@ -3053,8 +3044,8 @@ jobs:
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
           prerelease: true
-          files: |
-            ${{ steps.filter.outputs.files }}
+          files: ${{ runner.temp }}/artifacts/gh-release-*/*
+          fail_on_unmatched_files: false
   github_finalize:
     name: Finalize GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2747,19 +2747,8 @@ jobs:
 
       - name: Download all artifacts
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
-        id: download
         with:
           path: ${{ runner.temp }}/artifacts
-
-      # Publish anything with the gh-release- prefix
-      - name: Filter artifacts
-        id: filter
-        run: |
-          files="$(ls -1 ${{ runner.temp }}/artifacts/gh-release-*/* || true)"
-          DELIMITER=$(echo $RANDOM | md5sum | head -c 32)
-          echo "files<<${DELIMITER}" >> $GITHUB_OUTPUT
-          echo "${files}" >> $GITHUB_OUTPUT
-          echo "${DELIMITER}" >> $GITHUB_OUTPUT
 
       # https://github.com/softprops/action-gh-release
       - name: Publish draft release
@@ -2770,8 +2759,8 @@ jobs:
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
           prerelease: true
-          files: |
-            ${{ steps.filter.outputs.files }}
+          files: ${{ runner.temp }}/artifacts/gh-release-*/*
+          fail_on_unmatched_files: false
 
   github_finalize:
     name: Finalize GitHub release


### PR DESCRIPTION
The default behaviour was fixed upstream via
https://github.com/softprops/action-gh-release/pull/425/commits/f4bd9669044d0fa04ba1b4b0785e05e2b6055d66

Change-type: patch