### PR TITLE
Restore re-itemization of notable changes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -688,6 +688,7 @@ jobs:
                   release_notes="$(printf '## %s\n\n### Notable changes\n\n%s\n\n%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
 
                   # Prepare the comment body
+                  notable_changes="$(echo "${notable_changes}" | sed -E 's|^|* |g')"
                   notable_changes="$(printf 'Notable changes\n* [only keep the important and rephrase]\n%s' "${notable_changes}")"
 
                   # https://zulip.com/help/format-your-message-using-markdown

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1334,6 +1334,7 @@ jobs:
                   release_notes="$(printf '## %s\n\n### Notable changes\n\n%s\n\n%s' "${pr_title}" "${notable_changes}" "${pr_body}")"
 
                   # Prepare the comment body
+                  notable_changes="$(echo "${notable_changes}" | sed -E 's|^|* |g')"
                   notable_changes="$(printf 'Notable changes\n* [only keep the important and rephrase]\n%s' "${notable_changes}")"
 
                   # https://zulip.com/help/format-your-message-using-markdown


### PR DESCRIPTION
For the release notes comment, this restores the re-itemization of the notable changes list with `*`, to make it clear that the lines should be edited.

Change-type: patch