### PR TITLE
Do not run cargo publish if disabled in Cargo.toml

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1404,6 +1404,7 @@ jobs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
       cargo_sbom: ${{ inputs.generate_sbom }}
+      cargo_publish: ${{ steps.cargo_publish.outputs.value }}
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
@@ -1462,6 +1463,14 @@ jobs:
           else
             echo "enabled=false" >> "${GITHUB_OUTPUT}"
           fi
+      - name: Check private
+        if: steps.cargo_yml.outputs.enabled == 'true'
+        uses: dangdennis/toml-action@v1.3.0
+        id: cargo_publish
+        with:
+          file: Cargo.toml
+          field: package.publish
+          working-directory: ${{ inputs.working_directory }}
   is_balena:
     name: Is balena
     runs-on: ${{ fromJSON(inputs.runs_on) }}
@@ -3997,6 +4006,7 @@ jobs:
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crate to ${{ env.CARGO_REGISTRY }}
+        if: needs.is_cargo.outputs.cargo_publish != 'false'
         env:
           CARGO_REGISTRY_DEFAULT: ${{ env.CARGO_REGISTRY }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2030,6 +2030,7 @@ jobs:
       cargo_targets: ${{ steps.cargo_targets.outputs.build }}
       cargo: ${{ steps.cargo_yml.outputs.enabled }}
       cargo_sbom: ${{ inputs.generate_sbom }}
+      cargo_publish: ${{ steps.cargo_publish.outputs.value }}
 
     steps:
       - *getGitHubAppToken
@@ -2051,6 +2052,15 @@ jobs:
           else
             echo "enabled=false" >> "${GITHUB_OUTPUT}"
           fi
+
+      - name: Check private
+        if: steps.cargo_yml.outputs.enabled == 'true'
+        uses: dangdennis/toml-action@v1.3.0
+        id: cargo_publish
+        with:
+          file: "Cargo.toml"
+          field: "package.publish"
+          working-directory: ${{ inputs.working_directory }}
 
   # check for balena.yml in source
   is_balena:
@@ -3701,6 +3711,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Publish crate to ${{ env.CARGO_REGISTRY }}
+        if: needs.is_cargo.outputs.cargo_publish != 'false'
         env:
           CARGO_REGISTRY_DEFAULT: ${{ env.CARGO_REGISTRY }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust_test"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The cargo_finalize step publishes to the configured registry if CARGO_REGISTRY_TOKEN is set, but this step will fail if `publish` is set to false in Cargo.toml. This disables the step in that case to prevent an error.

Change-type: patch