### PR TITLE
Restore previous conditions for release_notes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -670,7 +670,6 @@ jobs:
     needs:
       - versioned_source
     if: |
-      inputs.release_notes == true &&
       needs.versioned_source.outputs.tag != '' &&
       (
         github.event.action != 'closed' ||
@@ -856,6 +855,12 @@ jobs:
     needs:
       - versioned_source
       - release_notes
+    if: |
+      inputs.release_notes == true &&
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      )
     defaults:
       run:
         working-directory: .

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1399,7 +1399,6 @@ jobs:
     # By filtering on the tag output of versioned_source, we can ensure that this job
     # only runs when versioning is enabled, or when a tag is pushed.
     if: |
-        inputs.release_notes == true &&
         needs.versioned_source.outputs.tag != '' &&
         (
           github.event.action != 'closed' ||
@@ -1590,6 +1589,12 @@ jobs:
     needs:
       - versioned_source
       - release_notes
+    if: |
+      inputs.release_notes == true &&
+      (
+        github.event.action != 'closed' ||
+        github.event.pull_request.merged == true
+      )
 
     <<: *rootWorkingDirectory
 


### PR DESCRIPTION
The release_notes input is meant to control
whether we take special balena-specific steps
to publish release notes to internal message boards.

It is NOT a flag to disable or enable creating releases.

Fixes: https://github.com/product-os/flowzone/pull/1332/commits/16edbed9baf703844f47a54e81e9a982f2e096dd