### PR TITLE
Pin helper jobs to ubuntu-24.04 runners by default

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -201,7 +201,7 @@ on:
         required: false
         default: |
           [
-            "ubuntu-22.04"
+            "ubuntu-24.04"
           ]
       docker_runs_on:
         description: JSON key-value pairs mapping platforms to arrays of runner labels. Unlisted platforms will use `runs_on`.
@@ -284,7 +284,7 @@ env:
 jobs:
   event_types:
     name: Event Types
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     if: |
       (
@@ -2649,7 +2649,7 @@ jobs:
           docker save ${{ join(fromJSON(steps.test_meta.outputs.json).tags,' ') }} -o ${DOCKER_TAR}
           zstd -v ${DOCKER_TAR}
       - name: Enable KVM group perms
-        if: contains(matrix.runs_on,'ubuntu-latest') || contains(matrix.runs_on,'ubuntu-22.04')
+        if: contains(fromJSON('["ubuntu-22.04","ubuntu-24.04","ubuntu-latest"]'), matrix.runs_on[0])
         continue-on-error: true
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ jobs:
       # Required: false
       runs_on: >
         [
-          "ubuntu-22.04"
+          "ubuntu-24.04"
         ]
 
       # JSON key-value pairs mapping platforms to arrays of runner labels. Unlisted platforms will

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -989,7 +989,7 @@ on:
         required: false
         default: >
           [
-            "ubuntu-22.04"
+            "ubuntu-24.04"
           ]
       docker_runs_on:
         description: "JSON key-value pairs mapping platforms to arrays of runner labels. Unlisted platforms will use `runs_on`."
@@ -1094,7 +1094,7 @@ env:
 jobs:
   event_types:
     name: Event Types
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Wait up to 60 min for workflow approvals on forks.
     # App Installation tokens expire in 1h either way.
     timeout-minutes: 60
@@ -3062,7 +3062,7 @@ jobs:
       # https://github.com/ankidroid/Anki-Android/commit/3a5ecaa9837691817022d11b0dbe383b8e82d9fe
       # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
       - name: Enable KVM group perms
-        if: contains(matrix.runs_on,'ubuntu-latest') || contains(matrix.runs_on,'ubuntu-22.04')
+        if: contains(fromJSON('["ubuntu-22.04","ubuntu-24.04","ubuntu-latest"]'), matrix.runs_on[0])
         continue-on-error: true
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules


### PR DESCRIPTION
This is the new default "ubuntu-latest" tag provided by GitHub starting in Dec 2024.

See: https://github.com/actions/runner-images/issues/10636