### PR TITLE
Wait for approvals on pull_request_target events

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -257,11 +257,6 @@ on:
         type: boolean
         required: false
         default: true
-      ok_to_test_label:
-        description: Require a label before running checks for external contributions (forks).
-        type: string
-        required: false
-        default: ok-to-test
       release_notes:
         description: Create git tags and a PR comment with detailed change log.
         type: boolean
@@ -291,7 +286,6 @@ jobs:
   event_types:
     name: Event Types
     runs-on: ${{ fromJSON(inputs.runs_on) }}
-    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     if: |
       (
         (
@@ -329,32 +323,13 @@ jobs:
           echo "::error::Internal workflows should not be used with 'pull_request_target' events. \
             Please consult the documentation for more information."
           exit 1
-      - name: Reject unapproved pull_request_target events
-        if: |
-          inputs.ok_to_test_label != '' &&
-          github.event.pull_request.state == 'open' &&
-          github.event.pull_request.head.repo.full_name != github.repository
-        env:
-          GH_DEBUG: "true"
-          GH_PAGER: cat
-          GH_PROMPT_DISABLED: "true"
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pr_labels="$(gh pr view ${{ github.event.pull_request.number }} --json labels -q .labels[].name)"
-
-          for label in ${pr_labels}
-          do
-            if [[ "$label" =~ '${{ inputs.ok_to_test_label }}' ]]
-            then
-              gh pr edit ${{ github.event.pull_request.number }} --remove-label '${{ inputs.ok_to_test_label }}'
-              exit 0
-            fi
-          done
-
-          echo "::error::External contributions must be approved with the label '${{ inputs.ok_to_test_label }}'. \
-            Please contact a member of the organization for assistance."
-          exit 1
+      - name: Wait for approval on pull_request_target events
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.merged != true
+        timeout-minutes: 90
+        uses: product-os/review-commit-action@v0.1.4
+        with:
+          poll-interval: "10"
+          allow-authors: false
       - name: Reject missing secrets
         run: |
           if [ -z '${{ secrets.FLOWZONE_TOKEN }}${{ secrets.GH_APP_PRIVATE_KEY }}' ]

--- a/README.md
+++ b/README.md
@@ -359,11 +359,6 @@ jobs:
       # Required: false
       toggle_auto_merge: true
 
-      # Require a label before running checks for external contributions (forks).
-      # Type: string
-      # Required: false
-      ok_to_test_label: ok-to-test
-
       # Create git tags and a PR comment with detailed change log.
       # Type: boolean
       # Required: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -553,32 +553,6 @@
         exit 1
       fi
 
-  # require the label 'ok-to-test' to be present on the PR before running checks
-  # and remove the label after every run so it must be re-added on push, retest, etc.
-  - &rejectUnapprovedPullRequestTarget
-    name: Reject unapproved pull_request_target events
-    if: |
-      inputs.ok_to_test_label != '' &&
-      github.event.pull_request.state == 'open' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    env:
-      <<: *gitHubCliEnvironment
-    run: |
-      pr_labels="$(gh pr view ${{ github.event.pull_request.number }} --json labels -q .labels[].name)"
-
-      for label in ${pr_labels}
-      do
-        if [[ "$label" =~ '${{ inputs.ok_to_test_label }}' ]]
-        then
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label '${{ inputs.ok_to_test_label }}'
-          exit 0
-        fi
-      done
-
-      echo "::error::External contributions must be approved with the label '${{ inputs.ok_to_test_label }}'. \
-        Please contact a member of the organization for assistance."
-      exit 1
-
   - &rejectExternalPullRequest
     name: Reject external pull_request events on pull_request
     if: |
@@ -1029,11 +1003,6 @@ on:
         type: boolean
         required: false
         default: true
-      ok_to_test_label:
-        description: "Require a label before running checks for external contributions (forks)."
-        type: string
-        required: false
-        default: "ok-to-test"
       release_notes:
         description: "Create git tags and a PR comment with detailed change log."
         type: boolean
@@ -1081,7 +1050,6 @@ jobs:
   event_types:
     name: Event Types
     runs-on: ${{ fromJSON(inputs.runs_on) }}
-    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     if: |
       (
         (
@@ -1108,7 +1076,20 @@ jobs:
     steps:
       - *rejectExternalPullRequest
       - *rejectInternalPullRequestTarget
-      - *rejectUnapprovedPullRequestTarget
+      
+      # Combining pull_request_target workflow trigger with an explicit checkout of an
+      # untrusted PR is a dangerous practice that may lead to repository compromise.
+      # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+      # This action requires approvals via reactions for each workflow run.
+      # https://github.com/product-os/review-commit-action
+      - name: Wait for approval on pull_request_target events
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.merged != true
+        timeout-minutes: 90
+        uses: product-os/review-commit-action@v0.1.4
+        with:
+          poll-interval: '10'
+          allow-authors: false
+
       - *rejectMissingSecrets
       - *logGitHubContext
 


### PR DESCRIPTION
The existing method of using labels allows for
Actions Time Of Check to Time Of Use (TOCTOU) attacks because we do not associate the label with any commit.

This action requires approvals via reactions on a unique comment for every workflow run.

See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
See: https://balena.fibery.io/Work/Improvement/Require-approvals-for-pull_request_target-triggers-in-Flowzone-2260
See: https://github.com/product-os/review-commit-action