### PR TITLE
Use a checkout depth of 100 when no submodules exist

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -45,10 +45,12 @@ runs:
       run: |
         set -x
         tag="$(git tag --points-at HEAD | tail -n1)"
-        echo "tag=${tag}" >> $GITHUB_OUTPUT
-        echo "semver=$(npx -q -y -- semver -c -l "${tag}")" >> $GITHUB_OUTPUT
-        echo "describe=$(git describe --tags --always --dirty | cat)" >> $GITHUB_OUTPUT
-        echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+        npx -q -y -- semver -c -l "${tag}"
+        git describe --tags --always --dirty | cat
+        git rev-parse HEAD
+        git submodule
+        git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged
 
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -385,6 +385,7 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.bot }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
+      depth: ${{ steps.git_describe.outputs.depth || 0 }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -442,6 +443,12 @@ jobs:
             echo "describe=$(git describe --tags --always --dirty | cat)" ;
             echo "sha=$(git rev-parse HEAD)" ;
           } >> "${GITHUB_OUTPUT}"
+
+          if [[ "$(git submodule)" = "" ]]; then
+            echo "depth=100" >> "${GITHUB_OUTPUT}"
+          else
+            echo "depth=0" >> "${GITHUB_OUTPUT}"
+          fi
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
         with:
@@ -897,7 +904,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -946,7 +953,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1071,7 +1078,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1294,7 +1301,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1394,7 +1401,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1465,7 +1472,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1541,7 +1548,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1715,7 +1722,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1763,7 +1770,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1866,12 +1873,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -1995,12 +2002,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -2240,12 +2247,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -2761,7 +2768,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -2979,24 +2986,31 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned commit with total depth
+      - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Fetch tags
+        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
+        run: git fetch -q --tags
+      - name: Create local tag for draft version
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Generate short release note
         id: release_notes
         env:
-          look_back: 1
+          look_back: 2
           user_defined: ${{ needs.release_notes.outputs.body }}
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
 
-          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
@@ -3013,10 +3027,6 @@ jobs:
 
           echo "${release_notes}" > "${release_notes_file}"
           echo "file=${release_notes_file}" >> "${GITHUB_OUTPUT}"
-      - name: Create local refs
-        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
-        run: |
-          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - uses: balena-io/deploy-to-balena-action@31d0b891b057ae02329ab9874ccd0f1239e3c792
         id: balena_deploy
         with:
@@ -3070,13 +3080,21 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout versioned commit with total depth
+      - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Fetch tags
+        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
+        run: git fetch -q --tags
+      - name: Create local tag for draft version
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Generate short release note
         id: release_notes
         env:
@@ -3087,7 +3105,6 @@ jobs:
           # prevent git from existing with 141
           set +o pipefail
 
-          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
@@ -3166,12 +3183,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -3259,12 +3276,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -3348,12 +3365,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -3423,7 +3440,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3481,12 +3498,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -3622,24 +3639,31 @@ jobs:
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Checkout versioned commit with total depth
+      - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Fetch tags
+        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
+        run: git fetch -q --tags
+      - name: Create local tag for draft version
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Generate short release note
         id: release_notes
         env:
+          look_back: 2
           user_defined: ${{ needs.release_notes.outputs.body }}
-          look_back: 1
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
 
-          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
@@ -3710,24 +3734,31 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-      - name: Checkout versioned commit with total depth
+      - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Fetch tags
+        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
+        run: git fetch -q --tags
+      - name: Create local tag for draft version
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Generate short release note
         id: release_notes
         env:
-          user_defined: ${{ needs.release_notes.outputs.body }}
           look_back: 2
+          user_defined: ${{ needs.release_notes.outputs.body }}
         run: |
           set -ea
           # prevent git from existing with 141
           set +o pipefail
 
-          look_back="${look_back:-1}"
           previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
           release_notes_file="$(mktemp)"
@@ -3815,12 +3846,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -3885,12 +3916,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -3971,12 +4002,12 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -4034,7 +4065,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4087,7 +4118,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4096,7 +4127,7 @@ jobs:
         run: |
           git fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -4157,7 +4188,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4166,7 +4197,7 @@ jobs:
         run: |
           git fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
