### PR TITLE
Add regex manager to commit hooks package rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
 	],
 	"packageRules": [
 		{
-			"matchManagers": ["github-actions"],
+			"matchManagers": ["github-actions","regex"],
 			"matchFileNames": ["flowzone.yml"],
 			"postUpgradeTasks": {
 				"commands": ["npm ci", "npm run build"],


### PR DESCRIPTION
Whether the manager is github-actions or regex, we still need to re-generate .github/workflows/flowzone.yml if ./flowzone.yml has changed.

Change-type: patch