### PR TITLE
Ignore SARIF file upload failures from octoscan

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -969,7 +969,7 @@ jobs:
           disable_rules: shellcheck,local-action,runner-label
       - name: Upload SARIF file to GitHub
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88
-        continue-on-error: ${{ github.event.repository.private == true }}
+        continue-on-error: true
         with:
           sarif_file: ${{steps.octoscan.outputs.sarif_output}}
           category: octoscan

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1695,7 +1695,10 @@ jobs:
 
       - name: Upload SARIF file to GitHub
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3
-        continue-on-error: ${{ github.event.repository.private == true }}
+        # Do not fail if the calling workflow failed to provide the security-events:write permission
+        # https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions
+        # https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-code-scanning-alerts
+        continue-on-error: true
         with:
           sarif_file: "${{steps.octoscan.outputs.sarif_output}}"
           category: octoscan


### PR DESCRIPTION
It is unclear why most of our public repos do
not fail this step, as expected. Add this condition for those that do, and private repos.

Change-type: patch