### PR TITLE
Remove node version from artifact names

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2339,7 +2339,8 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}(-v[0-9]+\.[0-9]+\.[0-9]+|-[0-9][0-9]\.x)?
+          name_is_regexp: true
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         env:
@@ -2391,7 +2392,8 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: docs-${{ github.event.pull_request.head.sha }}(-v[0-9]+\.[0-9]+\.[0-9]+|-[0-9][0-9]\.x)?
+          name_is_regexp: true
       - name: Extract docs artifact
         run: |
           docs="$(ls ${{ runner.temp }}/*.tar.zst | sort -t- -n -k3 | tail -n1)"

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2158,7 +2158,7 @@ jobs:
         if: needs.is_npm.outputs.npm_private != 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
       - name: Generate docs (if present)
@@ -2172,7 +2172,7 @@ jobs:
         if: needs.is_npm.outputs.npm_docs == 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: docs-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/docs.tar.zst
           retention-days: 90
   npm_sbom:
@@ -2276,7 +2276,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
       - name: Setup Node.js
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
         env:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2843,11 +2843,12 @@ jobs:
           # FIXME: workaround when `npm pack` for npm 6.x dumps tarball into the current directory because it has no `--pack-destination` flag
           [[ "$(npm --version)" =~ ^6\..* ]] && find . -maxdepth 1 -name '*.tgz' -exec mv {} ${{ runner.temp }}/npm-pack \; || true
 
+      # https://github.com/actions/upload-artifact
       - name: Upload artifact
         if: needs.is_npm.outputs.npm_private != 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
 
@@ -2860,11 +2861,12 @@ jobs:
         if: needs.is_npm.outputs.npm_docs == 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         run: tar --auto-compress -cvf ${{ runner.temp }}/docs.tar.zst ./docs
 
+      # https://github.com/actions/upload-artifact
       - name: Upload artifact
         if: needs.is_npm.outputs.npm_docs == 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ matrix.node_version }}
+          name: docs-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/docs.tar.zst
           retention-days: 90
 
@@ -2933,11 +2935,12 @@ jobs:
     permissions: {}
 
     steps:
+      # https://github.com/actions/download-artifact
       - name: Download npm artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          name: npm-${{ github.event.pull_request.head.sha }}
 
       - <<: *setupNode
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2998,7 +2998,10 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: npm-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          # Optionally match version suffix in the format -v22.13.1 or -22.x as we used to
+          # include a version suffix on draft artifacts.
+          name: npm-${{ github.event.pull_request.head.sha }}(-v[0-9]+\.[0-9]+\.[0-9]+|-[0-9][0-9]\.x)?
+          name_is_regexp: true
 
       - <<: *setupNode
         with:
@@ -3051,7 +3054,10 @@ jobs:
           commit: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}
           workflow_conclusion: success
-          name: docs-${{ github.event.pull_request.head.sha }}-${{ needs.is_npm.outputs.max_node_version }}
+          # Optionally match version suffix in the format -v22.13.1 or -22.x as we used to
+          # include a version suffix on draft artifacts.
+          name: docs-${{ github.event.pull_request.head.sha }}(-v[0-9]+\.[0-9]+\.[0-9]+|-[0-9][0-9]\.x)?
+          name_is_regexp: true
 
       - name: Extract docs artifact
         run: |


### PR DESCRIPTION
This avoids artifact download failures when the node version changes between draft and merge.