### PR TITLE
Use PR body to build GitHub/Balena release notes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -622,6 +622,8 @@ jobs:
       run:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
+    outputs:
+      body: ${{ steps.format_release_notes.outputs.body }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -652,17 +654,17 @@ jobs:
         run: |
           set -x
 
-          # if Renovate did this, extract its release notes from pull request body and
-          # massage until they resemble balena-io-modules/balena-deploy-request output
-          renovate_bot="$(gh pr view ${{ github.event.pull_request.number }} --json author --jq \
-            'select((.author.is_bot==true) and (.author.login | contains("renovate"))).author.login')"
+          pr_title="$(gh pr view ${{ github.event.pull_request.number }} --json title --jq .title)"
+          raw_body="$(gh pr view ${{ github.event.pull_request.number }} --json body --jq .body)"
 
-          if [[ -n "$renovate_bot" ]]; then
-              pr_title="$(gh pr view ${{ github.event.pull_request.number }} --json title --jq .title)"
+          if [[ -n "$pr_title" ]]; then
 
-              raw_body="$(gh pr view ${{ github.event.pull_request.number }} --json body --jq .body)"
+              # if Renovate did this, extract its release notes from pull request body and
+              # massage until they resemble balena-io-modules/balena-deploy-request output
+              renovate_bot="$(gh pr view ${{ github.event.pull_request.number }} --json author --jq \
+                  'select((.author.is_bot==true) and (.author.login | contains("renovate"))).author.login')"
 
-              if [[ -n "$pr_title" ]] && [[ "$raw_body" =~ '### Release Notes' ]]; then
+              if [[ -n "$renovate_bot" ]] && [[ "$raw_body" =~ '### Release Notes' ]]; then
                   pr_body="$(echo "${raw_body}" \
                     | sed -n '/^### Release Notes$/,/^---$/p' \
                     | sed "s|^### Release Notes$||g" \
@@ -676,24 +678,46 @@ jobs:
                     | sed 's|^</summary>$||g' \
                     | sed 1d)"
 
+                  # Prepare the release notes
+                  release_notes="$(printf '## %s\n\n### Notable changes\n\n%s\n\n%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
+
+                  # Prepare the comment body
                   notable_changes="$(echo "${notable_changes}" | sed -E 's|^|* |g')"
                   notable_changes="$(printf 'Notable changes\n* [only keep the important and rephrase]\n%s' "${notable_changes}")"
 
                   # https://zulip.com/help/format-your-message-using-markdown
                   # shortnames: https://pygments.org/docs/lexers/
-                  release_notes="$(printf '#release-notes %s\n\n%s%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
+                  release_notes_comment="$(printf '#release-notes %s\n\n%s%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
+              fi
 
