### PR TITLE
Use shallow clone when there are no git submodules

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -378,7 +378,7 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.author }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
-      depth: 0
+      depth: ${{ steps.git_describe.outputs.depth || 0 }}
     env:
       GH_DEBUG: "true"
       GH_PAGER: cat
@@ -466,7 +466,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
           if [[ "$(git submodule)" = "" ]]; then
-            echo "depth=100" >> "${GITHUB_OUTPUT}"
+            echo "depth=1" >> "${GITHUB_OUTPUT}"
           else
             echo "depth=0" >> "${GITHUB_OUTPUT}"
           fi

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -242,7 +242,7 @@
       } >> "${GITHUB_OUTPUT}"
 
       if [[ "$(git submodule)" = "" ]]; then
-        echo "depth=100" >> "${GITHUB_OUTPUT}"
+        echo "depth=1" >> "${GITHUB_OUTPUT}"
       else
         echo "depth=0" >> "${GITHUB_OUTPUT}"
       fi
@@ -255,28 +255,6 @@
     if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
     run: |
       git update-ref refs/tags/${{ needs.versioned_source.outputs.tag }} ${{ needs.versioned_source.outputs.tag_sha }}
-
-  # Enabling fetch-tags via actions/checkout does not work when fetch-depth > 0
-  # https://github.com/actions/checkout/issues/1781
-  - &fetchTags
-    name: Fetch tags
-    if: needs.versioned_source.outputs.depth != 0 && needs.versioned_source.outputs.depth != ''
-    env:
-      GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-    # Use bash without tracing to avoid leaking secrets
-    shell: bash
-    # Create base64 encoded auth header
-    #
-    # Use git -c for non-persistent credential configuration
-    #
-    # The git -c option sets a configuration value for a single Git command invocation.
-    # It does not modify any configuration files or persist the setting beyond this specific command.
-    #
-    # This approach ensures that the authentication credentials are used securely for this
-    # specific operation without risk of unintended persistence or exposure in configuration files.
-    run: |
-      auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-      git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch -q --tags
 
   - &loginWithDockerHub
     name: Login to Docker Hub
@@ -1174,10 +1152,8 @@ jobs:
       commit_sha: ${{ steps.create_commit.outputs.sha }}
       author: ${{ steps.create_commit.outputs.author }}
       tag_sha: ${{ steps.create_tag.outputs.sha }}
-      # depth: ${{ steps.git_describe.outputs.depth || 0 }}
-      # Force full fetch depth for now in order to retrieve tags (this takes longer).
-      # https://github.com/actions/checkout/issues/1781
-      depth: 0
+      # Should be 0 (full) if git submodules are present, otherwise for minimal fetch depth.
+      depth: ${{ steps.git_describe.outputs.depth || 0 }}
 
     env:
       <<: *gitHubCliEnvironment


### PR DESCRIPTION
Now that release note generation does not require
a local checkout with previous tags we can default to a depth of 1 when checking out versioned source.

This saves a lot of time on each job that needs to checkout.

Change-type: minor