### PR TITLE
Use calculated fetch depth for versioned source checkout

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -196,11 +196,6 @@ on:
         type: boolean
         required: false
         default: false
-      checkout_fetch_depth:
-        description: Configures the depth of the actions/checkout git fetch.
-        type: number
-        required: false
-        default: 1
       runs_on:
         description: JSON array of runner label strings for default jobs.
         type: string

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -381,6 +381,7 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.bot }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
+      depth: ${{ steps.git_describe.outputs.depth }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -437,6 +438,7 @@ jobs:
             echo "semver=$(npx -q -y -- semver -c -l "${tag}")" ;
             echo "describe=$(git describe --tags --always --dirty | cat)" ;
             echo "sha=$(git rev-parse HEAD)" ;
+            echo "depth=$(git rev-list "$(git describe --tags --abbrev=0 "$(git rev-list --tags --skip=1 --max-count=1 2>/dev/null)" 2>/dev/null)..HEAD" --count)" ;
           } >> "${GITHUB_OUTPUT}"
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
@@ -893,7 +895,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -941,7 +943,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1065,7 +1067,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1287,7 +1289,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1386,7 +1388,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1456,7 +1458,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1531,7 +1533,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1704,7 +1706,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1751,7 +1753,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1853,7 +1855,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1981,7 +1983,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2225,7 +2227,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2745,7 +2747,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2965,7 +2967,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3056,7 +3058,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3149,7 +3151,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3241,7 +3243,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3329,7 +3331,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3403,7 +3405,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3458,7 +3460,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3594,7 +3596,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3680,7 +3682,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3782,7 +3784,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3851,7 +3853,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3936,7 +3938,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3998,7 +4000,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4050,7 +4052,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4119,7 +4121,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4182,7 +4184,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4242,7 +4244,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4297,7 +4299,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4362,7 +4364,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
       docker_publish_platform_tags: true
       docker_runs_on: >
         {
-          "linux/amd64": ["actuated-2cpu-8gb"],
-          "linux/arm64": ["actuated-arm64-2cpu-8gb"],
+          "linux/amd64": ["self-hosted","X64"],
+          "linux/arm64": ["self-hosted","ARM64"],
           "linux/arm/v7": ["self-hosted","ARM64"],
-          "linux/arm/v6": ["self-hosted","X64"]
+          "linux/arm/v6": ["self-hosted","ARM64"]
         }
       custom_test_matrix: >
         {
@@ -50,8 +50,7 @@ jobs:
             ["ubuntu-latest"],
             ["macos-latest"],
             ["windows-latest"],
-            ["self-hosted"],
-            ["actuated-2cpu-8gb"]
+            ["self-hosted"]
           ],
           "environment": ["test"]
         }

--- a/README.md
+++ b/README.md
@@ -288,11 +288,6 @@ jobs:
       # Required: false
       disable_versioning: false
 
-      # Configures the depth of the actions/checkout git fetch.
-      # Type: number
-      # Required: false
-      checkout_fetch_depth: 1
-
       # JSON array of runner label strings for default jobs.
       # Type: string
       # Required: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -955,11 +955,6 @@ on:
         type: boolean
         required: false
         default: false
-      checkout_fetch_depth:
-        description: "Configures the depth of the actions/checkout git fetch."
-        type: number
-        required: false
-        default: 1
       runs_on:
         description: "JSON array of runner label strings for default jobs."
         type: string

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -216,7 +216,7 @@
     name: Checkout versioned commit
     uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     with:
-      fetch-depth: 0
+      fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
       submodules: "recursive"
       # fallback to an invalid ref if the checkout ref is undefined
       ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
@@ -231,7 +231,13 @@
       git fetch origin ${{ github.ref }}
       git checkout FETCH_HEAD -- .github
 
-  - &describeGitState # Resolve tag, semver, sha, and description of current git working copy.
+  # Resolve tag, semver, sha, and description of current git working copy.
+  # tag is the latest tag that points to the current commit.
+  # semver is the semantic version of the tag.
+  # describe is the output of `git describe --tags --always --dirty`.
+  # sha is the full commit hash.
+  # depth is the number of commits since the second most recent tag.
+  - &describeGitState
     name: Describe git state
     id: git_describe
     run: |
@@ -241,6 +247,7 @@
         echo "semver=$(npx -q -y -- semver -c -l "${tag}")" ;
         echo "describe=$(git describe --tags --always --dirty | cat)" ;
         echo "sha=$(git rev-parse HEAD)" ;
+        echo "depth=$(git rev-list "$(git describe --tags --abbrev=0 "$(git rev-list --tags --skip=1 --max-count=1 2>/dev/null)" 2>/dev/null)..HEAD" --count)" ;
       } >> "${GITHUB_OUTPUT}"
 
   - &createLocalRefs
@@ -1103,6 +1110,7 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.bot }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
+      depth: ${{ steps.git_describe.outputs.depth }}
 
     env:
       <<: *gitHubCliEnvironment


### PR DESCRIPTION
This should reduce our fetch depth in almost all cases
while still including commits required for versioning
and changelogs and release notes.

Reducing fetch depth saves a lot of time on the checkout
step present in most jobs, so every little bit helps.