### PR TITLE
don't clobber edited comments

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -695,8 +695,17 @@ jobs:
           comment-author: flowzone-app[bot]
           body-includes: "#release-notes"
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
+        id: find_edited_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: flowzone-app[bot]
+          body-regex: ^\* \[only keep the important and rephrase\]$
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
-        if: steps.format_release_notes.outputs.text != ''
+        if: |
+          steps.format_release_notes.outputs.text != ''
+          && steps.find_edited_comment.outputs.comment-id != ''
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1335,8 +1335,18 @@ jobs:
           body-includes: "#release-notes"
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
+      - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        id: find_edited_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "flowzone-app[bot]"
+          body-regex: '^\* \[only keep the important and rephrase\]$'
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
-        if: steps.format_release_notes.outputs.text != ''
+        if: |
+          steps.format_release_notes.outputs.text != ''
+          && steps.find_edited_comment.outputs.comment-id != ''
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
* otherwise on every PR sync, manually edited release notes will be lost

change-type: patch