### PR TITLE
Use Node major version for matrix and artifact name

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1207,7 +1207,7 @@ jobs:
       - name: Check engine
         id: check_engine_18
         run: |
-          node_version="$(node --version)"
+          node_version="$(node --version | cut -d'.' -f1).x"
           if npx -q -y -- check-engine
           then
             echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"
@@ -1219,7 +1219,7 @@ jobs:
       - name: Check engine
         id: check_engine_20
         run: |
-          node_version="$(node --version)"
+          node_version="$(node --version | cut -d'.' -f1).x"
           if npx -q -y -- check-engine
           then
             echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"
@@ -1231,7 +1231,7 @@ jobs:
       - name: Check engine
         id: check_engine_22
         run: |
-          node_version="$(node --version)"
+          node_version="$(node --version | cut -d'.' -f1).x"
           if npx -q -y -- check-engine
           then
             echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1956,7 +1956,7 @@ jobs:
         name: Check engine
         id: check_engine_18
         run: |
-          node_version="$(node --version)"
+          node_version="$(node --version | cut -d'.' -f1).x"
           if npx -q -y -- check-engine
           then
             echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
The node version matrix uses full version (v22.12.0), for the install process and the build artifact name. This can cause an issue if the runners are using different Node versions

Change-type: patch