### PR TITLE
Unset the token permissions for octoscan

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -953,8 +953,6 @@ jobs:
     timeout-minutes: 5
     needs:
       - event_types
-    permissions:
-      contents: read
     steps:
       - name: Checkout event ref
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1661,9 +1661,10 @@ jobs:
     needs:
       - event_types
 
-    permissions:
-      # security-events: write # used to push the output of octoscan to GitHub code scanning.
-      contents: read # Used for checkout
+    # The calling workflow must set these permissions to use these optional features.
+    # permissions:
+    #   security-events: write # required by github/codeql-action/upload-sarif
+    #   contents: read # required by github/codeql-action/upload-sarif
 
     steps:
       # No need for the Flowzone Installation App token here as we are not cloning


### PR DESCRIPTION
In order for these permissions to be inherited, they must be set by the calling workflow.

Setting them in the job will cause workflows to not start when the permission is unavailable.

Change-type: patch