### PR TITLE
Replace almost-EOL node 21 with node 22 (current)

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1013,14 +1013,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:
-          node-version: 21.x
+          node-version: 22.x
         if: steps.npm.outputs.enabled == 'true'
       - name: Check engine
         if: steps.npm.outputs.enabled == 'true'
         run: |
           if npx -q -y -- check-engine
           then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["21.x"]')" >> "${GITHUB_ENV}"
+            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["22.x"]')" >> "${GITHUB_ENV}"
           fi
       - name: Set Node.js versions
         if: steps.npm.outputs.enabled == 'true'

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1640,14 +1640,14 @@ jobs:
       - <<: *setupNode
         if: steps.npm.outputs.enabled == 'true'
         with:
-          node-version: 21.x
+          node-version: 22.x
 
       - name: Check engine
         if: steps.npm.outputs.enabled == 'true'
         run: |
           if npx -q -y -- check-engine
           then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["21.x"]')" >> "${GITHUB_ENV}"
+            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["22.x"]')" >> "${GITHUB_ENV}"
           fi
 
       # default to the current LTS version if none were matched


### PR DESCRIPTION
Node 21 is going EOL on 01 Jun 2024.
Not marking node 22 as the default yet,
since it's not yet LTS.

Change-type: minor
See: https://endoflife.date/nodejs