### PR TITLE
Only generate installation tokens when App ID is provided

### DIFF
--- a/.github/actions/always/action.yml
+++ b/.github/actions/always/action.yml
@@ -31,10 +31,11 @@ runs:
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      if: ${{ fromJSON(inputs.json).app_id }}
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: organization
+        installation_retrieval_payload: ${{ github.repository_owner }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/clean/action.yml
+++ b/.github/actions/clean/action.yml
@@ -31,10 +31,11 @@ runs:
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      if: ${{ fromJSON(inputs.json).app_id }}
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: organization
+        installation_retrieval_payload: ${{ github.repository_owner }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/finalize/action.yml
+++ b/.github/actions/finalize/action.yml
@@ -31,10 +31,11 @@ runs:
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      if: ${{ fromJSON(inputs.json).app_id }}
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: organization
+        installation_retrieval_payload: ${{ github.repository_owner }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -55,11 +55,12 @@ runs:
     # https://github.com/marketplace/actions/github-app-token
     - name: Generate GitHub App installation token
       uses: tibdex/github-app-token@0914d50df753bbc42180d982a6550f195390069f # v2.0.0
+      if: ${{ fromJSON(inputs.json).app_id }}
       id: gh_app_installation_token
       with:
         app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: id
-        installation_retrieval_payload: ${{ fromJSON(inputs.json).installation_id }}
+        installation_retrieval_mode: organization
+        installation_retrieval_payload: ${{ github.repository_owner }}
         private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
         permissions: ${{ fromJSON(inputs.json).token_scope }}
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,6 @@
 		"**/vendor/**",
 		"**/examples/**",
 		"**/__tests__/**",
-		"**/test/**",
 		"**/tests/**",
 		"**/__fixtures__/**",
 		".github/workflows/flowzone.yml"

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -104,15 +104,14 @@ on:
         required: false
         default: ""
       app_id:
-        description: GitHub App id to impersonate
+        description: GitHub App ID to impersonate
         type: string
         required: false
-        default: ${{ vars.APP_ID || '291899' }}
+        default: ${{ vars.APP_ID }}
       installation_id:
-        description: GitHub App installation id
+        description: Deprecated, no longer used
         type: string
         required: false
-        default: ${{ vars.INSTALLATION_ID || '34040165' }}
       token_scope:
         description: Ephemeral token scope(s)
         type: string
@@ -372,12 +371,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -621,12 +620,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -785,12 +784,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -921,12 +920,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -972,12 +971,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1087,12 +1086,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1312,12 +1311,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1415,12 +1414,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1496,12 +1495,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1574,12 +1573,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1754,12 +1753,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1804,12 +1803,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -1909,12 +1908,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -2040,12 +2039,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -2171,12 +2170,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -2227,12 +2226,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -2290,12 +2289,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -2818,12 +2817,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3042,12 +3041,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3106,12 +3105,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3175,12 +3174,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3270,12 +3269,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3361,12 +3360,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3438,12 +3437,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3500,12 +3499,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3596,12 +3595,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3641,12 +3640,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3718,12 +3717,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3801,12 +3800,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3873,12 +3872,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -3961,12 +3960,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -4026,12 +4025,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -4085,12 +4084,12 @@ jobs:
           exit 1
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned commit
@@ -4160,12 +4159,12 @@ jobs:
           exit 1
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned commit
@@ -4229,12 +4228,12 @@ jobs:
           exit 1
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned commit
@@ -4295,12 +4294,12 @@ jobs:
           exit 1
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned commit
@@ -4356,12 +4355,12 @@ jobs:
           exit 1
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
       - name: Checkout versioned commit
@@ -4425,12 +4424,12 @@ jobs:
           version: 2.15.43
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
@@ -4966,12 +4965,12 @@ jobs:
     steps:
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        continue-on-error: true
+        if: inputs.app_id
         id: gh_app_token
         with:
           app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: id
-          installation_retrieval_payload: ${{ inputs.installation_id }}
+          installation_retrieval_mode: organization
+          installation_retrieval_payload: ${{ github.repository_owner }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {

--- a/README.md
+++ b/README.md
@@ -193,15 +193,15 @@ jobs:
       # Required: false
       cloudformation_templates: 
 
-      # GitHub App id to impersonate
+      # GitHub App ID to impersonate
       # Type: string
       # Required: false
-      app_id: ${{ vars.APP_ID || '291899' }}
+      app_id: ${{ vars.APP_ID }}
 
-      # GitHub App installation id
+      # Deprecated, no longer used
       # Type: string
       # Required: false
-      installation_id: ${{ vars.INSTALLATION_ID || '34040165' }}
+      installation_id:
 
       # Ephemeral token scope(s)
       # Type: string

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -14,14 +14,13 @@
   - &getGitHubAppToken # https://github.com/marketplace/actions/github-app-token
     name: Generate GitHub App installation token
     uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-    continue-on-error: true
+    if: inputs.app_id
     id: gh_app_token
     with: &getGitHubAppTokenWith
       app_id: ${{ inputs.app_id }}
-      installation_retrieval_mode: id
-      installation_retrieval_payload: ${{ inputs.installation_id }}
+      installation_retrieval_mode: organization
+      installation_retrieval_payload: ${{ github.repository_owner }}
       private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-      # permissions: ${{ inputs.token_scope }}
       permissions: >-
         {
           "contents": "read",
@@ -841,20 +840,15 @@ on:
         required: false
         default: ""
       app_id:
-        description: "GitHub App id to impersonate"
+        description: "GitHub App ID to impersonate"
         type: string
         required: false
-        # https://github.com/organizations/product-os/settings/apps/flowzone-app
-        # https://github.com/organizations/product-os/settings/variables/actions/APP_ID
-        default: "${{ vars.APP_ID || '291899' }}"
+        default: "${{ vars.APP_ID }}"
       # not needed if installed on this current org/repo
       installation_id:
-        description: "GitHub App installation id"
+        description: "Deprecated, no longer used"
         type: string
         required: false
-        # https://github.com/organizations/product-os/settings/installations
-        # https://github.com/organizations/product-os/settings/variables/actions/INSTALLATION_ID
-        default: "${{ vars.INSTALLATION_ID || '34040165' }}"
       token_scope:
         description: "Ephemeral token scope(s)"
         type: string


### PR DESCRIPTION
This allows us to fail the step as expected if an App ID is provided but we are unable to generate a token. Otherwise it is very hard to find the issue in the logs.

Change-type: minor