### PR TITLE
Revert "Test with unsupported node version (should use 20.x)"

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "jest": "^29.0.0"
   },
   "engines": {
-    "node": "<18.0.0"
+    "node": ">=20.0.0"
   },
   "versionist": {
     "publishedAt": "2022-10-21T11:50:36.742Z"


### PR DESCRIPTION
This reverts commit 441c9e81fa5e562870de346b1dc16e0b00e1a124.

This commit was only for testing, but the PR was merged by mistake when I didn't mark it as draft.

Change-type: patch