-      - name: Create local refs
+      - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
@@ -4221,7 +4252,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4282,7 +4313,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4338,7 +4369,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4404,7 +4435,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: 100
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -632,6 +632,7 @@ jobs:
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
       comment: ${{ steps.format_release_notes.outputs.comment }}
+      note: ${{ steps.short_release_notes.outputs.note }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -728,6 +729,51 @@ jobs:
                   echo "$EOF" >> $GITHUB_OUTPUT
               fi
           fi
+      - name: Checkout versioned commit
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-tags: true
+          submodules: recursive
+          ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: Fetch tags
+        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
+        run: git fetch -q --tags
+      - name: Create local tag for draft version
+        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
+        run: |
+          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
+      - name: Generate short release note
+        id: short_release_notes
+        env:
+          look_back: 2
+          user_defined: ${{ steps.format_release_notes.outputs.body }}
+        run: |
+          set -ea
+          # prevent git from existing with 141
+          set +o pipefail
+
+          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
+
+          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="${changelog}"
+          if [[ -n "${user_defined}" ]]; then
+            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
+          fi
+
+          EOF="$(openssl rand -hex 16)"
+          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
+          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
+          echo "$EOF" >> "${GITHUB_OUTPUT}"
+
+          echo "${release_notes}" > "${{ runner.temp }}/release-notes.txt"
+      - name: Upload release notes file
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
+        with:
+          name: release-notes
+          path: ${{ runner.temp }}/release-notes.txt
+          retention-days: 1
   release_notes_comment:
     name: Prepare deploy message
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -2994,39 +3040,6 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Fetch tags
-        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-        run: git fetch -q --tags
-      - name: Create local tag for draft version
-        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
-        run: |
-          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
-      - name: Generate short release note
-        id: release_notes
-        env:
-          look_back: 2
-          user_defined: ${{ needs.release_notes.outputs.body }}
-        run: |
-          set -ea
-          # prevent git from existing with 141
-          set +o pipefail
-
-          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
-
-          release_notes_file="$(mktemp)"
-          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
-          release_notes="${changelog}"
-          if [[ -n "${user_defined}" ]]; then
-            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
-          fi
-
-          EOF="$(openssl rand -hex 16)"
-          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
-          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
-          echo "$EOF" >> "${GITHUB_OUTPUT}"
-
-          echo "${release_notes}" > "${release_notes_file}"
-          echo "file=${release_notes_file}" >> "${GITHUB_OUTPUT}"
       - uses: balena-io/deploy-to-balena-action@31d0b891b057ae02329ab9874ccd0f1239e3c792
         id: balena_deploy
         with:
@@ -3034,7 +3047,7 @@ jobs:
           environment: ${{ inputs.balena_environment }}
           fleet: ${{ matrix.slug }}
           source: ${{ inputs.working_directory }}
-          note: ${{ steps.release_notes.outputs.note }}
+          note: ${{ needs.release_notes.outputs.note }}
           registry_secrets: |
             {
               "ghcr.io": {
@@ -3088,39 +3101,6 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Fetch tags
-        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-        run: git fetch -q --tags
-      - name: Create local tag for draft version
-        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
-        run: |
-          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
-      - name: Generate short release note
-        id: release_notes
-        env:
-          look_back: 2
-          user_defined: ${{ needs.release_notes.outputs.body }}
-        run: |
-          set -ea
-          # prevent git from existing with 141
-          set +o pipefail
-
-          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
-
-          release_notes_file="$(mktemp)"
-          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
-          release_notes="${changelog}"
-          if [[ -n "${user_defined}" ]]; then
-            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
-          fi
-
-          EOF="$(openssl rand -hex 16)"
-          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
-          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
-          echo "$EOF" >> "${GITHUB_OUTPUT}"
-
-          echo "${release_notes}" > "${release_notes_file}"
-          echo "file=${release_notes_file}" >> "${GITHUB_OUTPUT}"
       - uses: balena-io/deploy-to-balena-action@31d0b891b057ae02329ab9874ccd0f1239e3c792
         id: balena_deploy
         with:
@@ -3128,7 +3108,7 @@ jobs:
           environment: ${{ inputs.balena_environment }}
           fleet: ${{ matrix.slug }}
           source: ${{ inputs.working_directory }}
-          note: ${{ steps.release_notes.outputs.note }}
+          note: ${{ needs.release_notes.outputs.note }}
           registry_secrets: |
             {
               "ghcr.io": {
@@ -3647,45 +3627,17 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Fetch tags
-        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-        run: git fetch -q --tags
-      - name: Create local tag for draft version
-        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
-        run: |
-          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
-      - name: Generate short release note
-        id: release_notes
-        env:
-          look_back: 2
-          user_defined: ${{ needs.release_notes.outputs.body }}
-        run: |
-          set -ea
-          # prevent git from existing with 141
-          set +o pipefail
-
-          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
-
-          release_notes_file="$(mktemp)"
-          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
-          release_notes="${changelog}"
-          if [[ -n "${user_defined}" ]]; then
-            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
-          fi
-
-          EOF="$(openssl rand -hex 16)"
-          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
-          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
-          echo "$EOF" >> "${GITHUB_OUTPUT}"
-
-          echo "${release_notes}" > "${release_notes_file}"
-          echo "file=${release_notes_file}" >> "${GITHUB_OUTPUT}"
-      - name: Download all artifacts
+      - name: Download release artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           path: ${{ runner.temp }}/artifacts
           pattern: gh-release-*
           merge-multiple: true
+      - name: Download release notes
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          path: ${{ runner.temp }}
+          name: release-notes
       - name: Publish draft release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191
         with:
@@ -3696,8 +3648,8 @@ jobs:
           prerelease: true
           files: ${{ runner.temp }}/artifacts/*
           fail_on_unmatched_files: false
-          body: ${{ steps.release_notes.outputs.note }}
-          body_path: ${{ steps.release_notes.outputs.file }}
+          body: ${{ needs.release_notes.outputs.note }}
+          body_path: ${{ runner.temp }}/release-notes.txt
   github_finalize:
     name: Finalize GitHub release
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -3742,39 +3694,11 @@ jobs:
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Fetch tags
-        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-        run: git fetch -q --tags
-      - name: Create local tag for draft version
-        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
-        run: |
-          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
-      - name: Generate short release note
-        id: release_notes
-        env:
-          look_back: 2
-          user_defined: ${{ needs.release_notes.outputs.body }}
-        run: |
-          set -ea
-          # prevent git from existing with 141
-          set +o pipefail
-
-          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
-
-          release_notes_file="$(mktemp)"
-          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
-          release_notes="${changelog}"
-          if [[ -n "${user_defined}" ]]; then
-            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
-          fi
-
-          EOF="$(openssl rand -hex 16)"
-          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
-          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
-          echo "$EOF" >> "${GITHUB_OUTPUT}"
-
-          echo "${release_notes}" > "${release_notes_file}"
-          echo "file=${release_notes_file}" >> "${GITHUB_OUTPUT}"
+      - name: Download release notes
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          path: ${{ runner.temp }}
+          name: release-notes
       - name: Finalize GitHub release (if any)
         env:
           GH_DEBUG: "true"
@@ -3787,7 +3711,7 @@ jobs:
 
           if gh release view "${GITHUB_HEAD_REF}"; then
             gh release edit "${GITHUB_HEAD_REF}" \
-              --notes-file '${{ steps.release_notes.outputs.file }}' \
+              --notes-file '${{ runner.temp }}/release-notes.txt' \
               --title '${{ needs.versioned_source.outputs.tag }}' \
               --tag '${{ needs.versioned_source.outputs.tag }}' \
               --prerelease='${{ inputs.github_prerelease }}' \

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -196,11 +196,6 @@ on:
         type: boolean
         required: false
         default: false
-      checkout_fetch_depth:
-        description: Configures the depth of the actions/checkout git fetch.
-        type: number
-        required: false
-        default: 1
       runs_on:
         description: JSON array of runner label strings for default jobs.
         type: string
@@ -902,7 +897,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -951,7 +946,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1076,7 +1071,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1299,7 +1294,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1399,7 +1394,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1470,7 +1465,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1546,7 +1541,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1720,7 +1715,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1768,7 +1763,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -1871,7 +1866,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -2000,7 +1995,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -2245,7 +2240,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -2766,7 +2761,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3171,7 +3166,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3264,7 +3259,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3353,7 +3348,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3428,7 +3423,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3486,7 +3481,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3820,7 +3815,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3890,7 +3885,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -3976,7 +3971,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4039,7 +4034,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4092,7 +4087,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4162,7 +4157,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4226,7 +4221,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4287,7 +4282,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4343,7 +4338,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
@@ -4409,7 +4404,7 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          fetch-depth: ${{ inputs.checkout_fetch_depth }}
+          fetch-depth: 100
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}

--- a/README.md
+++ b/README.md
@@ -288,11 +288,6 @@ jobs:
       # Required: false
       disable_versioning: false
 
-      # Configures the depth of the actions/checkout git fetch.
-      # Type: number
-      # Required: false
-      checkout_fetch_depth: 1
-
       # JSON array of runner label strings for default jobs.
       # Type: string
       # Required: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -67,7 +67,7 @@
       environment: ${{ inputs.balena_environment }}
       fleet: ${{ matrix.slug }}
       source: ${{ inputs.working_directory }}
-      note: ${{ steps.release_notes.outputs.note }}
+      note: ${{ needs.release_notes.outputs.note }}
       registry_secrets: |
         {
           "ghcr.io": {
@@ -79,37 +79,6 @@
             "password": "${{ secrets.DOCKERHUB_TOKEN }}"
           }
         }
-
-  - &getReleaseNotes
-    name: Generate short release note
-    id: release_notes
-    # Look back should always be 2
-    # First is the current versioned tag
-    # Second is the previous versioned tag
-    env:
-      look_back: 2
-      user_defined: ${{ needs.release_notes.outputs.body }}
-    run: |
-      set -ea
-      # prevent git from existing with 141
-      set +o pipefail
-
-      previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
-
-      release_notes_file="$(mktemp)"
-      changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
-      release_notes="${changelog}"
-      if [[ -n "${user_defined}" ]]; then
-        release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
-      fi
-
-      EOF="$(openssl rand -hex 16)"
-      echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
-      echo "${release_notes}" >> "${GITHUB_OUTPUT}"
-      echo "$EOF" >> "${GITHUB_OUTPUT}"
-
-      echo "${release_notes}" > "${release_notes_file}"
-      echo "file=${release_notes_file}" >> "${GITHUB_OUTPUT}"
 
   - &getTimeStamp
     name: Get and format timestamp
@@ -1342,6 +1311,7 @@ jobs:
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
       comment: ${{ steps.format_release_notes.outputs.comment }}
+      note: ${{ steps.short_release_notes.outputs.note }}
 
     env:
       <<: *gitHubCliEnvironment
@@ -1432,6 +1402,46 @@ jobs:
                   echo "$EOF" >> $GITHUB_OUTPUT
               fi
           fi
+
+      - *checkoutVersionedSha
+      - *fetchTags
+      - *createLocalRefs
+
+      - name: Generate short release note
+        id: short_release_notes
+        # Look back should always be 2
+        # First is the current versioned tag
+        # Second is the previous versioned tag
+        env:
+          look_back: 2
+          user_defined: ${{ steps.format_release_notes.outputs.body }}
+        run: |
+          set -ea
+          # prevent git from existing with 141
+          set +o pipefail
+
+          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
+
+          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
+          release_notes="${changelog}"
+          if [[ -n "${user_defined}" ]]; then
+            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
+          fi
+
+          EOF="$(openssl rand -hex 16)"
+          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
+          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
+          echo "$EOF" >> "${GITHUB_OUTPUT}"
+
+          echo "${release_notes}" > "${{ runner.temp }}/release-notes.txt"
+
+      # https://github.com/actions/upload-artifact
+      - name: Upload release notes file
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: release-notes
+          path: ${{ runner.temp }}/release-notes.txt
+          retention-days: 1
 
   release_notes_comment:
     name: Prepare deploy message
@@ -3011,9 +3021,6 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
-      - *fetchTags
-      - *createLocalRefs
-      - *getReleaseNotes
       - *deployToBalenaAction
 
   balena_finalize:
@@ -3038,9 +3045,6 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
-      - *fetchTags
-      - *createLocalRefs
-      - *getReleaseNotes
       - *deployToBalenaAction
 
   ###################################################
@@ -3401,17 +3405,21 @@ jobs:
 
       - *deleteDraftGitHubRelease
       - *checkoutVersionedSha
-      - *fetchTags
-      - *createLocalRefs
-      - *getReleaseNotes
 
       # https://github.com/actions/download-artifact
-      - name: Download all artifacts
+      - name: Download release artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: ${{ runner.temp }}/artifacts
           pattern: gh-release-*
           merge-multiple: true
+
+      # https://github.com/actions/download-artifact
+      - name: Download release notes
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: ${{ runner.temp }}
+          name: release-notes
 
       # https://github.com/softprops/action-gh-release
       - name: Publish draft release
@@ -3424,8 +3432,8 @@ jobs:
           prerelease: true
           files: ${{ runner.temp }}/artifacts/*
           fail_on_unmatched_files: false
-          body: ${{ steps.release_notes.outputs.note }}
-          body_path: ${{ steps.release_notes.outputs.file }}
+          body: ${{ needs.release_notes.outputs.note }}
+          body_path: ${{ runner.temp }}/release-notes.txt
 
   github_finalize:
     name: Finalize GitHub release
@@ -3459,9 +3467,13 @@ jobs:
             }
 
       - *checkoutVersionedSha
-      - *fetchTags
-      - *createLocalRefs
-      - *getReleaseNotes
+
+      # https://github.com/actions/download-artifact
+      - name: Download release notes
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: ${{ runner.temp }}
+          name: release-notes
 
       # https://docs.github.com/en/rest/releases
       - name: Finalize GitHub release (if any)
@@ -3473,7 +3485,7 @@ jobs:
 
           if gh release view "${GITHUB_HEAD_REF}"; then
             gh release edit "${GITHUB_HEAD_REF}" \
-              --notes-file '${{ steps.release_notes.outputs.file }}' \
+              --notes-file '${{ runner.temp }}/release-notes.txt' \
               --title '${{ needs.versioned_source.outputs.tag }}' \
               --tag '${{ needs.versioned_source.outputs.tag }}' \
               --prerelease='${{ inputs.github_prerelease }}' \

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -83,15 +83,17 @@
   - &getReleaseNotes
     name: Generate short release note
     id: release_notes
+    # Look back should always be 2
+    # First is the current versioned tag
+    # Second is the previous versioned tag
     env:
-      look_back: 1
-      user_defined: ""
+      look_back: 2
+      user_defined: ${{ needs.release_notes.outputs.body }}
     run: |
       set -ea
       # prevent git from existing with 141
       set +o pipefail
 
-      look_back="${look_back:-1}"
       previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
 
       release_notes_file="$(mktemp)"
@@ -216,20 +218,10 @@
     name: Checkout versioned commit
     uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     with:
-      fetch-depth: ${{ inputs.checkout_fetch_depth }}
+      fetch-depth: "${{ needs.versioned_source.outputs.depth || 0 }}"
       # Note that fetch-tags is not currently working as described:
       # https://github.com/actions/checkout/issues/1781
       fetch-tags: true
-      submodules: "recursive"
-      # fallback to an invalid ref if the checkout ref is undefined
-      ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
-      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-
-  - &checkoutVersionedShaDeep # https://github.com/actions/checkout
-    name: Checkout versioned commit with total depth
-    uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-    with:
-      fetch-depth: 0
       submodules: "recursive"
       # fallback to an invalid ref if the checkout ref is undefined
       ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
@@ -249,7 +241,8 @@
   # semver is the semantic version of the tag.
   # describe is the output of `git describe --tags --always --dirty`.
   # sha is the full commit hash.
-  # depth is the number of commits since the second most recent tag.
+  # depth is set to a default number of commits to fetch on downstream jobs
+  # (enough to get last two tags, or 0 for all commits when submodules are present)
   - &describeGitState
     name: Describe git state
     id: git_describe
@@ -262,14 +255,27 @@
         echo "sha=$(git rev-parse HEAD)" ;
       } >> "${GITHUB_OUTPUT}"
 
+      if [[ "$(git submodule)" = "" ]]; then
+        echo "depth=100" >> "${GITHUB_OUTPUT}"
+      else
+        echo "depth=0" >> "${GITHUB_OUTPUT}"
+      fi
+
+  # Create a local reference for the versioned tag so that it
+  # may be consumed by build steps that need to know the version of the source.
+  # These refs should already exist on merge/finalize.
   - &createLocalRefs
-    # Create a local reference for the versioned tag so that it
-    # may be consumed by build steps that need to know the version of the source.
-    # These refs should already exist on merge/finalize.
-    name: Create local refs
+    name: Create local tag for draft version
     if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
     run: |
       git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
+
+  # Enabling fetch-tags via actions/checkout does not work when fetch-depth > 0
+  # https://github.com/actions/checkout/issues/1781
+  - &fetchTags
+    name: Fetch tags
+    if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
+    run: git fetch -q --tags
 
   - &loginWithDockerHub
     name: Login to Docker Hub
@@ -1126,6 +1132,7 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.bot }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
+      depth: ${{ steps.git_describe.outputs.depth || 0 }}
 
     env:
       <<: *gitHubCliEnvironment
@@ -3003,12 +3010,10 @@ jobs:
 
     steps:
       - *getGitHubAppToken
-      - *checkoutVersionedShaDeep
-      - <<: *getReleaseNotes
-        env:
-          look_back: 1
-          user_defined: ${{ needs.release_notes.outputs.body }}
+      - *checkoutVersionedSha
+      - *fetchTags
       - *createLocalRefs
+      - *getReleaseNotes
       - *deployToBalenaAction
 
   balena_finalize:
@@ -3032,12 +3037,10 @@ jobs:
 
     steps:
       - *getGitHubAppToken
-      - *checkoutVersionedShaDeep
-      - <<: *getReleaseNotes
-        env:
-          look_back: 2
-          user_defined: ${{ needs.release_notes.outputs.body }}
-
+      - *checkoutVersionedSha
+      - *fetchTags
+      - *createLocalRefs
+      - *getReleaseNotes
       - *deployToBalenaAction
 
   ###################################################
@@ -3397,11 +3400,10 @@ jobs:
             }
 
       - *deleteDraftGitHubRelease
-      - *checkoutVersionedShaDeep
-      - <<: *getReleaseNotes
-        env:
-          user_defined: ${{ needs.release_notes.outputs.body }}
-          look_back: 1
+      - *checkoutVersionedSha
+      - *fetchTags
+      - *createLocalRefs
+      - *getReleaseNotes
 
       # https://github.com/actions/download-artifact
       - name: Download all artifacts
@@ -3456,11 +3458,10 @@ jobs:
               "metadata": "read"
             }
 
-      - *checkoutVersionedShaDeep
-      - <<: *getReleaseNotes
-        env:
-          user_defined: ${{ needs.release_notes.outputs.body }}
-          look_back: 2
+      - *checkoutVersionedSha
+      - *fetchTags
+      - *createLocalRefs
+      - *getReleaseNotes
 
       # https://docs.github.com/en/rest/releases
       - name: Finalize GitHub release (if any)

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -974,11 +974,6 @@ on:
         type: boolean
         required: false
         default: false
-      checkout_fetch_depth:
-        description: "Configures the depth of the actions/checkout git fetch."
-        type: number
-        required: false
-        default: 1
       runs_on:
         description: "JSON array of runner label strings for default jobs."
         type: string


### PR DESCRIPTION
This also requires manually fetching all tags for
jobs that generate release notes.