### PR TITLE
Set a 60 min timeout for event_types jobs

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -285,6 +285,7 @@ jobs:
   event_types:
     name: Event Types
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: |
       (
         (
@@ -347,7 +348,6 @@ jobs:
             }
       - name: Wait for approval on pull_request_target events
         if: github.event_name == 'pull_request_target' && github.event.pull_request.merged != true
-        timeout-minutes: 90
         uses: product-os/review-commit-action@cddebf4cec8e40ea8f698b6dcce8cd70e38b7320
         with:
           poll-interval: "10"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1043,6 +1043,9 @@ jobs:
   event_types:
     name: Event Types
     runs-on: ubuntu-latest
+    # Wait up to 60 min for workflow approvals on forks.
+    # App Installation tokens expire in 1h either way.
+    timeout-minutes: 60
     if: |
       (
         (
@@ -1089,7 +1092,6 @@ jobs:
       # https://github.com/product-os/review-commit-action
       - name: Wait for approval on pull_request_target events
         if: github.event_name == 'pull_request_target' && github.event.pull_request.merged != true
-        timeout-minutes: 90
         uses: product-os/review-commit-action@cddebf4cec8e40ea8f698b6dcce8cd70e38b7320 # v0.1.7
         with:
           poll-interval: "10"


### PR DESCRIPTION
We are now using an app installation token for the workflow approval action, and this token expires after 1h.

Note that the job can still be re-run and the approval will be requested again.

See: https://balena.fibery.io/Work/Improvement/Define-explicit-permissions-in-Flowzone-for-GITHUB_TOKEN-2307