### PR TITLE
Check KVM support on any X64 Linux runner

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -68,22 +68,24 @@ runs:
     # https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
     # https://github.com/ankidroid/Anki-Android/commit/3a5ecaa9837691817022d11b0dbe383b8e82d9fe
     # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
-    - name: Enable KVM group perms
-      if: contains(fromJSON(env.os_value),'ubuntu-latest') || contains(fromJSON(env.os_value),'ubuntu-22.04')
+    - name: Check KVM permissions
       shell: bash
-      run: |
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-        sudo udevadm control --reload-rules
-        sudo udevadm trigger -v --name-match=kvm
-
-    - name: Test KVM
-      if: contains(fromJSON(env.os_value),'ubuntu-latest') || contains(fromJSON(env.os_value),'ubuntu-22.04')
-      shell: bash
+      if: runner.os == 'Linux' && runner.arch == 'X64'
+      continue-on-error: true
       run: |
         set -x
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends cpu-checker
 
-        ls -al /dev/kvm
-        test -w /dev/kvm
+        if ! command -v kvm-ok > /dev/null 2>&1
+        then
+          sudo apt-get update
+          sudo apt-get install -y cpu-checker
+        fi
+
+        if ! kvm-ok
+        then
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger -v --name-match=kvm
+        fi
+
         kvm-ok

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2779,13 +2779,27 @@ jobs:
         run: |
           docker save ${{ join(fromJSON(steps.test_meta.outputs.json).tags,' ') }} -o ${DOCKER_TAR}
           zstd -v ${DOCKER_TAR}
-      - name: Enable KVM group perms
-        if: contains(fromJSON('["ubuntu-22.04","ubuntu-24.04","ubuntu-latest"]'), matrix.runs_on[0])
+      - name: Check KVM permissions
+        if: runner.os == 'Linux' && runner.arch == 'X64'
         continue-on-error: true
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger -v --name-match=kvm
+          if ! command -v kvm-ok > /dev/null 2>&1
+          then
+            sudo apt-get update
+            sudo apt-get install -y cpu-checker
+          fi
+
+          if ! kvm-ok
+          then
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger -v --name-match=kvm
+          fi
+
+          if ! kvm-ok
+          then
+            echo "::warn::KVM is not supported"
+          fi
       - name: Run docker compose tests
         if: needs.is_docker.outputs.docker_compose_tests == 'true'
         run: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3355,13 +3355,27 @@ jobs:
       # https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
       # https://github.com/ankidroid/Anki-Android/commit/3a5ecaa9837691817022d11b0dbe383b8e82d9fe
       # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
-      - name: Enable KVM group perms
-        if: contains(fromJSON('["ubuntu-22.04","ubuntu-24.04","ubuntu-latest"]'), matrix.runs_on[0])
+      - name: Check KVM permissions
+        if: runner.os == 'Linux' && runner.arch == 'X64'
         continue-on-error: true
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger -v --name-match=kvm
+          if ! command -v kvm-ok > /dev/null 2>&1
+          then
+            sudo apt-get update
+            sudo apt-get install -y cpu-checker
+          fi
+
+          if ! kvm-ok
+          then
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger -v --name-match=kvm
+          fi
+
+          if ! kvm-ok
+          then
+            echo "::warn::KVM is not supported"
+          fi
 
       # run docker compose tests and print the logs from all services
       - name: Run docker compose tests


### PR DESCRIPTION
This includes large runners we may provision during
outages of self-hosted runners.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Github-Actions-are-not-picked-up-by-self-hosted-github-runners-68