### PR TITLE
patch: add an option to not generate sbom

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -277,6 +277,11 @@ on:
         type: number
         required: false
         default: 20
+      generate_sbom:
+        description: Generate a Software Bill of Materials (SBOM) for the release.
+        type: boolean
+        required: false
+        default: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: ${{ github.event.action == 'synchronize' }}
@@ -916,7 +921,7 @@ jobs:
       has_npm_lockfile: ${{ steps.npm_lock.outputs.has_npm_lockfile }}
       npm_private: ${{ steps.npm.outputs.private }}
       npm_docs: ${{ steps.npm.outputs.docs }}
-      npm_sbom: ${{ steps.npm.outputs.sbom }}
+      npm_sbom: ${{ inputs.generate_sbom }}
       node_versions: ${{ steps.node_versions.outputs.json }}
       npm_access: ${{ steps.access.outputs.access }}
     steps:
@@ -950,7 +955,6 @@ jobs:
             echo "enabled=true" >> "${GITHUB_OUTPUT}"
             echo "private=$(jq -r '.private' package.json)" >> "${GITHUB_OUTPUT}"
             echo "docs=$(jq -r '.scripts | has("doc")' package.json)" >> "${GITHUB_OUTPUT}"
-            echo "sbom=true" >> "${GITHUB_OUTPUT}" # TODO: evaluate the need to offer an option to disable SBOM generation
             echo "NODE_VERSIONS=[]" >> "${GITHUB_ENV}"
           else
             echo "enabled=false" >> "${GITHUB_OUTPUT}"
@@ -1265,7 +1269,7 @@ jobs:
       python_poetry: ${{ steps.python_poetry.outputs.enabled }}
       python_versions: ${{ steps.python_versions.outputs.json }}
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
-      python_sbom: true
+      python_sbom: ${{ inputs.generate_sbom }}
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
@@ -1364,7 +1368,7 @@ jobs:
     outputs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
-      cargo_sbom: true
+      cargo_sbom: ${{ inputs.generate_sbom }}
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1954,6 +1954,7 @@ jobs:
   npm_sbom:
     name: Generate SBOM for NPM
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    continue-on-error: true
     needs:
       - is_npm
       - npm_test
@@ -3210,6 +3211,7 @@ jobs:
   python_sbom:
     name: Generate SBOM for python
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    continue-on-error: true
     needs:
       - is_python
       - python_test
@@ -3802,6 +3804,7 @@ jobs:
   cargo_sbom:
     name: Generate SBOM for cargo
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    continue-on-error: true
     needs:
       - is_cargo
       - cargo_test

--- a/README.md
+++ b/README.md
@@ -379,6 +379,11 @@ jobs:
       # Required: false
       max_parallel: 20
 
+      # Generate a Software Bill of Materials (SBOM) for the release.
+      # Type: boolean
+      # Required: false
+      generate_sbom: true
+
 
 ```
 <!-- end usage -->

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1034,6 +1034,11 @@ on:
         type: number
         required: false
         default: 20
+      generate_sbom:
+        description: "Generate a Software Bill of Materials (SBOM) for the release."
+        type: boolean
+        required: false
+        default: true
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -1572,7 +1577,7 @@ jobs:
       has_npm_lockfile: ${{ steps.npm_lock.outputs.has_npm_lockfile }}
       npm_private: ${{ steps.npm.outputs.private }} # can be null or unset
       npm_docs: ${{ steps.npm.outputs.docs }} # can be null or unset
-      npm_sbom: ${{ steps.npm.outputs.sbom }} # can be null or unset
+      npm_sbom: ${{ inputs.generate_sbom }} # default true
       node_versions: ${{ steps.node_versions.outputs.json }}
       npm_access: ${{ steps.access.outputs.access }}
 
@@ -1589,7 +1594,6 @@ jobs:
             echo "enabled=true" >> "${GITHUB_OUTPUT}"
             echo "private=$(jq -r '.private' package.json)" >> "${GITHUB_OUTPUT}"
             echo "docs=$(jq -r '.scripts | has("doc")' package.json)" >> "${GITHUB_OUTPUT}"
-            echo "sbom=true" >> "${GITHUB_OUTPUT}" # TODO: evaluate the need to offer an option to disable SBOM generation
             echo "NODE_VERSIONS=[]" >> "${GITHUB_ENV}"
           else
             echo "enabled=false" >> "${GITHUB_OUTPUT}"
@@ -1901,7 +1905,7 @@ jobs:
       python_poetry: ${{ steps.python_poetry.outputs.enabled }}
       python_versions: ${{ steps.python_versions.outputs.json }}
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
-      python_sbom: true # TODO: offer a way to deactivate SBOM generation
+      python_sbom: ${{ inputs.generate_sbom }}
 
     steps:
       - *getGitHubAppToken
@@ -1984,7 +1988,7 @@ jobs:
     outputs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
-      cargo_sbom: true # TODO: offer a way to deactivate SBOM generation
+      cargo_sbom: ${{ inputs.generate_sbom }}
 
     steps:
       - *getGitHubAppToken

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2401,6 +2401,7 @@ jobs:
   npm_sbom:
     name: Generate SBOM for NPM
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    continue-on-error: true
     needs:
       - is_npm
       - npm_test
@@ -3107,6 +3108,7 @@ jobs:
   python_sbom:
     name: Generate SBOM for python
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    continue-on-error: true
     needs:
       - is_python
       - python_test
@@ -3503,6 +3505,7 @@ jobs:
   cargo_sbom:
     name: Generate SBOM for cargo
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    continue-on-error: true
     needs:
       - is_cargo
       - cargo_test


### PR DESCRIPTION
SBOM generation is failing for some repository with some specific configuration.

This PR adds a global flowzone parameter to turn off sbom generation (on by default) and will `continue-on-error`.