### PR TITLE
Prevent linting jobs from running on PR close events

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -995,13 +995,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout event ref
+      - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 1
           submodules: false
           persist-credentials: false
           token: ${{ github.token }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Add problem matcher
         run: |
           curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json > ${{ runner.temp }}/actionlint-matcher.json
@@ -1040,13 +1041,14 @@ jobs:
               "metadata": "read",
               "security_events": "write"
             }
-      - name: Checkout event ref
+      - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 1
           submodules: false
           persist-credentials: false
           token: ${{ github.token }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - id: octoscan
         name: Run octoscan
         uses: synacktiv/action-octoscan@6b1cf2343893dfb9e5f75652388bd2dc83f456b0
@@ -1101,7 +1103,7 @@ jobs:
             const { data } = await github.rest.repos.getContent({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref
+              ref: context.payload.pull_request.head.sha || context.ref
             });
 
             return data
@@ -1120,7 +1122,7 @@ jobs:
             const { data } = await github.rest.repos.getContent({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref,
+              ref: context.payload.pull_request.head.sha || context.ref,
               path: process.env.WORKING_DIRECTORY.startsWith('./') ? process.env.WORKING_DIRECTORY.slice(2) : process.env.WORKING_DIRECTORY
             });
 
@@ -1139,13 +1141,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout event ref
+      - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 1
           submodules: false
           persist-credentials: false
           token: ${{ github.token }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
@@ -1183,13 +1186,14 @@ jobs:
       NODE_VERSIONS: "[]"
       PACKAGE_JSON_PATH: ${{ inputs.working_directory }}/package.json
     steps:
-      - name: Checkout event ref
+      - name: Checkout source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 1
           submodules: false
           persist-credentials: false
           token: ${{ github.token }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Process package.json
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: package_json

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -989,6 +989,7 @@ jobs:
     name: actionlint
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 5
+    if: github.event.action != 'closed'
     needs:
       - event_types
     permissions:
@@ -1013,7 +1014,12 @@ jobs:
     name: octoscan
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 5
-    if: github.event_name != 'pull_request_target'
+    if: |
+      github.event_name != 'pull_request_target' &&
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      )
     needs:
       - event_types
     permissions:
@@ -1127,7 +1133,9 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
-    if: contains(needs.file_list.outputs.root, '.pre-commit-config.yaml')
+    if: |
+      contains(needs.file_list.outputs.root, '.pre-commit-config.yaml') &&
+      github.event.action != 'closed'
     permissions:
       contents: read
     steps:
@@ -1150,7 +1158,12 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
-    if: contains(needs.file_list.outputs.workdir, 'package.json')
+    if: |
+      contains(needs.file_list.outputs.workdir, 'package.json') &&
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -185,6 +185,21 @@
       ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
       <<: *checkoutAuth
 
+  - &shallowCheckout # https://github.com/actions/checkout
+    name: Checkout source
+    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    with:
+      # Disable submodules and deep cloning.
+      fetch-depth: 1
+      submodules: false
+      # Do not persist credentials.
+      persist-credentials: false
+      # Use the automatic actions token with contents:read permissions
+      token: ${{ github.token }}
+      # Use the tip of the pull request branch for pull request (target) events.
+      # Use the event sha for other events.
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
   - &resetGitHubDirectory
     # checkout the tip of BASE if the PR is from a fork
     # or the merge commit if the PR is internal
@@ -1168,7 +1183,6 @@ jobs:
       <<: *gitHubCliEnvironment
 
     steps:
-
       - <<: *getGitHubAppToken
         with:
           <<: *getGitHubAppTokenWith
@@ -1675,16 +1689,13 @@ jobs:
       # No need for the Flowzone Installation App token here as we are not cloning
       # submodules so the automatic actions token scoped to the repo is fine.
 
+      # Disable submodules and deep cloning.
+      # Do not persist credentials.
+      # Use the automatic actions token with contents:read permissions.
+      # Use the tip of the pull request branch for pull request (target) events.
+      # Use the event sha for other events.
       # https://github.com/actions/checkout
-      - name: Checkout event ref
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          # We only need to scan workflow files, so disable submodules and deep cloning
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          # Use the automatic actions token with contents:read permissions
-          token: ${{ github.token }}
+      - *shallowCheckout
 
       # https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md
       - name: Add problem matcher
@@ -1723,7 +1734,6 @@ jobs:
       contents: read # required for checkout without submodules
 
     steps:
-
       - <<: *getGitHubAppToken
         with:
           <<: *getGitHubAppTokenWith
@@ -1735,16 +1745,13 @@ jobs:
               "security_events": "write"
             }
 
+      # Disable submodules and deep cloning.
+      # Do not persist credentials.
+      # Use the automatic actions token with contents:read permissions.
+      # Use the tip of the pull request branch for pull request (target) events.
+      # Use the event sha for other events.
       # https://github.com/actions/checkout
-      - name: Checkout event ref
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          # We only need to scan workflow files, so disable submodules and deep cloning
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          # Use the automatic actions token with contents:read permissions
-          token: ${{ github.token }}
+      - *shallowCheckout
 
       # https://github.com/synacktiv/octoscan
       # https://github.com/synacktiv/action-octoscan
@@ -1822,11 +1829,13 @@ jobs:
         with:
           github-token: ${{ github.token }}
           result-encoding: json
+          # Use the tip of the pull request branch for pull request (target) events.
+          # Use the event sha for other events.
           script: |
             const { data } = await github.rest.repos.getContent({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref
+              ref: context.payload.pull_request.head.sha || context.ref
             });
 
             return data
@@ -1834,6 +1843,7 @@ jobs:
               .map(item => item.name);
 
       # Use GitHub REST API to safely get contents, limiting to one directory
+      # https://github.com/actions/github-script
       # https://octokit.github.io/rest.js/v21/#repos-get-content
       - name: List files in working directory
         id: working-dir
@@ -1844,19 +1854,20 @@ jobs:
         with:
           github-token: ${{ github.token }}
           result-encoding: json
-          # remove preceeding ./ from the working directory if it exists
+          # Use the tip of the pull request branch for pull request (target) events.
+          # Use the event sha for other events.
+          # Remove preceeding ./ from the working directory if it exists.
           script: |
             const { data } = await github.rest.repos.getContent({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: context.ref,
+              ref: context.payload.pull_request.head.sha || context.ref,
               path: process.env.WORKING_DIRECTORY.startsWith('./') ? process.env.WORKING_DIRECTORY.slice(2) : process.env.WORKING_DIRECTORY
             });
 
             return data
               .filter(item => item.type === 'file')
               .map(item => item.name);
-
 
   # Run pre-commit hooks if the config file exists in the project root.
   # This step will fail if the hooks find any differences after running.
@@ -1881,17 +1892,13 @@ jobs:
       contents: read # Required to checkout source project, without submodules
 
     steps:
+      # Disable submodules and deep cloning.
+      # Do not persist credentials.
+      # Use the automatic actions token with contents:read permissions.
+      # Use the tip of the pull request branch for pull request (target) events.
+      # Use the event sha for other events.
       # https://github.com/actions/checkout
-      - &checkoutEventRef
-        name: Checkout event ref
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          # We only need to scan workflow files, so disable submodules and deep cloning
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          # Use the automatic actions token with contents:read permissions
-          token: ${{ github.token }}
+      - *shallowCheckout
 
       # https://github.com/actions/setup-python
       - *setupPython
@@ -1922,7 +1929,7 @@ jobs:
       contents: read # Required to checkout source project, without submodules
 
     outputs:
-      npm: 'true'
+      npm: "true"
       has_npm_lockfile: ${{ contains(needs.file_list.outputs.workdir, 'package-lock.json') || contains(needs.file_list.outputs.workdir, 'npm-shrinkwrap.json') }}
       npm_private: ${{ steps.package_json.outputs.private }}
       npm_docs: ${{ steps.package_json.outputs.docs }}
@@ -1932,11 +1939,17 @@ jobs:
       max_node_version: ${{ steps.node_versions.outputs.max }}
 
     env:
-      NODE_VERSIONS: '[]'
-      PACKAGE_JSON_PATH: '${{ inputs.working_directory }}/package.json'
+      NODE_VERSIONS: "[]"
+      PACKAGE_JSON_PATH: "${{ inputs.working_directory }}/package.json"
 
     steps:
-      - *checkoutEventRef
+      # Disable submodules and deep cloning.
+      # Do not persist credentials.
+      # Use the automatic actions token with contents:read permissions.
+      # Use the tip of the pull request branch for pull request (target) events.
+      # Use the event sha for other events.
+      # https://github.com/actions/checkout
+      - *shallowCheckout
 
       - name: Process package.json
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
@@ -1969,7 +1982,7 @@ jobs:
 
       - <<: *setupNode
         env:
-         # renovate: datasource=node-version depName=node packageName=node-18.x
+          # renovate: datasource=node-version depName=node packageName=node-18.x
           NODE_VERSION: 18.20.5
 
       # https://www.npmjs.com/package/check-engine

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1662,6 +1662,8 @@ jobs:
     name: actionlint
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 5
+    # Do not run on PR close or merge events
+    if: github.event.action != 'closed'
     # Run this early in the workflow, as soon as we've validated event types
     needs:
       - event_types
@@ -1705,8 +1707,14 @@ jobs:
     name: octoscan
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 5
-    # Pull request target events will have the wrong ref and sha for SARIF uploads so skip it for now
-    if: github.event_name != 'pull_request_target'
+    # Pull request target events will have the wrong ref and sha for SARIF uploads so skip it for now.
+    # Do not run on PR close events.
+    if: |
+      github.event_name != 'pull_request_target' &&
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      )
     # Run this early in the workflow, as soon as we've validated event types
     needs:
       - event_types
