### PR TITLE
Align buildx versions to v0.20.1 for default target fix

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1349,7 +1349,9 @@ jobs:
         env:
           BUILDX_VERSION: v0.20.1
         with:
-          version: v0.9.1
+          driver-opts: network=host
+          install: true
+          version: ${{ env.BUILDX_VERSION }}
       - name: Pre-process Docker bake files
         id: docker_bake
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2112,10 +2112,12 @@ jobs:
       - *shallowCheckout
 
       - <<: *setupBuildx
-        with:
-          # pin to a known working version because v0.10.x will
-          # create a group called "default" that does not contain multiple targets
-          version: v0.9.1
+        env:
+          # Note that versions between v0.10.0 and v0.20.0 (inclusive) have a bug where the default group
+          # is created without the "default" target.
+          # See https://github.com/docker/buildx/issues/2859
+          # renovate: datasource=github-releases depName=docker/buildx
+          BUILDX_VERSION: v0.20.1
 
       # generate a custom bake json string from the provided bake targets and any discovered bake files
       # https://docs.docker.com/build/customize/bake/file-definition/#json-definition
@@ -3104,8 +3106,7 @@ jobs:
       - *checkoutVersionedSha
       - *createLocalRefs
       - *sanitizeDockerStrings
-
-      - <<: *setupBuildx
+      - *setupBuildx
 
       - id: native_platforms
         <<: *jsonArrayBuilder


### PR DESCRIPTION
The bug introduced in v0.10.0 has been fixed in [v0.20.1](https://github.com/docker/buildx/releases/tag/v0.20.1).

See: https://github.com/docker/buildx/issues/2859
See: https://github.com/docker/buildx/pull/2863