-                  if [[ -n "$release_notes" ]]; then
-                      EOF="$(openssl rand -hex 16)"
-                      echo "text<<$EOF" >> $GITHUB_OUTPUT
-                      echo "${release_notes}" >> $GITHUB_OUTPUT
-                      echo "$EOF" >> $GITHUB_OUTPUT
-                  fi
+              title_pattern="## (R|r)elease (N|n)otes"
+              if [[ "$raw_body" =~ $title_pattern ]]; then
+                # Find a section `## Release notes` and use that as the release notes body
+                release_notes_body="$(echo "${raw_body}" \
+                    | sed -n '/^## Release Notes/I,/^## /p' \
+                    | sed '/^## /d' \
+                    | sed -e :a -e '/./,$!d;/^\n*$/{$d;N;};/\n$/ba')" # Remove starting/trailing empty lines
+
+                release_notes="$(printf '## %s\n%s' "${pr_title}" "${release_notes_body}")"
+              fi
+
+              if [[ -n "$release_notes" ]]; then
+                  EOF="$(openssl rand -hex 16)"
+                  echo "body<<$EOF" >> $GITHUB_OUTPUT
+                  echo "${release_notes}" >> $GITHUB_OUTPUT
+                  echo "$EOF" >> $GITHUB_OUTPUT
+              fi
+
+              if [[ -n "$release_notes_comment" ]]; then
+                  EOF="$(openssl rand -hex 16)"
+                  echo "comment<<$EOF" >> $GITHUB_OUTPUT
+                  echo "${release_notes_comment}" >> $GITHUB_OUTPUT
+                  echo "$EOF" >> $GITHUB_OUTPUT
               fi
           fi
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: find_comment
-        if: steps.format_release_notes.outputs.text != ''
+        if: steps.format_release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: flowzone-app[bot]
@@ -701,7 +725,7 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: find_edited_comment
-        if: steps.format_release_notes.outputs.text != ''
+        if: steps.format_release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: flowzone-app[bot]
@@ -709,7 +733,7 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: |
-          steps.format_release_notes.outputs.text != '' &&
+          steps.format_release_notes.outputs.comment != '' &&
           (
             (
               steps.find_comment.outputs.comment-id == '' &&
@@ -724,7 +748,7 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ${{ steps.format_release_notes.outputs.text }}
+            ${{ steps.format_release_notes.outputs.comment }}
           edit-mode: replace
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           reactions: eyes
@@ -2853,15 +2877,22 @@ jobs:
         id: release_notes
         env:
           look_back: 1
+          user_defined: ""
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
 
+          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
-          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="${changelog}"
+          if [[ -n "${user_defined}" ]]; then
+            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
+          fi
+
           EOF="$(openssl rand -hex 16)"
           echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
           echo "${release_notes}" >> "${GITHUB_OUTPUT}"
@@ -2941,10 +2972,16 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
 
+          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
-          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="${changelog}"
+          if [[ -n "${user_defined}" ]]; then
+            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
+          fi
+
           EOF="$(openssl rand -hex 16)"
           echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
           echo "${release_notes}" >> "${GITHUB_OUTPUT}"
@@ -3303,6 +3340,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - versioned_source
+      - release_notes
       - npm_publish
       - python_publish
       - cargo_publish
@@ -3347,16 +3385,23 @@ jobs:
       - name: Generate short release note
         id: release_notes
         env:
+          user_defined: ${{ needs.release_notes.outputs.body }}
           look_back: 1
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
 
+          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
-          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="${changelog}"
+          if [[ -n "${user_defined}" ]]; then
+            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
+          fi
+
           EOF="$(openssl rand -hex 16)"
           echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
           echo "${release_notes}" >> "${GITHUB_OUTPUT}"
@@ -3386,6 +3431,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - versioned_source
+      - release_notes
     if: |
       (
         (
@@ -3425,16 +3471,23 @@ jobs:
       - name: Generate short release note
         id: release_notes
         env:
+          user_defined: ${{ needs.release_notes.outputs.body }}
           look_back: 2
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
 
+          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
-          release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="${changelog}"
+          if [[ -n "${user_defined}" ]]; then
+            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
+          fi
+
           EOF="$(openssl rand -hex 16)"
           echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
           echo "${release_notes}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2838,6 +2838,7 @@ jobs:
       - cargo_test
       - python_test
       - versioned_source
+      - release_notes
     if: |
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
@@ -2877,7 +2878,7 @@ jobs:
         id: release_notes
         env:
           look_back: 1
-          user_defined: ""
+          user_defined: ${{ needs.release_notes.outputs.body }}
         run: |
           set -ea
           # prevent git from existing with 141
@@ -2930,6 +2931,7 @@ jobs:
     needs:
       - is_balena
       - versioned_source
+      - release_notes
     if: |
       github.event.pull_request.merged == true || github.event_name == 'push'
     strategy:
@@ -2967,6 +2969,7 @@ jobs:
         id: release_notes
         env:
           look_back: 2
+          user_defined: ${{ needs.release_notes.outputs.body }}
         run: |
           set -ea
           # prevent git from existing with 141

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1267,6 +1267,9 @@ jobs:
 
     <<: *rootWorkingDirectory
 
+    outputs:
+      body: ${{ steps.format_release_notes.outputs.body }}
+
     env:
       <<: *gitHubCliEnvironment
 
@@ -1290,17 +1293,17 @@ jobs:
         run: |
           set -x
 
-          # if Renovate did this, extract its release notes from pull request body and
-          # massage until they resemble balena-io-modules/balena-deploy-request output
-          renovate_bot="$(gh pr view ${{ github.event.pull_request.number }} --json author --jq \
-            'select((.author.is_bot==true) and (.author.login | contains("renovate"))).author.login')"
+          pr_title="$(gh pr view ${{ github.event.pull_request.number }} --json title --jq .title)"
+          raw_body="$(gh pr view ${{ github.event.pull_request.number }} --json body --jq .body)"
 
-          if [[ -n "$renovate_bot" ]]; then
-              pr_title="$(gh pr view ${{ github.event.pull_request.number }} --json title --jq .title)"
+          if [[ -n "$pr_title" ]]; then
 
-              raw_body="$(gh pr view ${{ github.event.pull_request.number }} --json body --jq .body)"
+              # if Renovate did this, extract its release notes from pull request body and
+              # massage until they resemble balena-io-modules/balena-deploy-request output
+              renovate_bot="$(gh pr view ${{ github.event.pull_request.number }} --json author --jq \
+                  'select((.author.is_bot==true) and (.author.login | contains("renovate"))).author.login')"
 
-              if [[ -n "$pr_title" ]] && [[ "$raw_body" =~ '### Release Notes' ]]; then
+              if [[ -n "$renovate_bot" ]] && [[ "$raw_body" =~ '### Release Notes' ]]; then
                   pr_body="$(echo "${raw_body}" \
                     | sed -n '/^### Release Notes$/,/^---$/p' \
                     | sed "s|^### Release Notes$||g" \
@@ -1314,25 +1317,47 @@ jobs:
                     | sed 's|^</summary>$||g' \
                     | sed 1d)"
 
+                  # Prepare the release notes
+                  release_notes="$(printf '## %s\n\n### Notable changes\n\n%s\n\n%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
+
+                  # Prepare the comment body
                   notable_changes="$(echo "${notable_changes}" | sed -E 's|^|* |g')"
                   notable_changes="$(printf 'Notable changes\n* [only keep the important and rephrase]\n%s' "${notable_changes}")"
 
                   # https://zulip.com/help/format-your-message-using-markdown
                   # shortnames: https://pygments.org/docs/lexers/
-                  release_notes="$(printf '#release-notes %s\n\n%s%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
+                  release_notes_comment="$(printf '#release-notes %s\n\n%s%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
+              fi
 
-                  if [[ -n "$release_notes" ]]; then
-                      EOF="$(openssl rand -hex 16)"
-                      echo "text<<$EOF" >> $GITHUB_OUTPUT
-                      echo "${release_notes}" >> $GITHUB_OUTPUT
-                      echo "$EOF" >> $GITHUB_OUTPUT
-                  fi
+              title_pattern="## (R|r)elease (N|n)otes"
+              if [[ "$raw_body" =~ $title_pattern ]]; then
+                # Find a section `## Release notes` and use that as the release notes body
+                release_notes_body="$(echo "${raw_body}" \
+                    | sed -n '/^## Release Notes/I,/^## /p' \
+                    | sed '/^## /d' \
+                    | sed -e :a -e '/./,$!d;/^\n*$/{$d;N;};/\n$/ba')" # Remove starting/trailing empty lines
+
+                release_notes="$(printf '## %s\n%s' "${pr_title}" "${release_notes_body}")"
+              fi
+
+              if [[ -n "$release_notes" ]]; then
+                  EOF="$(openssl rand -hex 16)"
+                  echo "body<<$EOF" >> $GITHUB_OUTPUT
+                  echo "${release_notes}" >> $GITHUB_OUTPUT
+                  echo "$EOF" >> $GITHUB_OUTPUT
+              fi
+
+              if [[ -n "$release_notes_comment" ]]; then
+                  EOF="$(openssl rand -hex 16)"
+                  echo "comment<<$EOF" >> $GITHUB_OUTPUT
+                  echo "${release_notes_comment}" >> $GITHUB_OUTPUT
+                  echo "$EOF" >> $GITHUB_OUTPUT
               fi
           fi
 
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find_comment
-        if: steps.format_release_notes.outputs.text != ''
+        if: steps.format_release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "flowzone-app[bot]"
@@ -1341,7 +1366,7 @@ jobs:
 
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find_edited_comment
-        if: steps.format_release_notes.outputs.text != ''
+        if: steps.format_release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "flowzone-app[bot]"
@@ -1352,7 +1377,7 @@ jobs:
       # .. found, or if one exists, it is unedited
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         if: |
-          steps.format_release_notes.outputs.text != '' &&
+          steps.format_release_notes.outputs.comment != '' &&
           (
             (
               steps.find_comment.outputs.comment-id == '' &&
@@ -1367,7 +1392,7 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ${{ steps.format_release_notes.outputs.text }}
+            ${{ steps.format_release_notes.outputs.comment }}
           edit-mode: replace
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           reactions: eyes
@@ -1429,6 +1454,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           reactions: hooray
+
 
   lint_workflows:
     name: Lint workflows

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -85,15 +85,22 @@
     id: release_notes
     env:
       look_back: 1
+      user_defined: ""
     run: |
       set -ea
       # prevent git from existing with 141
       set +o pipefail
 
+      look_back="${look_back:-1}"
       previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
       release_notes_file="$(mktemp)"
-      release_notes="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+      changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+      release_notes="${changelog}"
+      if [[ -n "${user_defined}" ]]; then
+        release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
+      fi
+
       EOF="$(openssl rand -hex 16)"
       echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
       echo "${release_notes}" >> "${GITHUB_OUTPUT}"
@@ -1454,7 +1461,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           reactions: hooray
-
 
   lint_workflows:
     name: Lint workflows
@@ -3137,6 +3143,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - versioned_source
+      - release_notes
       - npm_publish
       - python_publish
       - cargo_publish
@@ -3161,7 +3168,10 @@ jobs:
 
       - *deleteDraftGitHubRelease
       - *checkoutVersionedSha
-      - *getReleaseNotes
+      - <<: *getReleaseNotes
+        env:
+          user_defined: ${{ needs.release_notes.outputs.body }}
+          look_back: 1
 
       - name: Download all artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
@@ -3188,6 +3198,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - versioned_source
+      - release_notes
     if: |
       (
         (
@@ -3215,6 +3226,7 @@ jobs:
       - *checkoutVersionedSha
       - <<: *getReleaseNotes
         env:
+          user_defined: ${{ needs.release_notes.outputs.body }}
           look_back: 2
 
       # https://docs.github.com/en/rest/releases

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2859,6 +2859,7 @@ jobs:
       - cargo_test
       - python_test
       - versioned_source
+      - release_notes
     # allow some dependencies to be skipped
     if: |
       !failure() && !cancelled() &&
@@ -2876,7 +2877,10 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
-      - *getReleaseNotes
+      - <<: *getReleaseNotes
+        env:
+          look_back: 1
+          user_defined: ${{ needs.release_notes.outputs.body }}
       - *createLocalRefs
       - *deployToBalenaAction
 
@@ -2887,6 +2891,7 @@ jobs:
     needs:
       - is_balena
       - versioned_source
+      - release_notes
     if: |
       github.event.pull_request.merged == true || github.event_name == 'push'
 
@@ -2904,6 +2909,7 @@ jobs:
       - <<: *getReleaseNotes
         env:
           look_back: 2
+          user_defined: ${{ needs.release_notes.outputs.body }}
 
       - *deployToBalenaAction
 


### PR DESCRIPTION
Look for a `## Release notes` section on the PR body and append the contents of the section to the release notes in GitHub and balenaCloud.

## Release Notes 

Flowzone will now look for a `## Release notes` section on the PR body. When defined, it will use the contents of that section and the PR title for the automatically [generated release notes in GitHub](https://github.com/product-os/flowzone/releases/tag/v11.4.10). If the repository is identified as a [Balena project](https://github.com/product-os/flowzone?tab=readme-ov-file#balena), it will also use the user provided release notes to populate the Balena release notes.

If no `Release notes` section is defined, the workflow will just use the Git change-log, unless the `release_notes` option is set to `false`.