### PR TITLE
Share max buildkit cache across all branches

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1973,8 +1973,8 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.platform=${{ matrix.platform }}
-            *.cache-to=type=gha,mode=min,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
-            *.cache-from=type=gha,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-to=type=gha,mode=max,scope=buildkit
+            *.cache-from=type=gha,scope=buildkit
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[0] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[1] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[2] || ''}}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2195,8 +2195,8 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.platform=${{ matrix.platform }}
-            *.cache-to=type=gha,mode=min,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
-            *.cache-from=type=gha,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-to=type=gha,mode=max,scope=buildkit
+            *.cache-from=type=gha,scope=buildkit
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[0] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[1] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[2] || ''}}


### PR DESCRIPTION
Increase the cases where we can reuse the cache from the target branch in a new branch.

The cache size will increase up to 10GB before
old layers start getting removed.

Change-type: minor