### PR TITLE
Add tree sha to create_tree outputs

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -577,13 +577,14 @@ jobs:
               base_tree: baseTreeSha
             });
 
+            core.setOutput('sha', tree.sha);
             return tree;
       - name: Create commit object
         if: inputs.disable_versioning != true
         id: create_commit
         env:
           MESSAGE: ${{ steps.versionist.outputs.tag }}
-          TREE_SHA: ${{ fromJSON(steps.create_tree.outputs.result).sha }}
+          TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1337,6 +1337,7 @@ jobs:
               base_tree: baseTreeSha
             });
 
+            core.setOutput('sha', tree.sha);
             return tree;
 
       # https://octokit.github.io/rest.js/v21/#git-create-commit
@@ -1346,7 +1347,7 @@ jobs:
         id: create_commit
         env:
           MESSAGE: ${{ steps.versionist.outputs.tag }}
-          TREE_SHA: ${{ fromJSON(steps.create_tree.outputs.result).sha }}
+          TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:


### PR DESCRIPTION
Parsing the tree JSON will break the workflow
if versioning is disabled and the JSON is null.

Add a new 'sha' output in addition to the entire
tree returned object.

See: https://github.com/klutchell/dnscrypt-proxy-docker/actions/runs/12636875719/job/35209949431?pr=511