### PR TITLE
Don't assume every project includes repo.yml

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -512,7 +512,9 @@ jobs:
                 silent: false,
               });
             } catch (e) {
-              core.setFailed(e.message);
+              if (! /^No such file or directory:.*$/.test(e.message)) {
+                core.setFailed(e.message);
+              }
             }
 
             console.log('New version: ', version);

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1217,7 +1217,9 @@ jobs:
                 silent: false,
               });
             } catch (e) {
-              core.setFailed(e.message);
+              if (! /^No such file or directory:.*$/.test(e.message)) {
+                core.setFailed(e.message);
+              }
             }
 
             console.log('New version: ', version);


### PR DESCRIPTION
> e.g. https://github.com/product-os/.github/actions/runs/13248425179/job/36986287233#step:11:41

Check error message string to restore behaviour prior to https://github.com/product-os/flowzone/pull/1358

.. or we add `repo.yml` to **every** project; or refactor `balena-versionist` to have some sensible defaults, error message handling and exit codes