### PR TITLE
Increase default max parallel matrix jobs to 20

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -283,7 +283,7 @@ on:
         description: Set a max parallel value for ALL matrix strategy jobs.
         type: number
         required: false
-        default: 8
+        default: 20
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: ${{ github.event.action == 'synchronize' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,4 +56,3 @@ jobs:
           "environment": ["test"]
         }
       release_notes: true
-      max_parallel: 4

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ jobs:
       # Set a max parallel value for ALL matrix strategy jobs.
       # Type: number
       # Required: false
-      max_parallel: 8
+      max_parallel: 20
 
 
 ```

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -997,7 +997,7 @@ on:
         description: "Set a max parallel value for ALL matrix strategy jobs."
         type: number
         required: false
-        default: 8
+        default: 20
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:


### PR DESCRIPTION
According to the team at Actuated, and observed in our job queue, setting a max parallel matrix value DOES NOT prevent a runner from being assigned to the job. It takes the runner but is prevented from executing the steps if the max value is reached.

So for now we will set the default max parallel jobs to the same global 20 concurrent max in our Actuated plan.

This will prevent jobs from taking a runner slot only to be stopped from execution by the GH max parallel setting.

Change-type: patch