### PR TITLE
Add top-level flowzone.yml to custom regex manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,5 +22,18 @@
 				"executionMode": "update"
 			}
 		}
+	],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"fileMatch": [
+				"(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$",
+				"(^|/)action\\.ya?ml$",
+				"flowzone.yml"
+			],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+			]
+		}
 	]
 }

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -639,7 +639,7 @@
     uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
     env:
       LOG_LEVEL: debug
-      # renovate: datasource=docker depName=binfmt packageName=tonistiigi/binfmt
+      # renovate: datasource=docker depName=tonistiigi/binfmt
       BINFMT_VERSION: qemu-v8.0.4-33
     with:
       platforms: ${{ matrix.platform }}


### PR DESCRIPTION
Manager preset is copied from here:
https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions

Without this change Renovate was not discovering any of the `# renovate` regex in `flowzone.yml`