### PR TITLE
Use hosted Ubuntu 24.04 X64 and ARM runners for Docker by default

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -196,7 +196,13 @@ on:
         description: JSON key-value pairs mapping platforms to arrays of runner labels. Unlisted platforms will use `runs_on`.
         type: string
         required: false
-        default: "{}"
+        default: |
+          {
+            "linux/amd64": ["ubuntu-24.04"],
+            "linux/arm64": ["ubuntu-24.04-arm"],
+            "linux/arm/v7": ["ubuntu-24.04-arm"],
+            "linux/arm/v6": ["ubuntu-24.04-arm"]
+          }
       cloudformation_runs_on:
         description: JSON array of runner label strings for cloudformation jobs.
         type: string

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,13 +63,6 @@ jobs:
         multiarch
       jobs_timeout_minutes: 30
       docker_publish_platform_tags: true
-      docker_runs_on: >
-        {
-          "linux/amd64": ["self-hosted","X64"],
-          "linux/arm64": ["self-hosted","ARM64"],
-          "linux/arm/v7": ["self-hosted","ARM64"],
-          "linux/arm/v6": ["self-hosted","ARM64"]
-        }
       custom_test_matrix: >
         {
           "value": ["foo", "bar"],

--- a/README.md
+++ b/README.md
@@ -288,7 +288,13 @@ jobs:
       # use `runs_on`.
       # Type: string
       # Required: false
-      docker_runs_on: {}
+      docker_runs_on: >
+        {
+          "linux/amd64": ["ubuntu-24.04"],
+          "linux/arm64": ["ubuntu-24.04-arm"],
+          "linux/arm/v7": ["ubuntu-24.04-arm"],
+          "linux/arm/v6": ["ubuntu-24.04-arm"]
+        }
 
       # JSON array of runner label strings for cloudformation jobs.
       # Type: string

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -952,7 +952,13 @@ on:
         description: "JSON key-value pairs mapping platforms to arrays of runner labels. Unlisted platforms will use `runs_on`."
         type: string
         required: false
-        default: "{}"
+        default: >
+          {
+            "linux/amd64": ["ubuntu-24.04"],
+            "linux/arm64": ["ubuntu-24.04-arm"],
+            "linux/arm/v7": ["ubuntu-24.04-arm"],
+            "linux/arm/v6": ["ubuntu-24.04-arm"]
+          }
       cloudformation_runs_on:
         description: "JSON array of runner label strings for cloudformation jobs."
         type: string


### PR DESCRIPTION
Now that GitHub offers free hosted runners in both architectures we should default to these in Flowzone.

Change-type: minor

See https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Github-Actions-are-not-picked-up-by-self-hosted-github-runners-68