### PR TITLE
Ignore failures to upload SARIF file for private repos

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -971,6 +971,7 @@ jobs:
           disable_rules: shellcheck,local-action,runner-label
       - name: Upload SARIF file to GitHub
         uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: ${{ github.event.repository.private == true }}
         with:
           sarif_file: ${{steps.octoscan.outputs.sarif_output}}
           category: octoscan

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1694,6 +1694,7 @@ jobs:
 
       - name: Upload SARIF file to GitHub
         uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: ${{ github.event.repository.private == true }}
         with:
           sarif_file: "${{steps.octoscan.outputs.sarif_output}}"
           category: octoscan


### PR DESCRIPTION
Private repositories seem to not have the required permissions for upload.

See: https://balena.fibery.io/Work/Improvement/Run-octoscan-as-part-of-Flowzone-workflows-2384
See: https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions