### PR TITLE
Use app installation token to validate linear history

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -385,41 +385,6 @@ jobs:
       GH_PROMPT_DISABLED: "true"
       GH_REPO: ${{ github.repository }}
     steps:
-      - name: Reject HEAD branches containing merge commits
-        if: github.event.pull_request.state == 'open'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
-        with:
-          github-token: ${{ github.token }}
-          result-encoding: json
-          script: |
-            const { data: commits } = await github.rest.pulls.listCommits({
-              ...context.repo,
-              pull_number: context.payload.pull_request.number
-            });
-
-            if (commits.some(({ parents }) => parents.length > 1)) {
-              throw new Error('Non-linear history detected - merge commit(s) identified in HEAD branch');
-            }
-      - name: Reject merge commits that do not include the HEAD commit as a parent
-        if: github.event.pull_request.merged
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
-        with:
-          github-token: ${{ github.token }}
-          result-encoding: json
-          script: |
-            console.debug(`Merge commit SHA: ${context.sha}`)
-            console.debug(`HEAD commit SHA: ${context.payload.pull_request.head.sha}`)
-
-            const { data: commit } = await github.rest.repos.getCommit({
-              ...context.repo,
-              ref: context.sha
-            });
-
-            console.debug('Commit parents: %s', JSON.stringify(commit.parents, null, 2))
-
-            if (!commit.parents.some(({ sha }) => sha === context.payload.pull_request.head.sha)) {
-              throw new Error('Non-linear history detected - HEAD branch commit is not a parent of the merge commit');
-            }
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         if: inputs.app_id
@@ -435,6 +400,41 @@ jobs:
               "contents": "write",
               "metadata": "read",
               "pull_requests": "read"
+            }
+      - name: Reject HEAD branches containing merge commits
+        if: github.event.pull_request.state == 'open'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          result-encoding: json
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            if (commits.some(({ parents }) => parents.length > 1)) {
+              throw new Error('Non-linear history detected - merge commit(s) identified in HEAD branch');
+            }
+      - name: Reject merge commits that do not include the HEAD commit as a parent
+        if: github.event.pull_request.merged
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          result-encoding: json
+          script: |
+            console.debug(`Merge commit SHA: ${context.sha}`)
+            console.debug(`HEAD commit SHA: ${context.payload.pull_request.head.sha}`)
+
+            const { data: commit } = await github.rest.repos.getCommit({
+              ...context.repo,
+              ref: context.sha
+            });
+
+            console.debug('Commit parents: %s', JSON.stringify(commit.parents, null, 2))
+
+            if (!commit.parents.some(({ sha }) => sha === context.payload.pull_request.head.sha)) {
+              throw new Error('Non-linear history detected - HEAD branch commit is not a parent of the merge commit');
             }
       - name: Checkout pull request head sha
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -580,7 +580,7 @@
     if: github.event.pull_request.state == 'open'
     uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
     with:
-      github-token: ${{ github.token }}
+      github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       result-encoding: json
       script: |
         const { data: commits } = await github.rest.pulls.listCommits({
@@ -604,7 +604,7 @@
     if: github.event.pull_request.merged
     uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
     with:
-      github-token: ${{ github.token }}
+      github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       result-encoding: json
       script: |
         console.debug(`Merge commit SHA: ${context.sha}`)
@@ -1191,9 +1191,6 @@ jobs:
 
     steps:
 
-      - *rejectNonLinearHead
-      - *rejectNonLinearMerge
-
       - <<: *getGitHubAppToken
         with:
           <<: *getGitHubAppTokenWith
@@ -1206,6 +1203,9 @@ jobs:
               "metadata": "read",
               "pull_requests": "read"
             }
+
+      - *rejectNonLinearHead
+      - *rejectNonLinearMerge
 
       # Checkout the tip of the pull request branch for open PRs.
       # The default behaviour for GitHub Actions is to checkout the merge commit but we


### PR DESCRIPTION
The default permissions do not always include pull_request:read

Change-type: patch