@@ -1862,7 +1870,10 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
-    if: contains(needs.file_list.outputs.root, '.pre-commit-config.yaml')
+    # Do not run on PR close or merge events.
+    if: |
+      contains(needs.file_list.outputs.root, '.pre-commit-config.yaml') &&
+      github.event.action != 'closed'
 
     # No need for the Flowzone Installation App token here as we are not cloning
     # submodules so the automatic actions token scoped to the repo is fine.
@@ -1895,7 +1906,13 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
-    if: contains(needs.file_list.outputs.workdir, 'package.json')
+    # Do not run on PR close events.
+    if: |
+      contains(needs.file_list.outputs.workdir, 'package.json') &&
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      )
 
     <<: *customWorkingDirectory
 


### PR DESCRIPTION
#### Prevent linting jobs from running on PR close events

There is no value in running actionlint or pre-commit checks
on PR merge or close events.

Same with the Node version checks, no need on close events.

The octoscan checks should run on merge to update the main
branch code scanning results, but not on PR close.

Tested close event [here](https://github.com/product-os/flowzone/actions/runs/12817468822).
Note that `File List` runs without failing, so we can leverage it for `Custom always` job conditions in a future PR.

#### Use shallow checkout with github token for linting jobs
These jobs do not rely on versioned source, so they
can default to the pull request HEAD sha and fallback
to the github ref for other event types.

Using the github ref is not appropriate for pull_request_target
events where the ref/sha is always the base branch.