### PR TITLE
Improve caching of docker builds

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2388,8 +2388,8 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.platform=${{ matrix.platform }}
-            *.cache-to=type=gha,mode=min,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
-            *.cache-from=type=gha,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-from=type=gha,scope=${{ matrix.target }}-${{ matrix.platform }}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[0] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[1] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[2] || ''}}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2665,8 +2665,8 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.platform=${{ matrix.platform }}
-            *.cache-to=type=gha,mode=min,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
-            *.cache-from=type=gha,scope=${{ github.head_ref }}-${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-from=type=gha,scope=${{ matrix.target }}-${{ matrix.platform }}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[0] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[1] || ''}}
             *.cache-from=${{fromJSON(steps.cache_meta.outputs.json || '{}').tags[2] || ''}}


### PR DESCRIPTION
Increase cache from min to max, and remove the branch
name from the cache scope.

Max mode will cache all layers, including intermediate stages.

This is a minor change as some repositories may run out
of cache space when building for many platforms.

See: https://docs.docker.com/build/cache/backends/gha/
Change-type: minor