### PR TITLE
CloudFormation package does not install Lambda deps.

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4547,6 +4547,23 @@ jobs:
 
           with_backoff aws cloudformation validate-template \
             --template-url "https://s3.amazonaws.com/${{ steps.make_bucket.outputs.s3_bucket }}/${tmpvalid}"
+      - name: Prepare (Python) Lambda dependencies
+        run: |
+          template_base_directory="$(dirname '${{ steps.shared.outputs.template_file }}')"
+
+          python_lambdas="$(cat '${{ steps.shared.outputs.template_file }}' \
+            | yq e -oj \
+            | jq -r '.Resources[]
+            | select((.Type=="AWS::Lambda::Function")
+            and (.Properties.Runtime | startswith("python"))).Properties.Code')"
+
+          for python_lambda in ${python_lambdas}; do
+              pushd "${template_base_directory}/${python_lambda}"
+              if [[ -s requirements.txt ]]; then
+                  pip install -r requirements.txt -t .
+              fi
+              popd
+          done
       - name: Package template
         run: |
           source '${{ steps.functions.outputs.with_backoff }}'

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3318,7 +3318,7 @@ jobs:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           wranglerVersion: "3.5.1" # latest - https://www.npmjs.com/package/wrangler
           command: pages deploy --branch ${{ env.CF_BRANCH }} --project-name=${{ inputs.cloudflare_website }} build/
-      
+
       - name: Set Cloudflare Pages deployment-url to output
         id: output_cf_url
         if: steps.deploy_cf_pages.outputs.deployment-url != ''
@@ -4085,6 +4085,24 @@ jobs:
 
           with_backoff aws cloudformation validate-template \
             --template-url "https://s3.amazonaws.com/${{ steps.make_bucket.outputs.s3_bucket }}/${tmpvalid}"
+
+      - name: Prepare (Python) Lambda dependencies
+        run: |
+          template_base_directory="$(dirname '${{ steps.shared.outputs.template_file }}')"
+
+          python_lambdas="$(cat '${{ steps.shared.outputs.template_file }}' \
+            | yq e -oj \
+            | jq -r '.Resources[]
+            | select((.Type=="AWS::Lambda::Function")
+            and (.Properties.Runtime | startswith("python"))).Properties.Code')"
+
+          for python_lambda in ${python_lambdas}; do
+              pushd "${template_base_directory}/${python_lambda}"
+              if [[ -s requirements.txt ]]; then
+                  pip install -r requirements.txt -t .
+              fi
+              popd
+          done
 
       - name: Package template
         run: |


### PR DESCRIPTION
Tested [here](https://github.com/balena-io/environment-staging/actions/runs/10409345156/job/28831503909#step:16:52)

There needs to be an additional step when packaging CFN tempates containing Lambda/Code: reference directory. By default, without using a completely different CFN "SAML" workflow (we don't want to go there maybe yet), dependencies need to be installed into the same directory as the Lamda code.

This comit implements this workflow for Python code when requirements.txt is present.

change-type: patch