### PR TITLE
Output Cloudflare Deployment URL 

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -277,6 +277,10 @@ on:
         type: boolean
         required: false
         default: true
+    outputs:
+      cloudflare_deployment_url:
+        description: Cloudflare Deployment URL
+        value: ${{ jobs.website_publish.outputs.cloudflare_deployment_url }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: ${{ github.event.action == 'synchronize' }}
@@ -3430,6 +3434,8 @@ jobs:
   website_publish:
     name: Publish website
     runs-on: ${{fromJSON(inputs.runs_on)}}
+    outputs:
+      cloudflare_deployment_url: ${{ steps.output_cf_url.outputs.cloudflare_deployment_url }}
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
     needs:
@@ -3500,6 +3506,13 @@ jobs:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: 3.5.1
           command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/
+      - name: Set Cloudflare Pages deployment-url to output
+        id: output_cf_url
+        if: steps.deploy_cf_pages.outputs.deployment-url != ''
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy_cf_pages.outputs.deployment-url }}
+        run: |
+          echo "cloudflare_deployment_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
       - name: Find Cloudflare Pages link comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: find_cf_comment

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1043,6 +1043,10 @@ on:
         type: boolean
         required: false
         default: true
+    outputs:
+      cloudflare_deployment_url:
+        description: 'Cloudflare Deployment URL'
+        value: ${{ jobs.website_publish.outputs.cloudflare_deployment_url }}
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -3243,6 +3247,8 @@ jobs:
   website_publish:
     name: Publish website
     runs-on: ${{fromJSON(inputs.runs_on)}}
+    outputs:
+      cloudflare_deployment_url: ${{ steps.output_cf_url.outputs.cloudflare_deployment_url }}
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
     needs:
@@ -3298,6 +3304,14 @@ jobs:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: "3.5.1" # latest - https://www.npmjs.com/package/wrangler
           command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/
+      
+      - name: Set Cloudflare Pages deployment-url to output
+        id: output_cf_url
+        if: steps.deploy_cf_pages.outputs.deployment-url != ''
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy_cf_pages.outputs.deployment-url }}
+        run: |
+          echo "cloudflare_deployment_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Find Cloudflare Pages link comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0


### PR DESCRIPTION
My usecase for this output is to get it from Flowzone and give it to the link checker running in Docs to check links for the staging docs in order to make sure we are not breaking links on a per PR basis. 
(Pain driven development: I broke a link on a previous PR and link-checker didn't find out)

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
