### PR TITLE
Add dangerous-write to octoscan ignore list

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1044,7 +1044,7 @@ jobs:
         uses: synacktiv/action-octoscan@6b1cf2343893dfb9e5f75652388bd2dc83f456b0
         with:
           filter_triggers: allnopr
-          disable_rules: shellcheck,local-action,runner-label
+          disable_rules: shellcheck,local-action,runner-label,dangerous-write
       - name: Upload SARIF file to GitHub
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         continue-on-error: true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1768,7 +1768,7 @@ jobs:
           # external: https://github.com/synacktiv/octoscan/blob/3f7fd6e563be43432cef874c82a7714f67a8ef92/common/helpers.go#L69
           # allnopr: https://github.com/synacktiv/octoscan/blob/3f7fd6e563be43432cef874c82a7714f67a8ef92/common/helpers.go#L76
           filter_triggers: allnopr
-          disable_rules: shellcheck,local-action,runner-label
+          disable_rules: shellcheck,local-action,runner-label,dangerous-write
 
       # The codeql-action/upload-sarif action uses internal endpoints and does not work with app installation tokens
       # so here we use the github-script action to upload the SARIF file to GitHub via the REST API


### PR DESCRIPTION
The octoscan commit that added this check was clear that it needs some improved regex.

As it stands it will flag any writes to GITHUB_ENV or GITHUB_OUTPUT whether they are being used
unsafely in a following step or not.

For now let's disable it to get past all the noise until octoscan can correctly identify improper usage.

Reduces our code scanning alerts from 162 to 73 ([see here](https://github.com/product-os/flowzone/security/code-scanning?query=is%3Aopen+pr%3A1316)).

Change-type: minor