### PR TITLE
Fix version bump on merging

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -574,7 +574,7 @@ jobs:
         if: github.event.pull_request.merged == true && steps.create_commit.outputs.sha != ''
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          REF: /repos/$GH_REPO/git/refs/heads/${{ github.base_ref }}
+          REF: /repos/${{ github.repository }}/git/refs/heads/${{ github.base_ref }}
           SHA: ${{ steps.create_commit.outputs.sha }}
         run: |
           gh api \
@@ -726,7 +726,7 @@ jobs:
           github.event.pull_request.merged == true
           && needs.versioned_source.outputs.commit_sha != ''
         env:
-          REF: /repos/$GH_REPO/git/refs/tags/production-${{ steps.timestamp.outputs.datetime }}
+          REF: /repos/${{ github.repository }}/git/refs/tags/production-${{ steps.timestamp.outputs.datetime }}
           SHA: ${{ needs.versioned_source.outputs.commit_sha }}
         run: |
           gh api \

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -116,7 +116,7 @@
     if: github.event.pull_request.merged == true && steps.create_commit.outputs.sha != ''
     env:
       GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      REF: '/repos/$GH_REPO/git/refs/heads/${{ github.base_ref }}'
+      REF: '/repos/${{ github.repository }}/git/refs/heads/${{ github.base_ref }}'
       SHA: ${{ steps.create_commit.outputs.sha }}
     run: |
       gh api \
@@ -1330,7 +1330,7 @@ jobs:
           github.event.pull_request.merged == true
           && needs.versioned_source.outputs.commit_sha != ''
         env:
-          REF: '/repos/$GH_REPO/git/refs/tags/production-${{ steps.timestamp.outputs.datetime }}'
+          REF: '/repos/${{ github.repository }}/git/refs/tags/production-${{ steps.timestamp.outputs.datetime }}'
           SHA: ${{ needs.versioned_source.outputs.commit_sha }}
 
       - name: Renovate release notes


### PR DESCRIPTION
When the github url was moved into the yaml env var declarations the $GH_REPO env var substitution that was previously being handled by bash is no longer being performed which means the incorrect url is being used to attempt the update. This change switches to the gh action interpolation for the repository which will restore the url to its previous state.

Change-type: patch