### PR TITLE
Fix regression on the GitHub finalize job

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -616,14 +616,14 @@ jobs:
       (
         github.event.action != 'closed' ||
         github.event.pull_request.merged == true
-      ) &&
-      inputs.release_notes == true
+      )
     defaults:
       run:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
+      comment: ${{ steps.format_release_notes.outputs.comment }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -646,7 +646,7 @@ jobs:
               "metadata": "read",
               "pull_requests": "write"
             }
-      - name: Draft PR comment
+      - name: Format release notes
         id: format_release_notes
         continue-on-error: true
         env:
@@ -720,9 +720,48 @@ jobs:
                   echo "$EOF" >> $GITHUB_OUTPUT
               fi
           fi
+  release_notes_comment:
+    name: Prepare deploy message
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - versioned_source
+      - release_notes
+    if: |
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      ) &&
+      inputs.release_notes == true
+    defaults:
+      run:
+        working-directory: .
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+    env:
+      GH_DEBUG: "true"
+      GH_PAGER: cat
+      GH_PROMPT_DISABLED: "true"
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Generate GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        continue-on-error: true
+        id: gh_app_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ inputs.installation_id }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "write",
+              "metadata": "read",
+              "pull_requests": "write"
+            }
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: find_comment
-        if: steps.format_release_notes.outputs.comment != ''
+        if: needs.release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: flowzone-app[bot]
@@ -730,7 +769,7 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: find_edited_comment
-        if: steps.format_release_notes.outputs.comment != ''
+        if: needs.release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: flowzone-app[bot]
@@ -738,7 +777,7 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: |
-          steps.format_release_notes.outputs.comment != '' &&
+          needs.release_notes.outputs.comment != '' &&
           (
             (
               steps.find_comment.outputs.comment-id == '' &&
@@ -753,7 +792,7 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ${{ steps.format_release_notes.outputs.comment }}
+            ${{ needs.release_notes.outputs.comment }}
           edit-mode: replace
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           reactions: eyes

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1289,13 +1289,13 @@ jobs:
       (
         github.event.action != 'closed' ||
         github.event.pull_request.merged == true
-      ) &&
-      inputs.release_notes == true
+      )
 
     <<: *rootWorkingDirectory
 
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
+      comment: ${{ steps.format_release_notes.outputs.comment }}
 
     env:
       <<: *gitHubCliEnvironment
@@ -1312,7 +1312,7 @@ jobs:
             }
 
       # Get Renovate release notes from PR body, massage a little and draft a comment.
-      - name: Draft PR comment
+      - name: Format release notes
         id: format_release_notes
         continue-on-error: true
         env:
@@ -1387,9 +1387,39 @@ jobs:
               fi
           fi
 
+  release_notes_comment:
+    name: Prepare deploy message
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    needs:
+      - versioned_source
+      - release_notes
+    if: |
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      ) &&
+      inputs.release_notes == true
+
+    <<: *rootWorkingDirectory
+
+    env:
+      <<: *gitHubCliEnvironment
+
+    steps:
+      - <<: *getGitHubAppToken
+        with:
+          <<: *getGitHubAppTokenWith
+          permissions: >-
+            {
+              "contents": "write",
+              "metadata": "read",
+              "pull_requests": "write"
+            }
+
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find_comment
-        if: steps.format_release_notes.outputs.comment != ''
+        if: needs.release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "flowzone-app[bot]"
@@ -1398,7 +1428,7 @@ jobs:
 
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         id: find_edited_comment
-        if: steps.format_release_notes.outputs.comment != ''
+        if: needs.release_notes.outputs.comment != ''
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "flowzone-app[bot]"
@@ -1409,7 +1439,7 @@ jobs:
       # .. found, or if one exists, it is unedited
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         if: |
-          steps.format_release_notes.outputs.comment != '' &&
+          needs.release_notes.outputs.comment != '' &&
           (
             (
               steps.find_comment.outputs.comment-id == '' &&
@@ -1424,7 +1454,7 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ${{ steps.format_release_notes.outputs.comment }}
+            ${{ needs.release_notes.outputs.comment }}
           edit-mode: replace
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           reactions: eyes


### PR DESCRIPTION
The work on PR #1046 made the finalize github release job dependent on the `release_notes` input. That's a regression on the correct behavior. This PR moves the PR comment and deploy message actions to a separate job that is dependent on the release notes input, and makes the release_notes job run on every PR, which allows the github finalize job to always run on merge.

This is a major change because it changes the way the release_notes input work, even though it restores the right behavior.

Change-type: major

## Release notes

This release fixes a regression that prevented finalizing the GitHub release unless the `release_comment` input was set to true. This restores the correct behavior, however it is a major change as it is changing an interface (even if the interface was bad).