### PR TITLE
Check if Code does in fact point to a valid directory

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4551,18 +4551,20 @@ jobs:
         run: |
           template_base_directory="$(dirname '${{ steps.shared.outputs.template_file }}')"
 
-          python_lambdas="$(cat '${{ steps.shared.outputs.template_file }}' \
+          python_lambdas="$(cat <'${{ steps.shared.outputs.template_file }}' \
             | yq e -oj \
             | jq -r '.Resources[]
             | select((.Type=="AWS::Lambda::Function")
             and (.Properties.Runtime | startswith("python"))).Properties.Code')"
 
           for python_lambda in ${python_lambdas}; do
-              pushd "${template_base_directory}/${python_lambda}"
-              if [[ -s requirements.txt ]]; then
-                  pip install -r requirements.txt -t .
+              if [[ -d "$template_base_directory/$python_lambda" ]]; then
+                  pushd "${template_base_directory}/${python_lambda}"
+                  if [[ -s requirements.txt ]]; then
+                      pip install -r requirements.txt -t .
+                  fi
+                  popd
               fi
-              popd
           done
       - name: Package template
         run: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4090,18 +4090,20 @@ jobs:
         run: |
           template_base_directory="$(dirname '${{ steps.shared.outputs.template_file }}')"
 
-          python_lambdas="$(cat '${{ steps.shared.outputs.template_file }}' \
+          python_lambdas="$(cat <'${{ steps.shared.outputs.template_file }}' \
             | yq e -oj \
             | jq -r '.Resources[]
             | select((.Type=="AWS::Lambda::Function")
             and (.Properties.Runtime | startswith("python"))).Properties.Code')"
 
           for python_lambda in ${python_lambdas}; do
-              pushd "${template_base_directory}/${python_lambda}"
-              if [[ -s requirements.txt ]]; then
-                  pip install -r requirements.txt -t .
+              if [[ -d "$template_base_directory/$python_lambda" ]]; then
+                  pushd "${template_base_directory}/${python_lambda}"
+                  if [[ -s requirements.txt ]]; then
+                      pip install -r requirements.txt -t .
+                  fi
+                  popd
               fi
-              popd
           done
 
       - name: Package template


### PR DESCRIPTION
`AWS::Lambda::Function(s)` can have different code syntax

(1) point to a directory to be packaged manually

```
  LambdaFunction:
    Type: AWS::Lambda::Function
    Properties:
      Code: lambda/
      Handler: handler.lambda_handler
```

(2) inline

```
  BackupCopyManagerLambda:
    Type: AWS::Lambda::Function
    Properties:
      Handler: index.lambda_handler
      Code:
        ZipFile: |
          import time, json, boto3, os, sys, logging, urllib3

          COPY_TO_ACCOUNT_TAG = os.environ.get('COPY_TO_ACCOUNT_TAG')
          ...
```

This patch should handle both cases (currently it only handles 1).

change-type: patch