### PR TITLE
Remove version from npm artifact

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2055,7 +2055,7 @@ jobs:
         if: needs.is_npm.outputs.npm_private != 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
       - name: Generate docs (if present)
@@ -2069,7 +2069,7 @@ jobs:
         if: needs.is_npm.outputs.npm_docs == 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: docs-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/docs.tar.zst
           retention-days: 90
   npm_sbom:
@@ -2171,7 +2171,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
@@ -2232,7 +2232,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         with:
@@ -2282,7 +2282,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: docs-${{ github.event.pull_request.head.sha }}
       - name: Extract docs artifact
         run: |
           docs="$(ls ${{ runner.temp }}/*.tar.zst | sort -t- -n -k3 | tail -n1)"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2673,7 +2673,7 @@ jobs:
         if: needs.is_npm.outputs.npm_private != 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
 
@@ -2690,7 +2690,7 @@ jobs:
         if: needs.is_npm.outputs.npm_docs == 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: docs-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/docs.tar.zst
           retention-days: 90
 
@@ -2763,7 +2763,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
 
       - <<: *setupNode
         with:
@@ -2821,7 +2821,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
 
       - <<: *setupNode
         with:
@@ -2874,7 +2874,7 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: docs-${{ github.event.pull_request.head.sha }}
 
       - name: Extract docs artifact
         run: |


### PR DESCRIPTION
There is only one NPM artifact published during the npm_test job. There is no need for the version suffix.

Change-type: patch