### PR TITLE
Use Renovate to pin to latest LTS node releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,18 @@
 				"fileFilters": [".github/workflows/flowzone.yml"],
 				"executionMode": "update"
 			}
+		},
+		{
+			"matchPackageNames": ["node-18.x"],
+			"allowedVersions": "18"
+		},
+		{
+			"matchPackageNames": ["node-20.x"],
+			"allowedVersions": "20"
+		},
+		{
+			"matchPackageNames": ["node-22.x"],
+			"allowedVersions": "22"
 		}
 	],
 	"customManagers": [

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -472,8 +472,10 @@ jobs:
           fi
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
-          node-version: 20.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install versioning tools
         if: inputs.disable_versioning != true
         run: |
@@ -1202,8 +1204,10 @@ jobs:
             return json;
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 18.20.5
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Check engine
         id: check_engine_18
         run: |
@@ -1214,8 +1218,10 @@ jobs:
           fi
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
-          node-version: 20.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Check engine
         id: check_engine_20
         run: |
@@ -1226,8 +1232,10 @@ jobs:
           fi
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 22.12.0
         with:
-          node-version: 22.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Check engine
         id: check_engine_22
         run: |
@@ -1992,6 +2000,8 @@ jobs:
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
@@ -1999,6 +2009,8 @@ jobs:
         if: needs.is_npm.outputs.has_npm_lockfile == 'true'
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
@@ -2116,6 +2128,8 @@ jobs:
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
           node-version: ${{ fromJSON(needs.is_npm.outputs.node_versions)[0] }}
       - run: npm install
@@ -2174,8 +2188,10 @@ jobs:
           name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
-          node-version: "18"
+          node-version: ${{ needs.is_npm.outputs.max_node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
       - name: Publish draft release
         env:
@@ -2235,8 +2251,10 @@ jobs:
           name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
-          node-version: "18"
+          node-version: ${{ needs.is_npm.outputs.max_node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
       - name: Publish final release
         env:
@@ -3508,6 +3526,8 @@ jobs:
           git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        env:
+          NODE_VERSION: 20.18.1
         with:
           node-version: 18
       - name: Docusaurus Builder

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -629,8 +629,11 @@
   - &setupNode # https://github.com/actions/setup-node
     name: Setup Node.js
     uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+    env:
+      # renovate: datasource=node-version depName=node packageName=node-20.x
+      NODE_VERSION: 20.18.1
     with:
-      node-version: 20.x
+      node-version: ${{ env.NODE_VERSION }}
 
   - &setupCrane # https://github.com/imjasonh/setup-crane
     name: Setup crane
@@ -1948,8 +1951,9 @@ jobs:
       # if there are no engine requirements then the current LTS will be used
 
       - <<: *setupNode
-        with:
-          node-version: 18.x
+        env:
+         # renovate: datasource=node-version depName=node packageName=node-18.x
+          NODE_VERSION: 18.20.5
 
       # https://www.npmjs.com/package/check-engine
       - &checkEngine
@@ -1963,15 +1967,17 @@ jobs:
           fi
 
       - <<: *setupNode
-        with:
-          node-version: 20.x
+        env:
+          # renovate: datasource=node-version depName=node packageName=node-20.x
+          NODE_VERSION: 20.18.1
 
       - <<: *checkEngine
         id: check_engine_20
 
       - <<: *setupNode
-        with:
-          node-version: 22.x
+        env:
+          # renovate: datasource=node-version depName=node-22 packageName=node-22.x
+          NODE_VERSION: 22.12.0
 
       - <<: *checkEngine
         id: check_engine_22
@@ -2769,7 +2775,7 @@ jobs:
         with:
           # use npm v9 or later as the access flag behaviour has changed
           # https://docs.npmjs.com/cli/v9/commands/npm-publish?access
-          node-version: "18"
+          node-version: "${{ needs.is_npm.outputs.max_node_version }}"
           registry-url: "${{ env.NPM_REGISTRY }}"
 
       # unpack the tarball provided by the tests so we can apply the draft version to package.json
@@ -2827,7 +2833,7 @@ jobs:
         with:
           # use npm v9 or later as the access flag behaviour has changed
           # https://docs.npmjs.com/cli/v9/commands/npm-publish?access
-          node-version: "18"
+          node-version: "${{ needs.is_npm.outputs.max_node_version }}"
           registry-url: "${{ env.NPM_REGISTRY }}"
 
       - name: Publish final release
@@ -3586,6 +3592,7 @@ jobs:
       - *createLocalRefs
 
       - <<: *setupNode
+        # FIXME: does this need to be pinned to 18? Remove the property and use the global default otherwise.
         with:
           node-version: 18
 


### PR DESCRIPTION
This prevents drift of node versions in the tool cache between main and development branches.

Dry-run here for testing Renovate: https://github.com/product-os/.github/pull/118