### PR TITLE
Ignore custom runner labels in actionlint

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -623,7 +623,7 @@ jobs:
       - name: Check workflow files
         uses: docker://rhysd/actionlint:1.6.27
         with:
-          args: -color -shellcheck=
+          args: -color -ignore="custom label for self-hosted runner" -shellcheck=
   is_npm:
     name: Is npm
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1208,8 +1208,9 @@ jobs:
         # https://github.com/rhysd/actionlint/releases
         uses: docker://rhysd/actionlint:1.6.27
         with:
-          # disable shellcheck for now
-          args: -color -shellcheck=
+          # ignore errors on unkown runner custom runner labels
+          # ignore shellcheck for now
+          args: -color -ignore="custom label for self-hosted runner" -shellcheck=
 
   # check if the repository has a package.json file and which engine versions are supported
   is_npm:


### PR DESCRIPTION
Otherwise we get errors when using labels like "vm" or "actuated".

See: https://github.com/balena-io/e2e/actions/runs/8649345888/job/23715409080?pr=647
Change-type: patch