### PR TITLE
Fix missing dependency on versioned source

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2983,6 +2983,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - versioned_source
       - npm_publish
       - python_publish
       - cargo_publish

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2709,6 +2709,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - versioned_source
       - npm_publish
       - python_publish
       - cargo_publish


### PR DESCRIPTION
Without this dependency, we were cloning the default
sha in the checkoutVersionedSha sha step. It was a coincidence
that this worked for internal PRs.

It became obvious when I saw the step in the workflow reported
as "Checkout" instead of "Checkout abc123..."