### PR TITLE
Pin buildx to v0.19.1 to fix broken bake definiton parsing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2493,6 +2493,7 @@ jobs:
         with:
           driver-opts: network=host
           install: true
+          version: v0.19.1
       - id: native_platforms
         name: Build JSON array
         shell: bash
@@ -2780,6 +2781,7 @@ jobs:
         with:
           driver-opts: network=host
           install: true
+          version: v0.19.1
       - name: Setup crane
         uses: imjasonh/setup-crane@31b88efe9de28ae0ffa220711af4b60be9435f6e
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -628,6 +628,8 @@
     with:
       driver-opts: network=host
       install: true
+      # FIXME: "Error: cannot parse bake definitions: ERROR: EOF" with v0.19.2
+      version: v0.19.1
 
   - &setupQemuBinfmt # https://github.com/docker/setup-qemu-action
     name: Setup QEMU


### PR DESCRIPTION
See: https://github.com/docker/buildx/releases/tag/v0.19.2

```
  #1 [internal] load local bake definitions
  #1 reading /home/runner/work/_temp/docker-bake.json 342B / 342B done
  #1 reading /home/runner/work/_temp/docker-actions-toolkit-DGkl1b/docker-metadata-action-bake.json 1.89kB / 1.89kB done
  #1 DONE 0.0s
  ERROR: EOF
Error: cannot parse bake definitions: ERROR: EOF
```