### PR TITLE
Add missing permissions to create PR comments

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -285,7 +285,7 @@ env:
 jobs:
   event_types:
     name: Event Types
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    runs-on: ubuntu-latest
     if: |
       (
         (
@@ -306,6 +306,8 @@ jobs:
         include:
           - event_name: ${{ github.event_name }}
             event_action: ${{ github.event.action }}
+    permissions:
+      pull-requests: write
     steps:
       - name: Reject external pull_request events on pull_request
         if: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1049,7 +1049,7 @@ env:
 jobs:
   event_types:
     name: Event Types
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    runs-on: ubuntu-latest
     if: |
       (
         (
@@ -1072,6 +1072,10 @@ jobs:
         include:
           - event_name: ${{ github.event_name }}
             event_action: ${{ github.event.action }}
+
+    permissions:
+      # Required to create comments on pull requests.
+      pull-requests: write
 
     steps:
       - *rejectExternalPullRequest


### PR DESCRIPTION
On PRs from forks the approval action was lacking
permission to create comments.

Change-type: patch