### PR TITLE
Remove some deprecated inputs

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -254,11 +254,6 @@ on:
         description: Deprecated. Add the 'os' property in custom_test_matrix, custom_publish_matrix, and custom_finalize_matrix instead.
         type: string
         required: false
-      custom_environments:
-        description: Deprecated. Add the 'environments' property in custom_test_matrix, custom_publish_matrix, and custom_finalize_matrix instead.
-        type: string
-        required: false
-        default: ""
       toggle_auto_merge:
         description: Set to false to disable toggling auto-merge on PRs.
         type: boolean
@@ -1534,30 +1529,6 @@ jobs:
         run: |
           git fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
-      - id: custom_environments_matrix
-        name: Build JSON array
-        shell: bash
-        run: |
-          set -x
-
-          # Remove spaces and newlines from the input
-          INPUT="$(echo "${INPUT}" | tr -d '[:space:]')"
-
-          # Convert to JSON array using jq to split the string by the given delimiter
-          # Add a step to check if the array is empty, default to [""] if so
-          JSON_ARRAY="$(jq --raw-input --compact-output --null-input --arg delim "$DELIMITER" --arg input "$INPUT" '
-            if $input == "" then
-              [""] # Default to a single empty string element if input is empty
-            else
-              $input | split($delim) # Split the input by the delimiter
-            end
-          ')"
-
-          echo "build=${JSON_ARRAY}" >> "${GITHUB_OUTPUT}"
-          echo "json=${JSON_ARRAY}" >> "${GITHUB_OUTPUT}"
-        env:
-          INPUT: ${{ inputs.custom_environments }}
-          DELIMITER: ","
       - id: custom_test_values
         if: contains(inputs.custom_test_matrix, '{') != true
         name: Build JSON array
@@ -1590,8 +1561,7 @@ jobs:
           MATRIX: |
             {
               "value": ${{ steps.custom_test_values.outputs.json }},
-              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }},
-              "environment": ${{ steps.custom_environments_matrix.outputs.json }}
+              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }}
             }
         run: |
           json=$(jq -e -c . <<<"${MATRIX}") || exit $?
@@ -1628,8 +1598,7 @@ jobs:
           MATRIX: |
             {
               "value": ${{ steps.custom_publish_values.outputs.json }},
-              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }},
-              "environment": ${{ steps.custom_environments_matrix.outputs.json }}
+              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }}
             }
         run: |
           json=$(jq -e -c . <<<"${MATRIX}") || exit $?
@@ -1666,8 +1635,7 @@ jobs:
           MATRIX: |
             {
               "value": ${{ steps.custom_finalize_values.outputs.json }},
-              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }},
-              "environment": ${{ steps.custom_environments_matrix.outputs.json }}
+              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }}
             }
         run: |
           json=$(jq -e -c . <<<"${MATRIX}") || exit $?

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -193,11 +193,6 @@ on:
         type: boolean
         required: false
         default: false
-      job_name:
-        description: The name of the job, necessary for branch protection if not using the default of 'Flowzone'
-        type: string
-        required: false
-        default: Flowzone
       checkout_fetch_depth:
         description: Configures the depth of the actions/checkout git fetch.
         type: number

--- a/README.md
+++ b/README.md
@@ -355,12 +355,6 @@ jobs:
       # Required: false
       custom_runs_on:
 
-      # Deprecated. Add the 'environments' property in custom_test_matrix, custom_publish_matrix,
-      # and custom_finalize_matrix instead.
-      # Type: string
-      # Required: false
-      custom_environments: 
-
       # Set to false to disable toggling auto-merge on PRs.
       # Type: boolean
       # Required: false

--- a/README.md
+++ b/README.md
@@ -284,12 +284,6 @@ jobs:
       # Required: false
       disable_versioning: false
 
-      # The name of the job, necessary for branch protection if not using the default of
-      # 'Flowzone'
-      # Type: string
-      # Required: false
-      job_name: Flowzone
-
       # Configures the depth of the actions/checkout git fetch.
       # Type: number
       # Required: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -930,11 +930,6 @@ on:
         type: boolean
         required: false
         default: false
-      job_name:
-        description: "The name of the job, necessary for branch protection if not using the default of 'Flowzone'"
-        type: string
-        required: false
-        default: "Flowzone"
       checkout_fetch_depth:
         description: "Configures the depth of the actions/checkout git fetch."
         type: number

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -991,11 +991,6 @@ on:
         description: "Deprecated. Add the 'os' property in custom_test_matrix, custom_publish_matrix, and custom_finalize_matrix instead."
         type: string
         required: false
-      custom_environments:
-        description: "Deprecated. Add the 'environments' property in custom_test_matrix, custom_publish_matrix, and custom_finalize_matrix instead."
-        type: string
-        required: false
-        default: ""
       toggle_auto_merge:
         description: "Set to false to disable toggling auto-merge on PRs."
         type: boolean
@@ -2048,13 +2043,6 @@ jobs:
       - *resetGitHubDirectory
 
       # FIXME: remove this handling of deprecated comma-separated values
-      - id: custom_environments_matrix
-        <<: *jsonArrayBuilder
-        env:
-          INPUT: ${{ inputs.custom_environments }}
-          DELIMITER: ","
-
-      # FIXME: remove this handling of deprecated comma-separated values
       - id: custom_test_values
         if: contains(inputs.custom_test_matrix, '{') != true
         <<: *jsonArrayBuilder
@@ -2071,8 +2059,7 @@ jobs:
           MATRIX: >
             {
               "value": ${{ steps.custom_test_values.outputs.json }},
-              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }},
-              "environment": ${{ steps.custom_environments_matrix.outputs.json }}
+              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }}
             }
         run: |
           json=$(jq -e -c . <<<"${MATRIX}") || exit $?
@@ -2094,8 +2081,7 @@ jobs:
           MATRIX: >
             {
               "value": ${{ steps.custom_publish_values.outputs.json }},
-              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }},
-              "environment": ${{ steps.custom_environments_matrix.outputs.json }}
+              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }}
             }
 
       # FIXME: remove this handling of deprecated comma-separated values
@@ -2114,8 +2100,7 @@ jobs:
           MATRIX: >
             {
               "value": ${{ steps.custom_finalize_values.outputs.json }},
-              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }},
-              "environment": ${{ steps.custom_environments_matrix.outputs.json }}
+              "os": ${{ inputs.custom_runs_on || format('[{0}]', inputs.runs_on) }}
             }
 
       - name: Check for custom actions


### PR DESCRIPTION
**Remove deprecated input job_name**
The functionality behind this input was removed
when we stopped patching branch protections.

**Remove deprecated custom_environments input**
This property was only used in one repository for testing