### PR TITLE
Remove admin:write from versioning steps

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -395,6 +395,7 @@ jobs:
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
+              "administration": "read",
               "contents": "write",
               "metadata": "read",
               "pull_requests": "read"
@@ -434,6 +435,29 @@ jobs:
             if (!commit.parents.some(({ sha }) => sha === context.payload.pull_request.head.sha)) {
               throw new Error('Non-linear history detected - HEAD branch commit is not a parent of the merge commit');
             }
+      - name: Check for legacy branch protection
+        uses: actions/github-script@v7
+        if: inputs.app_id && inputs.disable_versioning != true && github.event.pull_request.state == 'open'
+        with:
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          script: |
+            try {
+              const data = await github.rest.repos.getBranchProtection({
+                ...context.repo,
+                branch: context.payload.pull_request.base.ref,
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                // Branch not protected
+                return;
+              }
+              core.setFailed(e.message);
+              return;
+            }
+
+            core.setFailed("Legacy branch protection rules detected!\n\n" +
+              "Switching to Rulesets is required to allow GitHub Apps to bypass branch rules.\n\n" +
+              "See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets");
       - name: Checkout pull request head sha
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -104,7 +104,7 @@ on:
         required: false
         default: ""
       app_id:
-        description: GitHub App ID to impersonate
+        description: GitHub App ID to generate an installation token
         type: string
         required: false
         default: ${{ vars.FLOWZONE_APP_ID || vars.APP_ID }}
@@ -118,7 +118,6 @@ on:
         required: false
         default: |-
           {
-            "administration": "write",
             "contents": "write",
             "metadata": "read",
             "packages": "write",
@@ -396,7 +395,6 @@ jobs:
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
-              "administration": "write",
               "contents": "write",
               "metadata": "read",
               "pull_requests": "read"

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ jobs:
       # Required: false
       cloudformation_templates: 
 
-      # GitHub App ID to impersonate
+      # GitHub App ID to generate an installation token
       # Type: string
       # Required: false
       app_id: ${{ vars.FLOWZONE_APP_ID || vars.APP_ID }}
@@ -208,7 +208,6 @@ jobs:
       # Required: false
       token_scope: >
         {
-          "administration": "write",
           "contents": "write",
           "metadata": "read",
           "packages": "write",

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1156,8 +1156,10 @@ jobs:
           # contents: write is required to push git commit and tag references
           # This GitHub App should also be added to exceptions in branch rulesets in order to
           # bypass branch rules and push versioned commits directly to the main branch.
+          # administration: read is required to check for legacy branch protection rules and can be removed eventually.
           permissions: >-
             {
+              "administration": "read",
               "contents": "write",
               "metadata": "read",
               "pull_requests": "read"
@@ -1165,6 +1167,30 @@ jobs:
 
       - *rejectNonLinearHead
       - *rejectNonLinearMerge
+
+      - name: Check for legacy branch protection
+        uses: actions/github-script@v7
+        if: inputs.app_id && inputs.disable_versioning != true && github.event.pull_request.state == 'open'
+        with:
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          script: |
+            try {
+              const data = await github.rest.repos.getBranchProtection({
+                ...context.repo,
+                branch: context.payload.pull_request.base.ref,
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                // Branch not protected
+                return;
+              }
+              core.setFailed(e.message);
+              return;
+            }
+
+            core.setFailed("Legacy branch protection rules detected!\n\n" +
+              "Switching to Rulesets is required to allow GitHub Apps to bypass branch rules.\n\n" +
+              "See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets");
 
       # Checkout the tip of the pull request branch for open PRs.
       # The default behaviour for GitHub Actions is to checkout the merge commit but we

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -854,7 +854,7 @@ on:
         required: false
         default: ""
       app_id:
-        description: "GitHub App ID to impersonate"
+        description: "GitHub App ID to generate an installation token"
         type: string
         required: false
         default: "${{ vars.FLOWZONE_APP_ID || vars.APP_ID }}"
@@ -871,7 +871,6 @@ on:
         # https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-a-scoped-access-token
         default: >-
           {
-            "administration": "write",
             "contents": "write",
             "metadata": "read",
             "packages": "write",
@@ -1154,11 +1153,11 @@ jobs:
       - <<: *getGitHubAppToken
         with:
           <<: *getGitHubAppTokenWith
-          # administration: write is required to bypass branch protection rules
           # contents: write is required to push git commit and tag references
+          # This GitHub App should also be added to exceptions in branch rulesets in order to
+          # bypass branch rules and push versioned commits directly to the main branch.
           permissions: >-
             {
-              "administration": "write",
               "contents": "write",
               "metadata": "read",
               "pull_requests": "read"


### PR DESCRIPTION
Now that [we are using rulesets across all orgs](https://balena.fibery.io/Work/Project/Switch-to-rulesets-for-branch-protection-via-safe-settings-304) we can add the Flowzone GitHub App to the ruleset exceptions and no longer require `admin:write` permissions to push directly to main branches.

Change-type: minor

See: https://balena.fibery.io/Work/Project/Switch-to-rulesets-for-branch-protection-via-safe-settings-304
See: https://balena.fibery.io/Work/Improvement/Remove-admin-write-permissions-from-flowzone-app-1389

Merge tested here: https://github.com/balena-io-experimental/flowzone/actions/runs/13550595477/job/37873044837
Legacy protection check tested here: https://github.com/balena-io-experimental/flowzone/actions/runs/13553653908/job/37883000879?pr=15