### PR TITLE
check if the comment has been edited before sending msg

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -782,7 +782,9 @@ jobs:
           vars.ZULIP_BOT_EMAIL != '' &&
           vars.ZULIP_API_URL != '' &&
           steps.find_comment.outcome == 'success' &&
-          steps.find_comment.outputs.comment-body != ''
+          steps.find_comment.outputs.comment-body != '' &&
+          steps.find_edited_comment.outcome == 'success' &&
+          steps.find_edited_comment.outputs.comment-id == ''
         continue-on-error: true
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1407,7 +1407,9 @@ jobs:
           vars.ZULIP_BOT_EMAIL != '' &&
           vars.ZULIP_API_URL != '' &&
           steps.find_comment.outcome == 'success' &&
-          steps.find_comment.outputs.comment-body != ''
+          steps.find_comment.outputs.comment-body != '' &&
+          steps.find_edited_comment.outcome == 'success' &&
+          steps.find_edited_comment.outputs.comment-id == ''
         continue-on-error: true
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}


### PR DESCRIPTION
..  check if `find_edited_comment` step resolves to a blank string before sending a Zulip message; if the placeholder text has been removed this step evaluates to `''`. 

fixes: https://github.com/balena-io/environment-production/actions/runs/9036814183/job/24834604257