### PR TITLE
Revert to automatic github token for website comments

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3494,7 +3494,9 @@ jobs:
       !failure() && !cancelled() &&
       (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
       needs.is_website.result == 'success'
-    permissions: {}
+    permissions:
+      issues: read
+      pull-requests: write
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
@@ -3508,8 +3510,7 @@ jobs:
           permissions: |-
             {
               "metadata": "read",
-              "contents": "read",
-              "pull_requests": "write"
+              "contents": "read"
             }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -3567,6 +3568,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Website deployed to CF Pages, 👀 preview link
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create or update Cloudflare Pages link comment if deployment link present
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: steps.deploy_cf_pages.outputs.deployment-url != ''
@@ -3574,7 +3576,7 @@ jobs:
           comment-id: ${{ steps.find_cf_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             Website deployed to CF Pages, 👀 preview link ${{ steps.deploy_cf_pages.outputs.deployment-url }}
   github_clean:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ on:
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
 permissions:
   id-token: write # AWS GitHub OIDC provider
+  issues: read # List issue comments
   packages: write # push manifests to ghcr.io
   pull-requests: write # comment on PRs
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3357,7 +3357,9 @@ jobs:
       (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
       needs.is_website.result == 'success'
 
-    permissions: {}
+    permissions:
+      issues: read # List issue comments
+      pull-requests: write # Comment on PRs
 
     steps:
       - <<: *getGitHubAppToken
@@ -3366,8 +3368,7 @@ jobs:
           permissions: >-
             {
               "metadata": "read",
-              "contents": "read",
-              "pull_requests": "write"
+              "contents": "read"
             }
       - *checkoutVersionedSha
       - *createLocalRefs
@@ -3420,6 +3421,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Website deployed to CF Pages, 👀 preview link
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create or update Cloudflare Pages link comment if deployment link present
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
@@ -3428,7 +3430,7 @@ jobs:
           comment-id: ${{ steps.find_cf_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             Website deployed to CF Pages, 👀 preview link ${{ steps.deploy_cf_pages.outputs.deployment-url }}
 


### PR DESCRIPTION
Posting a comment to a PR does not require the elevated access of the flowzone-app[bot] so we can just go back to using the automatic github token with hardcoded permissions as we were before.

Change-type: patch