### PR TITLE
Update qemu to 9.1.2

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2418,7 +2418,7 @@ jobs:
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf
         env:
           LOG_LEVEL: debug
-          BINFMT_VERSION: qemu-v8.0.4-33
+          BINFMT_VERSION: qemu-v9.1.1
         with:
           platforms: ${{ matrix.platform }}
           image: tonistiigi/binfmt:${{ env.BINFMT_VERSION }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -586,7 +586,7 @@
     env:
       LOG_LEVEL: debug
       # renovate: datasource=docker depName=binfmt packageName=tonistiigi/binfmt
-      BINFMT_VERSION: qemu-v8.0.4-33
+      BINFMT_VERSION: qemu-v9.1.1
     with:
       platforms: ${{ matrix.platform }}
       # https://hub.docker.com/r/tonistiigi/binfmt


### PR DESCRIPTION
We need the new version to get the fix for https://gitlab.com/qemu-project/qemu/-/issues/1729 which is blocking balena-io-modules/node-systemd#11

Change-type: patch
Relates-to: balena-os/balena-supervisor#2356