### PR TITLE
Remove git hash from ephemeral artifact names

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -29,17 +29,14 @@ runs:
         echo "${VARIABLES}"
 
     - name: Create artifact
-      id: artifact
       shell: bash
       run: |
-        path="$(mktemp)"
-        echo "Hello, World!" > "${path}"
-        echo "path=${path}" >> "${GITHUB_OUTPUT}"
+        echo "Hello, World!" > "${{ runner.temp }}/hello.world.${{ strategy.job-index }}"
 
     # Test publishing release artifacts to github
-    - name: Upload generated flowzone.yml
+    - name: Upload artifact
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
       with:
-        name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}-${{ strategy.job-index }}
-        path: ${{ steps.artifact.outputs.path }}
+        name: gh-release-custom-${{ strategy.job-index }}
+        path: ${{ runner.temp }}/hello.world.${{ strategy.job-index }}
         retention-days: 1

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2059,7 +2059,7 @@ jobs:
         if: join(fromJSON(needs.is_docker.outputs.docker_images)) != ''
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
-          name: docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}-${{ matrix.platform_slug }}
+          name: docker-${{ matrix.target_slug }}-${{ matrix.platform_slug }}
           path: ${{ env.DOCKER_TAR }}.zst
           retention-days: 1
   docker_publish:
@@ -2170,10 +2170,10 @@ jobs:
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
         with:
           path: ${{ runner.temp }}
-          pattern: docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}-*
+          pattern: docker-${{ matrix.target_slug }}-*
       - name: Decompress artifacts
         env:
-          PATH_PREFIX: ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}
+          PATH_PREFIX: ${{ runner.temp }}/docker-${{ matrix.target_slug }}
         run: |
           for platform in ${{ matrix.platform_slugs }}
           do
@@ -2181,7 +2181,7 @@ jobs:
           done
       - name: Create local manifest
         env:
-          PATH_PREFIX: ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}
+          PATH_PREFIX: ${{ runner.temp }}/docker-${{ matrix.target_slug }}
         run: |
           for platform in ${{ matrix.platform_slugs }}
           do
@@ -3063,7 +3063,7 @@ jobs:
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
           prerelease: true
-          files: ${{ runner.temp }}/artifacts/gh-release-*/*
+          files: ${{ runner.temp }}/artifacts/gh-release*/*
           fail_on_unmatched_files: false
           body: ${{ steps.release_notes.outputs.note }}
           body_path: ${{ steps.release_notes.outputs.file }}
@@ -3304,7 +3304,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
         with:
-          name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}-${{ strategy.job-index }}
+          name: gh-release-${{ matrix.target }}
           path: ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.gz
           retention-days: 1
   cargo_finalize:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2302,7 +2302,7 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           # this docker-{sha}-{target}-{platform} naming scheme is used by docker_publish to find the correct artifact
-          name: docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}-${{ matrix.platform_slug }}
+          name: docker-${{ matrix.target_slug }}-${{ matrix.platform_slug }}
           path: ${{ env.DOCKER_TAR }}.zst
           retention-days: 1
 
@@ -2354,11 +2354,11 @@ jobs:
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           path: ${{ runner.temp }}
-          pattern: docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}-*
+          pattern: docker-${{ matrix.target_slug }}-*
 
       - name: Decompress artifacts
         env:
-          PATH_PREFIX: ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}
+          PATH_PREFIX: ${{ runner.temp }}/docker-${{ matrix.target_slug }}
         run: |
           for platform in ${{ matrix.platform_slugs }}
           do
@@ -2367,7 +2367,7 @@ jobs:
 
       - name: Create local manifest
         env:
-          PATH_PREFIX: ${{ runner.temp }}/docker-${{ github.event.pull_request.head.sha }}-${{ matrix.target_slug }}
+          PATH_PREFIX: ${{ runner.temp }}/docker-${{ matrix.target_slug }}
         run: |
           for platform in ${{ matrix.platform_slugs }}
           do
@@ -2820,7 +2820,7 @@ jobs:
           tag_name: ${{ github.event.pull_request.head.ref }}
           draft: true
           prerelease: true
-          files: ${{ runner.temp }}/artifacts/gh-release-*/*
+          files: ${{ runner.temp }}/artifacts/gh-release*/*
           fail_on_unmatched_files: false
           body: ${{ steps.release_notes.outputs.note }}
           body_path: ${{ steps.release_notes.outputs.file }}
@@ -3010,7 +3010,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: gh-release-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}-${{ strategy.job-index }}
+          name: gh-release-${{ matrix.target }}
           path: ${{ needs.cargo_test.outputs.package }}-${{ matrix.target }}.tar.gz
           retention-days: 1
 


### PR DESCRIPTION
These artifacts only need to exist until the next
job in the current workflow run, and have no need
for uniqeness as they are already tied to the run
of the workflow.

Change-type: patch