### PR TITLE
Restore docker build+test conditions

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1315,15 +1315,8 @@ jobs:
     if: |
       (
         inputs.docker_images ||
-        contains(needs.file_list.outputs.workdir, 'docker-compose.yml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-compose.yaml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.json') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.hcl') ||
         contains(needs.file_list.outputs.workdir, 'docker-compose.test.yaml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-compose.test.yml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.override.json') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.override.hcl') ||
-        contains(needs.file_list.outputs.workdir, 'Dockerfile')
+        contains(needs.file_list.outputs.workdir, 'docker-compose.test.yml')
       ) && (
         github.event.action != 'closed' ||
         github.event.pull_request.merged == true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2080,15 +2080,8 @@ jobs:
     if: |
       (
         inputs.docker_images ||
-        contains(needs.file_list.outputs.workdir, 'docker-compose.yml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-compose.yaml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.json') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.hcl') ||
         contains(needs.file_list.outputs.workdir, 'docker-compose.test.yaml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-compose.test.yml') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.override.json') ||
-        contains(needs.file_list.outputs.workdir, 'docker-bake.override.hcl') ||
-        contains(needs.file_list.outputs.workdir, 'Dockerfile')
+        contains(needs.file_list.outputs.workdir, 'docker-compose.test.yml')
       ) && (
         github.event.action != 'closed' ||
         github.event.pull_request.merged == true


### PR DESCRIPTION
Prior to the last change, we only ran docker build+test jobs if there were images to publish, or compose files to test.

Restore that behaviour to avoid running docker bake for repos only meant to publish to balena.

The previous conditions can be seen here:
https://github.com/product-os/flowzone/blob/e2e14f913b98332cb25a2ec1c26ee1343946e263/flowzone.yml#L2123-L2125