### PR TITLE
Provide temporary credentials when performing git fetch

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -742,7 +742,12 @@ jobs:
           persist-credentials: false
       - name: Fetch tags
         if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-        run: git fetch -q --tags
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch -q --tags
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -1598,8 +1603,12 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
         run: |
-          git fetch origin ${{ github.ref }}
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
       - id: custom_test_values
         if: contains(inputs.custom_test_matrix, '{') != true
@@ -4066,8 +4075,12 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
         run: |
-          git fetch origin ${{ github.ref }}
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -4137,8 +4150,12 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
         run: |
-          git fetch origin ${{ github.ref }}
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -4202,8 +4219,12 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
         run: |
-          git fetch origin ${{ github.ref }}
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
       - name: Set the matrix value env var
         shell: bash
@@ -4264,8 +4285,12 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
         run: |
-          git fetch origin ${{ github.ref }}
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
       - uses: ./.github/actions/clean
         with:
@@ -4321,8 +4346,12 @@ jobs:
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
         run: |
-          git fetch origin ${{ github.ref }}
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
           git checkout FETCH_HEAD -- .github
       - uses: ./.github/actions/always
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -204,9 +204,22 @@
     # checkout the tip of BASE if the PR is from a fork
     # or the merge commit if the PR is internal
     name: Reset .github directory to ${{ github.ref }}
-    # <<: *ifExternalPullRequest
+    env:
+      GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+    # Use bash without tracing to avoid leaking secrets
+    shell: bash
+    # Create base64 encoded auth header
+    #
+    # Use git-c for non-persistent credential configuration
+    # 
+    # The git -c option sets a configuration value for a single Git command invocation.
+    # It does not modify any configuration files or persist the setting beyond this specific command.
+    # 
+    # This approach ensures that the authentication credentials are used securely for this
+    # specific operation without risk of unintended persistence or exposure in configuration files.
     run: |
-      git fetch origin ${{ github.ref }}
+      auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+      git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
       git checkout FETCH_HEAD -- .github
 
   # Resolve tag, semver, sha, and description of current git working copy.
@@ -245,11 +258,25 @@
 
   # Enabling fetch-tags via actions/checkout does not work when fetch-depth > 0
   # https://github.com/actions/checkout/issues/1781
-  # FIXME: this step is broken now that we do not persist credentials from the checkout step
   - &fetchTags
     name: Fetch tags
     if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-    run: git fetch -q --tags
+    env:
+      GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+    # Use bash without tracing to avoid leaking secrets
+    shell: bash
+    # Create base64 encoded auth header
+    #
+    # Use git -c for non-persistent credential configuration
+    # 
+    # The git -c option sets a configuration value for a single Git command invocation.
+    # It does not modify any configuration files or persist the setting beyond this specific command.
+    # 
+    # This approach ensures that the authentication credentials are used securely for this
+    # specific operation without risk of unintended persistence or exposure in configuration files.
+    run: |
+      auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+      git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch -q --tags
 
   - &loginWithDockerHub
     name: Login to Docker Hub


### PR DESCRIPTION
In a [previous change](https://github.com/product-os/flowzone/pull/1187) we disabled persistence of auth following the actions/checkout step.

This PR is to manually provide temporary auth to `git fetch` steps that were relying on the existing auth before.

Change-type: patch