### PR TITLE
Use --locked option to test and build rust

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3632,7 +3632,7 @@ jobs:
       - name: Lint with clippy
         run: cross -v clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
       - name: Run tests for toolchain ${{ matrix.target }}
-        run: cross -v test --target ${{ matrix.target }}
+        run: cross -v test --locked --target ${{ matrix.target }}
       - name: Generate metadata
         id: meta
         run: |
@@ -3706,7 +3706,7 @@ jobs:
       - name: Install cross
         run: cargo install cross --locked
       - name: Build release for toolchain ${{ matrix.target }}
-        run: cross -v build --release --target ${{ matrix.target }}
+        run: cross -v build --locked --release --target ${{ matrix.target }}
       - name: Install LLVM
         run: sudo apt-get install -y llvm
       - name: LLVM strip

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3368,7 +3368,7 @@ jobs:
         run: cross -v clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
 
       - name: Run tests for toolchain ${{ matrix.target }}
-        run: cross -v test --target ${{ matrix.target }}
+        run: cross -v test --locked --target ${{ matrix.target }}
 
       - name: Generate metadata
         id: meta
@@ -3426,7 +3426,7 @@ jobs:
         run: cargo install cross --locked
 
       - name: Build release for toolchain ${{ matrix.target }}
-        run: cross -v build --release --target ${{ matrix.target }}
+        run: cross -v build --locked --release --target ${{ matrix.target }}
 
       - name: Install LLVM
         run: sudo apt-get install -y llvm


### PR DESCRIPTION
This ensures that the build will use the exact dependencies in Cargo.lock and fail if Cargo.lock has not been updated.

This is a stricter option which will could potentially cause previously working builds to fail, but it is necessary to allow for better reproducibility of builds.

Change-type: major

## Release Notes

Rust targets now are tested and built using the `--locked` flag, to [ensure that the cargo lock file is up-to-date](https://doc.rust-lang.org/cargo/commands/cargo-build.html#manifest-options). This is meant to improve build reproducibility, but it may cause previous working builds to fail.