### PR TITLE
Fix a typo in the test workflow providing discussion: read access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ permissions:
   deployments: none
   id-token: none # AWS GitHub OIDC provider
   issues: none
-  discussions: read
+  discussions: none
   # packages: read
   packages: write # Allow Flowzone to publish to ghcr.io
   pages: none


### PR DESCRIPTION
The default read-only policy does not provide any discussion permissions, so we should update this test workflow to remain aligned for clarity.

See: https://balena.fibery.io/Work/Improvement/Define-explicit-permissions-in-Flowzone-for-GITHUB_TOKEN-2307