### PR TITLE
Allow to install additional cargo packages

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -173,6 +173,11 @@ on:
           arm-unknown-linux-gnueabihf,
           x86_64-unknown-linux-gnu,
           i686-unknown-linux-gnu
+      cargo_install:
+        description: Space-delimited string of packages to install using cargo install
+        type: string
+        required: false
+        default: ""
       rust_toolchain:
         description: Version specifier (e.g. 1.65, stable, nigthly) for the toolchain to use when building Rust sources
         type: string
@@ -3590,6 +3595,9 @@ jobs:
         run: cargo fmt --check
       - name: Install cross
         run: cargo install cross --locked
+      - name: Cargo install
+        if: inputs.cargo_install != ''
+        run: cross install --force --locked ${{ inputs.cargo_install }}
       - name: Lint with clippy
         run: cross -v clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
       - name: Run tests for toolchain ${{ matrix.target }}
@@ -3666,6 +3674,9 @@ jobs:
           targets: ${{ matrix.target }}
       - name: Install cross
         run: cargo install cross --locked
+      - name: Cargo install
+        if: inputs.cargo_install != ''
+        run: cross install --force --locked ${{ inputs.cargo_install }}
       - name: Build release for toolchain ${{ matrix.target }}
         run: cross -v build --release --target ${{ matrix.target }}
       - name: Install LLVM

--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ jobs:
         x86_64-unknown-linux-gnu,
         i686-unknown-linux-gnu
 
+      # Space-delimited string of packages to install using cargo install
+      # Type: string
+      # Required: false
+      cargo_install: 
+
       # Version specifier (e.g. 1.65, stable, nigthly) for the toolchain to use when building Rust
       # sources
       # Type: string

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -909,6 +909,11 @@ on:
           arm-unknown-linux-gnueabihf,
           x86_64-unknown-linux-gnu,
           i686-unknown-linux-gnu
+      cargo_install:
+        description: "Space-delimited string of packages to install using cargo install"
+        type: string
+        required: false
+        default: ""
       rust_toolchain:
         description: "Version specifier (e.g. 1.65, stable, nigthly) for the toolchain to use when building Rust sources"
         type: string
@@ -3333,6 +3338,10 @@ jobs:
       - name: Install cross
         run: cargo install cross --locked
 
+      - name: Cargo install
+        if: inputs.cargo_install != ''
+        run: cross install --force --locked ${{ inputs.cargo_install }}
+
       - name: Lint with clippy
         run: cross -v clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
 
@@ -3393,6 +3402,10 @@ jobs:
 
       - name: Install cross
         run: cargo install cross --locked
+
+      - name: Cargo install
+        if: inputs.cargo_install != ''
+        run: cross install --force --locked ${{ inputs.cargo_install }}
 
       - name: Build release for toolchain ${{ matrix.target }}
         run: cross -v build --release --target ${{ matrix.target }}


### PR DESCRIPTION
Adds the `cargo_install` input to allow users to install additional cargo packages before the build.

Change-type: minor