### PR TITLE
relax regex to match anywhere

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -729,7 +729,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: flowzone-app[bot]
-          body-regex: ^\* \[only keep the important and rephrase\]$
+          body-regex: \* \[only keep the important and rephrase\]
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: |
@@ -805,8 +805,6 @@ jobs:
           vars.ZULIP_TOPIC != '' &&
           vars.ZULIP_BOT_EMAIL != '' &&
           vars.ZULIP_API_URL != '' &&
-          steps.find_comment.outcome == 'success' &&
-          steps.find_comment.outputs.comment-body != '' &&
           steps.find_edited_comment.outcome == 'success' &&
           steps.find_edited_comment.outputs.comment-id == ''
         continue-on-error: true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1377,7 +1377,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "flowzone-app[bot]"
-          body-regex: '^\* \[only keep the important and rephrase\]$'
+          body-regex: '\* \[only keep the important and rephrase\]'
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
       # to prevent clobbering edited comments, run only if no previous draft comment is
@@ -1438,8 +1438,6 @@ jobs:
           vars.ZULIP_TOPIC != '' &&
           vars.ZULIP_BOT_EMAIL != '' &&
           vars.ZULIP_API_URL != '' &&
-          steps.find_comment.outcome == 'success' &&
-          steps.find_comment.outputs.comment-body != '' &&
           steps.find_edited_comment.outcome == 'success' &&
           steps.find_edited_comment.outputs.comment-id == ''
         continue-on-error: true


### PR DESCRIPTION
.. this should match for the string `* [only keep the important and rephrase]` anywhere in the release notes text, without being tripped up by new lines, etc. (or if more whitespace is added by accident).

(string to match)
https://github.com/balena-io/environment-production/actions/runs/9082537944/job/24959245850#step:5:46

(aggressive regex)
https://github.com/balena-io/environment-production/actions/runs/9082537944/job/24959245850#step:5:133

(wrong, should be found)
https://github.com/balena-io/environment-production/actions/runs/9082537944/job/24959245850#step:5:138

.. suspect `\n` at the end is the cause.