### PR TITLE
Checkout versioned source with full depth for release notes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -390,7 +390,6 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.bot }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
-      depth: ${{ steps.git_describe.outputs.depth }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -447,7 +446,6 @@ jobs:
             echo "semver=$(npx -q -y -- semver -c -l "${tag}")" ;
             echo "describe=$(git describe --tags --always --dirty | cat)" ;
             echo "sha=$(git rev-parse HEAD)" ;
-            echo "depth=$(git rev-list "$(git describe --tags --abbrev=0 "$(git rev-list --tags --skip=1 --max-count=1 2>/dev/null)" 2>/dev/null)..HEAD" --count)" ;
           } >> "${GITHUB_OUTPUT}"
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
@@ -904,7 +902,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -952,7 +951,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1076,7 +1076,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1298,7 +1299,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1397,7 +1399,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1467,7 +1470,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1542,7 +1546,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1715,7 +1720,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1762,7 +1768,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1864,7 +1871,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1992,7 +2000,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2236,7 +2245,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2756,7 +2766,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2973,10 +2984,10 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned commit
+      - name: Checkout versioned commit with total depth
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: 0
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2990,8 +3001,6 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
 
-          # We are limiting search depth but we need tags to calculate the changelog
-          git fetch -q --tags
           look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
@@ -3066,10 +3075,10 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned commit
+      - name: Checkout versioned commit with total depth
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: 0
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3083,8 +3092,6 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
 
-          # We are limiting search depth but we need tags to calculate the changelog
-          git fetch -q --tags
           look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
@@ -3164,7 +3171,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3256,7 +3264,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3344,7 +3353,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3418,7 +3428,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3475,7 +3486,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3615,10 +3627,10 @@ jobs:
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Checkout versioned commit
+      - name: Checkout versioned commit with total depth
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: 0
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3632,8 +3644,6 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
 
-          # We are limiting search depth but we need tags to calculate the changelog
-          git fetch -q --tags
           look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
@@ -3705,10 +3715,10 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-      - name: Checkout versioned commit
+      - name: Checkout versioned commit with total depth
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: 0
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3722,8 +3732,6 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
 
-          # We are limiting search depth but we need tags to calculate the changelog
-          git fetch -q --tags
           look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
@@ -3812,7 +3820,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3881,7 +3890,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3966,7 +3976,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4028,7 +4039,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4080,7 +4092,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4149,7 +4162,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4212,7 +4226,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4272,7 +4287,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4327,7 +4343,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4392,7 +4409,8 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -196,6 +196,11 @@ on:
         type: boolean
         required: false
         default: false
+      checkout_fetch_depth:
+        description: Configures the depth of the actions/checkout git fetch.
+        type: number
+        required: false
+        default: 1
       runs_on:
         description: JSON array of runner label strings for default jobs.
         type: string

--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ jobs:
       # Required: false
       disable_versioning: false
 
+      # Configures the depth of the actions/checkout git fetch.
+      # Type: number
+      # Required: false
+      checkout_fetch_depth: 1
+
       # JSON array of runner label strings for default jobs.
       # Type: string
       # Required: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -91,8 +91,6 @@
       # prevent git from existing with 141
       set +o pipefail
 
-      # We are limiting search depth but we need tags to calculate the changelog
-      git fetch -q --tags
       look_back="${look_back:-1}"
       previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
@@ -218,7 +216,20 @@
     name: Checkout versioned commit
     uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     with:
-      fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+      fetch-depth: ${{ inputs.checkout_fetch_depth }}
+      # Note that fetch-tags is not currently working as described:
+      # https://github.com/actions/checkout/issues/1781
+      fetch-tags: true
+      submodules: "recursive"
+      # fallback to an invalid ref if the checkout ref is undefined
+      ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
+      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
+  - &checkoutVersionedShaDeep # https://github.com/actions/checkout
+    name: Checkout versioned commit with total depth
+    uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    with:
+      fetch-depth: 0
       submodules: "recursive"
       # fallback to an invalid ref if the checkout ref is undefined
       ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
@@ -249,7 +260,6 @@
         echo "semver=$(npx -q -y -- semver -c -l "${tag}")" ;
         echo "describe=$(git describe --tags --always --dirty | cat)" ;
         echo "sha=$(git rev-parse HEAD)" ;
-        echo "depth=$(git rev-list "$(git describe --tags --abbrev=0 "$(git rev-list --tags --skip=1 --max-count=1 2>/dev/null)" 2>/dev/null)..HEAD" --count)" ;
       } >> "${GITHUB_OUTPUT}"
 
   - &createLocalRefs
@@ -1121,7 +1131,6 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.bot }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
-      depth: ${{ steps.git_describe.outputs.depth }}
 
     env:
       <<: *gitHubCliEnvironment
@@ -2999,7 +3008,7 @@ jobs:
 
     steps:
       - *getGitHubAppToken
-      - *checkoutVersionedSha
+      - *checkoutVersionedShaDeep
       - <<: *getReleaseNotes
         env:
           look_back: 1
@@ -3028,7 +3037,7 @@ jobs:
 
     steps:
       - *getGitHubAppToken
-      - *checkoutVersionedSha
+      - *checkoutVersionedShaDeep
       - <<: *getReleaseNotes
         env:
           look_back: 2
@@ -3393,7 +3402,7 @@ jobs:
             }
 
       - *deleteDraftGitHubRelease
-      - *checkoutVersionedSha
+      - *checkoutVersionedShaDeep
       - <<: *getReleaseNotes
         env:
           user_defined: ${{ needs.release_notes.outputs.body }}
@@ -3452,7 +3461,7 @@ jobs:
               "metadata": "read"
             }
 
-      - *checkoutVersionedSha
+      - *checkoutVersionedShaDeep
       - <<: *getReleaseNotes
         env:
           user_defined: ${{ needs.release_notes.outputs.body }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -964,6 +964,11 @@ on:
         type: boolean
         required: false
         default: false
+      checkout_fetch_depth:
+        description: "Configures the depth of the actions/checkout git fetch."
+        type: number
+        required: false
+        default: 1
       runs_on:
         description: "JSON array of runner label strings for default jobs."
         type: string


### PR DESCRIPTION
Default to a fetch depth of 1 unless overridden via the input. Always use fetch depth of 0 when release notes are being calculated.

Some balenaOS repositories have submodules that require a fetch depth of 1700+ in order to get the pinned commit. Those repos need to be able to override the default of 1.

Change-type: minor