### PR TITLE
Mark All jobs as failed on PR closed events

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4818,8 +4818,18 @@ jobs:
       - custom_always
     if: |
       always() &&
-      github.event.pull_request.state == 'open'
+      (
+        github.event.pull_request.state == 'open' ||
+        (
+          github.event.pull_request.state == 'closed' && github.event.pull_request.merged != true
+        )
+      )
     steps:
+      - name: Reject on closed pull requests
+        if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged != true
+        run: |
+          echo "::warning::Marking this job as failed so if the PR is reopened it does not satisfy merge requirements"
+          exit 1
       - name: Reject failed jobs
         run: |
           if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ]

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4265,11 +4265,26 @@ jobs:
       - cargo_publish
       - custom_publish
       - custom_always
+    # Run on event triggers for open PRs
+    # OR when the PR is closed but not merged
+    # See https://github.com/product-os/flowzone/issues/1143
     if: |
       always() &&
-      github.event.pull_request.state == 'open'
+      (
+        github.event.pull_request.state == 'open' ||
+        (
+          github.event.pull_request.state == 'closed' && github.event.pull_request.merged != true
+        )
+      )
 
     steps:
+      # Avoid showing this job as skipped if a PR is reopened
+      # See https://github.com/product-os/flowzone/issues/1143
+      - name: Reject on closed pull requests
+        if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged != true
+        run: |
+          echo "::warning::Marking this job as failed so if the PR is reopened it does not satisfy merge requirements"
+          exit 1
       - *rejectFailedJobs
       - *rejectCancelledJobs
 


### PR DESCRIPTION
This job is used for branch requirements, and
we don't want it to show as skipped in case the PR is ever reopened.

See: https://github.com/product-os/flowzone/issues/1143

Change-type: minor