### PR TITLE
Use github-script to generate release notes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -670,6 +670,8 @@ jobs:
     needs:
       - versioned_source
     if: |
+      inputs.release_notes == true &&
+      needs.versioned_source.outputs.tag != '' &&
       (
         github.event.action != 'closed' ||
         github.event.pull_request.merged == true
@@ -683,7 +685,7 @@ jobs:
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
       comment: ${{ steps.format_release_notes.outputs.comment }}
-      note: ${{ steps.short_release_notes.outputs.note }}
+      note: ${{ steps.short_release_notes.outputs.result }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -854,12 +856,6 @@ jobs:
     needs:
       - versioned_source
       - release_notes
-    if: |
-      (
-        github.event.action != 'closed' ||
-        github.event.pull_request.merged == true
-      ) &&
-      inputs.release_notes == true
     defaults:
       run:
         working-directory: .
@@ -3668,7 +3664,8 @@ jobs:
       - cargo_sbom
     if: |
       !failure() && !cancelled() &&
-      github.event.pull_request.state == 'open'
+      github.event.pull_request.state == 'open' &&
+      needs.versioned_source.outputs.tag != ''
     defaults:
       run:
         working-directory: .

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -678,7 +678,8 @@ jobs:
       run:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
-    permissions: {}
+    permissions:
+      contents: read
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
       comment: ${{ steps.format_release_notes.outputs.comment }}
@@ -778,51 +779,68 @@ jobs:
                   echo "$EOF" >> $GITHUB_OUTPUT
               fi
           fi
-      - name: Checkout versioned commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
-          ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          persist-credentials: false
-      - name: Fetch tags
-        if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-        env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-        shell: bash
-        run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch -q --tags
-      - name: Create local tag for draft version
-        if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
-        run: |
-          git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
       - name: Generate short release note
         id: short_release_notes
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
-          look_back: 2
-          user_defined: ${{ steps.format_release_notes.outputs.body }}
-        run: |
-          set -ea
-          # prevent git from existing with 141
-          set +o pipefail
+          USER_DEFINED: ${{ steps.format_release_notes.outputs.body }}
+        with:
+          result-encoding: json
+          script: |
+            // Get all tags sorted by version in descending order
+            const { data: tags } = await github.rest.repos.listTags({
+              ...context.repo,
+              per_page: 10, // only fetch the last handful of tags
+              page: 1
+            });
 
-          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
+            console.log('tags:', JSON.stringify(tags, null, 2));
+            core.setOutput('tags', tags);
 
-          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
-          release_notes="${changelog}"
-          if [[ -n "${user_defined}" ]]; then
-            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
-          fi
+            // Get the previous version tag
+            const previousTag = tags.find(tag => tag.name.match(/^v\d+\.\d+\.\d+/));
 
-          EOF="$(openssl rand -hex 16)"
-          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
-          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
-          echo "$EOF" >> "${GITHUB_OUTPUT}"
+            if (!previousTag) {
+              core.setFailed('No previous version tag found');
+            }
 
-          echo "${release_notes}" > "${{ runner.temp }}/release-notes.txt"
+            console.log('previousTag:', JSON.stringify(previousTag, null, 2));
+            core.setOutput('previousTag', previousTag);
+
+            const base = previousTag.name;
+            const head = context.payload.pull_request?.head.sha || context.sha;
+
+            // Get commit history between previous tag and current commit
+            const { data: { commits } } = await github.rest.repos.compareCommitsWithBasehead({
+              ...context.repo,
+              basehead: `${base}...${head}`,
+            });
+
+            console.log('commits:', JSON.stringify(commits, null, 2));
+            core.setOutput('commits', commits);
+
+            // Format commits as git log --pretty=references
+            // e.g. 8011111 (commit message, yyyy-mm-dd)
+            const changelog = commits.map(commit => {
+              const shortSha = commit.sha.substring(0, 8);
+              return `${shortSha} (${commit.commit.message.split('\n')[0]}, ${commit.commit.author.date.split('T')[0]})`;
+            }).join('\n');
+
+            core.setOutput('changelog', changelog);
+
+            // Generate release notes
+            const userDefined = process.env.USER_DEFINED;
+            const releaseNotes = userDefined
+              ? `${userDefined}\n\n### List of commits\n\n${changelog}`
+              : changelog;
+
+            console.log(releaseNotes);
+
+            // Write to file
+            const fs = require('fs');
+            fs.writeFileSync(process.env.RUNNER_TEMP + '/release-notes.txt', releaseNotes);
+
+            return releaseNotes;
       - name: Upload release notes file
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1393,11 +1393,18 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - versioned_source
+    # On tag push events, we only want to generate release notes if versioning is disabled.
+    # On pull_request events, we want to generate release notes if versioning is enabled.
+    # Skip pull_request closed events, but allow pull_request merged events.
+    # By filtering on the tag output of versioned_source, we can ensure that this job
+    # only runs when versioning is enabled, or when a tag is pushed.
     if: |
-      (
-        github.event.action != 'closed' ||
-        github.event.pull_request.merged == true
-      )
+        inputs.release_notes == true &&
+        needs.versioned_source.outputs.tag != '' &&
+        (
+          github.event.action != 'closed' ||
+          github.event.pull_request.merged == true
+        )
 
     <<: *rootWorkingDirectory
 
@@ -1407,7 +1414,7 @@ jobs:
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
       comment: ${{ steps.format_release_notes.outputs.comment }}
-      note: ${{ steps.short_release_notes.outputs.note }}
+      note: ${{ steps.short_release_notes.outputs.result }}
 
     env:
       <<: *gitHubCliEnvironment
@@ -1583,12 +1590,6 @@ jobs:
     needs:
       - versioned_source
       - release_notes
-    if: |
-      (
-        github.event.action != 'closed' ||
-        github.event.pull_request.merged == true
-      ) &&
-      inputs.release_notes == true
 
     <<: *rootWorkingDirectory
 
@@ -3769,7 +3770,8 @@ jobs:
     # allow some dependencies to be skipped
     if: |
       !failure() && !cancelled() &&
-      github.event.pull_request.state == 'open'
+      github.event.pull_request.state == 'open' &&
+      needs.versioned_source.outputs.tag != ''
 
     <<: *rootWorkingDirectory
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1401,7 +1401,8 @@ jobs:
 
     <<: *rootWorkingDirectory
 
-    permissions: {}
+    permissions:
+      contents: read
 
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
@@ -1427,6 +1428,8 @@ jobs:
         id: format_release_notes
         continue-on-error: true
         env:
+          # We need pull_requests: read to get the PR title and body but that permission
+          # is not always granted by default to the actions token.
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         run: |
           set -x
@@ -1498,37 +1501,72 @@ jobs:
               fi
           fi
 
-      - *checkoutVersionedSha
-      - *fetchTags
-      - *createLocalRefs
-
+      # https://octokit.github.io/rest.js/v21/#repos-list-tags
+      # https://docs.github.com/en/rest/git/refs
+      # https://octokit.github.io/rest.js/v21/#repos-compare-commits-with-basehead
+      # https://docs.github.com/en/rest/commits/commits#compare-two-commits
       - name: Generate short release note
         id: short_release_notes
-        # Look back should always be 2
-        # First is the current versioned tag
-        # Second is the previous versioned tag
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         env:
-          look_back: 2
-          user_defined: ${{ steps.format_release_notes.outputs.body }}
-        run: |
-          set -ea
-          # prevent git from existing with 141
-          set +o pipefail
+          USER_DEFINED: ${{ steps.format_release_notes.outputs.body }}
+        with:
+          result-encoding: json
+          script: |
+            // Get all tags sorted by version in descending order
+            const { data: tags } = await github.rest.repos.listTags({
+              ...context.repo,
+              per_page: 10, // only fetch the last handful of tags
+              page: 1
+            });
 
-          previous_tag="$(git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged | head -n${look_back} | tail -n1)"
+            console.log('tags:', JSON.stringify(tags, null, 2));
+            core.setOutput('tags', tags);
 
-          changelog="$(git log ${previous_tag}..${{ github.event.pull_request.head.sha || github.event.head_commit.id }} --pretty=reference)"
-          release_notes="${changelog}"
-          if [[ -n "${user_defined}" ]]; then
-            release_notes="$(printf '%s\n\n### List of commits\n\n%s' "${user_defined}" "${changelog}")"
-          fi
+            // Get the previous version tag
+            const previousTag = tags.find(tag => tag.name.match(/^v\d+\.\d+\.\d+/));
 
-          EOF="$(openssl rand -hex 16)"
-          echo "note<<$EOF" >> "${GITHUB_OUTPUT}"
-          echo "${release_notes}" >> "${GITHUB_OUTPUT}"
-          echo "$EOF" >> "${GITHUB_OUTPUT}"
+            if (!previousTag) {
+              core.setFailed('No previous version tag found');
+            }
 
-          echo "${release_notes}" > "${{ runner.temp }}/release-notes.txt"
+            console.log('previousTag:', JSON.stringify(previousTag, null, 2));
+            core.setOutput('previousTag', previousTag);
+
+            const base = previousTag.name;
+            const head = context.payload.pull_request?.head.sha || context.sha;
+
+            // Get commit history between previous tag and current commit
+            const { data: { commits } } = await github.rest.repos.compareCommitsWithBasehead({
+              ...context.repo,
+              basehead: `${base}...${head}`,
+            });
+
+            console.log('commits:', JSON.stringify(commits, null, 2));
+            core.setOutput('commits', commits);
+
+            // Format commits as git log --pretty=references
+            // e.g. 8011111 (commit message, yyyy-mm-dd)
+            const changelog = commits.map(commit => {
+              const shortSha = commit.sha.substring(0, 8);
+              return `${shortSha} (${commit.commit.message.split('\n')[0]}, ${commit.commit.author.date.split('T')[0]})`;
+            }).join('\n');
+
+            core.setOutput('changelog', changelog);
+
+            // Generate release notes
+            const userDefined = process.env.USER_DEFINED;
+            const releaseNotes = userDefined
+              ? `${userDefined}\n\n### List of commits\n\n${changelog}`
+              : changelog;
+
+            console.log(releaseNotes);
+
+            // Write to file
+            const fs = require('fs');
+            fs.writeFileSync(process.env.RUNNER_TEMP + '/release-notes.txt', releaseNotes);
+
+            return releaseNotes;
 
       # https://github.com/actions/upload-artifact
       - name: Upload release notes file


### PR DESCRIPTION
This uses the GitHub API to get previous tags
and commit messages, while avoiding issues due to
extremely long strings and special characters.

This also means we don't need to clone the repo
with the last n tags in order to generate release
notes so we can change the default checkout depth
in a future PR.

This PR also fixes the run conditions for release_notes
to ensure we skip those jobs on repos with versioning disabled.

Example release from this PR: https://github.com/product-os/flowzone/releases/tag/untagged-71d2fb3c1318e8ec115d

## Release notes

Use the GitHub API to get previous tags
and commit messages, while avoiding issues due to
extremely long strings and special characters.