### PR TITLE
Handle another Lambda function definition

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4555,9 +4555,9 @@ jobs:
             | yq e -oj \
             | jq -r '.Resources[]
             | select((.Type=="AWS::Lambda::Function")
-            and (.Properties.Runtime | startswith("python"))).Properties.Code')"
+            and (.Properties.Runtime | select (.!=null) | startswith("python"))).Properties.Code')"
 
-          for python_lambda in ${python_lambdas}; do
+          for python_lambda in ${python_lambdas:-}; do
               if [[ -d "$template_base_directory/$python_lambda" ]]; then
                   pushd "${template_base_directory}/${python_lambda}"
                   if [[ -s requirements.txt ]]; then

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4094,9 +4094,9 @@ jobs:
             | yq e -oj \
             | jq -r '.Resources[]
             | select((.Type=="AWS::Lambda::Function")
-            and (.Properties.Runtime | startswith("python"))).Properties.Code')"
+            and (.Properties.Runtime | select (.!=null) | startswith("python"))).Properties.Code')"
 
-          for python_lambda in ${python_lambdas}; do
+          for python_lambda in ${python_lambdas:-}; do
               if [[ -d "$template_base_directory/$python_lambda" ]]; then
                   pushd "${template_base_directory}/${python_lambda}"
                   if [[ -s requirements.txt ]]; then


### PR DESCRIPTION
Apparently there is also this variant:

```
  Function:
    Type: AWS::Lambda::Function
    Properties:
      Code:
        ImageUri: !Ref EcrRepositoryUri
        ...
```

To handle it, let `jq` return a null without erroring back to the shell and let the for loop handle empties.

change-type: patch