### PR TITLE
Pin Node 22 minor version to 22.4

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1013,14 +1013,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
-          node-version: 22.x
+          node-version: 22.4
         if: steps.npm.outputs.enabled == 'true'
       - name: Check engine
         if: steps.npm.outputs.enabled == 'true'
         run: |
           if npx -q -y -- check-engine
           then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["22.x"]')" >> "${GITHUB_ENV}"
+            # TODO: replace with 22.x once this issue is closed
+            # https://github.com/npm/cli/issues/7657
+            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["22.4"]')" >> "${GITHUB_ENV}"
           fi
       - name: Set Node.js versions
         if: steps.npm.outputs.enabled == 'true'

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1665,14 +1665,18 @@ jobs:
       - <<: *setupNode
         if: steps.npm.outputs.enabled == 'true'
         with:
-          node-version: 22.x
+          # TODO: replace with 22.x once this issue is closed
+          # https://github.com/npm/cli/issues/7657
+          node-version: 22.4
 
       - name: Check engine
         if: steps.npm.outputs.enabled == 'true'
         run: |
           if npx -q -y -- check-engine
           then
-            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["22.x"]')" >> "${GITHUB_ENV}"
+            # TODO: replace with 22.x once this issue is closed
+            # https://github.com/npm/cli/issues/7657
+            echo "NODE_VERSIONS=$(echo "${NODE_VERSIONS}" | jq -c '. + ["22.4"]')" >> "${GITHUB_ENV}"
           fi
 
       # default to the current LTS version if none were matched


### PR DESCRIPTION
There is a bug in Node 22.5.0 that is affecting NPM workflows. This is a temporary fix until that issue closes.

Relates-to: npm/cli#7657
Change-type: patch