### PR TITLE
Add Cloudflare Pages link as PR comment

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3494,13 +3494,28 @@ jobs:
         run: |
           echo "CF_BRANCH=${{ github.event.repository.default_branch }}" >> "${GITHUB_ENV}"
       - name: Deploy to Cloudflare Pages
+        id: deploy_cf_pages
         uses: cloudflare/wrangler-action@f84a562284fc78278ff9052435d9526f9c718361
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: 3.5.1
-          command: --version
-          postCommands: npx wrangler pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ | tee -a $GITHUB_STEP_SUMMARY
+          command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/
+      - name: Find Cloudflare Pages link comment
+        uses: peter-evans/find-comment@v3.1.0
+        id: find_cf_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: Website deployed to CF Pages, 👀 preview link
+      - name: Create or update Cloudflare Pages link comment if deployment link present
+        uses: peter-evans/create-or-update-comment@v4.0.0
+        if: steps.deploy_cf_pages.outputs.deployment-url != ''
+        with:
+          comment-id: ${{ steps.find_cf_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            Website deployed to CF Pages, 👀 preview link ${{ steps.deploy_cf_pages.outputs.deployment-url }}
   github_clean:
     name: Clean GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3286,13 +3286,30 @@ jobs:
           echo "CF_BRANCH=${{ github.event.repository.default_branch }}" >> "${GITHUB_ENV}"
 
       - name: Deploy to Cloudflare Pages
+        id: deploy_cf_pages
         uses: cloudflare/wrangler-action@f84a562284fc78278ff9052435d9526f9c718361 # v3.7.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: "3.5.1" # latest - https://www.npmjs.com/package/wrangler
-          command: --version
-          postCommands: npx wrangler pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/ | tee -a $GITHUB_STEP_SUMMARY
+          command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/
+
+      - name: Find Cloudflare Pages link comment
+        uses: peter-evans/find-comment@v3.1.0
+        id: find_cf_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: Website deployed to CF Pages, 👀 preview link
+
+      - name: Create or update Cloudflare Pages link comment if deployment link present
+        uses: peter-evans/create-or-update-comment@v4.0.0
+        if: steps.deploy_cf_pages.outputs.deployment-url != ''
+        with:
+          comment-id: ${{ steps.find_cf_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            Website deployed to CF Pages, 👀 preview link ${{ steps.deploy_cf_pages.outputs.deployment-url }}
 
   ###################################################
   # GitHub


### PR DESCRIPTION
It's annoying to find the CF pages link from inside the GHA run summary, lost of people have had this friction. 
No more. This PR adds that link to the comments. 

![Screenshot 2024-07-11 at 4 18 26 PM](https://github.com/product-os/flowzone/assets/22801822/b4a343bd-4346-4a18-9943-ee799ce8f2e7)

Zulip: Started from https://balena.zulipchat.com/#narrow/stream/408336-aspect.2Fuser-experience/topic/Where.20should.20SAML.20docs.20fit.20in.3F

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
