### PR TITLE
Checkout submodules as a separate step

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1614,12 +1614,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Identify Poetry project
         id: python_poetry
         run: |
@@ -1717,12 +1725,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - id: cargo_targets
         name: Build JSON list from comma-separated input
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
@@ -1786,12 +1802,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - id: balena_slugs
         name: Build JSON list from comma-separated input
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
@@ -1843,12 +1867,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -1998,12 +2030,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Install yaml module
         run: |
           npm install -g yaml
@@ -2198,12 +2238,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -2326,12 +2374,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -2563,12 +2619,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3099,12 +3163,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Sanitize docker strings
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: strings
@@ -3332,12 +3404,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - uses: balena-io/deploy-to-balena-action@272ac9e33392eda88c3aa0887fdfddc811494b17
         id: balena_deploy
         with:
@@ -3401,12 +3481,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3496,12 +3584,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3587,12 +3683,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3664,12 +3768,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
@@ -3726,12 +3838,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3878,12 +3998,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Download release artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
@@ -3947,12 +4075,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Download release notes
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
@@ -4030,12 +4166,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -4102,12 +4246,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -4190,12 +4342,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -4255,12 +4415,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crate to ${{ env.CARGO_REGISTRY }}
@@ -4310,12 +4478,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4385,12 +4561,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4454,12 +4638,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4520,12 +4712,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4581,12 +4781,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4652,12 +4860,20 @@ jobs:
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
+      - name: Checkout submodules recursively
+        env:
+          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+        shell: bash
+        run: |
+          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          git submodule update --init --recursive
       - name: Random delay
         run: |
           DELAY="${DELAY-5}"

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1625,9 +1625,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Identify Poetry project
         id: python_poetry
         run: |
@@ -1736,9 +1743,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - id: cargo_targets
         name: Build JSON list from comma-separated input
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
@@ -1813,9 +1827,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - id: balena_slugs
         name: Build JSON list from comma-separated input
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
@@ -1878,9 +1899,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2041,9 +2069,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Install yaml module
         run: |
           npm install -g yaml
@@ -2249,9 +2284,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -2385,9 +2427,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -2630,9 +2679,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3174,9 +3230,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Sanitize docker strings
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: strings
@@ -3415,9 +3478,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - uses: balena-io/deploy-to-balena-action@272ac9e33392eda88c3aa0887fdfddc811494b17
         id: balena_deploy
         with:
@@ -3492,9 +3562,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3595,9 +3672,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3694,9 +3778,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -3779,9 +3870,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
@@ -3849,9 +3947,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -4009,9 +4114,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Download release artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
@@ -4086,9 +4198,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Download release notes
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
@@ -4177,9 +4296,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -4257,9 +4383,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -4353,9 +4486,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
         run: |
@@ -4426,9 +4566,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Publish crate to ${{ env.CARGO_REGISTRY }}
@@ -4489,9 +4636,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4572,9 +4726,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4649,9 +4810,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4723,9 +4891,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4792,9 +4967,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Reset .github directory to ${{ github.ref }}
         env:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4871,9 +5053,16 @@ jobs:
           GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         shell: bash
         run: |
-          auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+          # Configure Git to use a temporary credential helper
+          git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
           git submodule update --init --recursive
+
+          # After you're done, remove the credential helper configuration
+          git config --local --unset credential.helper
+
+          # For extra safety, you can also unset any cached credentials
+          git credential reject
       - name: Random delay
         run: |
           DELAY="${DELAY-5}"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -176,11 +176,10 @@
     name: Checkout versioned commit
     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     with:
-      fetch-depth: "${{ needs.versioned_source.outputs.depth || 0 }}"
-      # Note that fetch-tags is not currently working as described:
-      # https://github.com/actions/checkout/issues/1781
-      fetch-tags: true
-      submodules: "recursive"
+      # Disable submodules and deep cloning.
+      fetch-depth: 1
+      fetch-tags: false
+      submodules: false
       # fallback to an invalid ref if the checkout ref is undefined
       ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
       <<: *checkoutAuth
@@ -2446,6 +2445,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       - name: Identify Poetry project
         id: python_poetry
@@ -2532,6 +2532,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       - id: cargo_targets
         <<: *jsonArrayBuilder
@@ -2577,6 +2578,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       - id: balena_slugs
         <<: *jsonArrayBuilder
@@ -2609,6 +2611,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *resetGitHubDirectory
 
       # FIXME: remove this handling of deprecated comma-separated values
@@ -2720,6 +2723,7 @@ jobs:
 
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       - name: Install yaml module
         run: |
@@ -2912,6 +2916,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - <<: *setupNode
@@ -3032,6 +3037,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - <<: *setupNode
@@ -3247,6 +3253,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
       - *sanitizeDockerStrings
       - *setupBuildx
@@ -3578,6 +3585,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *sanitizeDockerStrings
       - *dockerFinalMetadata
       - *setupCrane
@@ -3650,6 +3658,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - uses: balena-io/deploy-to-balena-action@272ac9e33392eda88c3aa0887fdfddc811494b17 # v2.0.94
         id: balena_deploy
         with:
@@ -3707,6 +3716,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - <<: *setupPython
@@ -3782,6 +3792,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - *setupPython
@@ -3838,6 +3849,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - *setupPython
@@ -3877,6 +3889,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       - *setupPython
       - *setupPoetry
@@ -3929,6 +3942,7 @@ jobs:
               "pull_requests": "write"
             }
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - <<: *setupNode
@@ -4061,6 +4075,7 @@ jobs:
 
       - *deleteDraftGitHubRelease
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       # https://github.com/actions/download-artifact
       - name: Download release artifacts
@@ -4125,6 +4140,7 @@ jobs:
             }
 
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       # https://github.com/actions/download-artifact
       - name: Download release notes
@@ -4195,6 +4211,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - name: Set up toolchain ${{ matrix.target }}
@@ -4250,6 +4267,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - name: Set up toolchain
@@ -4310,6 +4328,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *createLocalRefs
 
       - name: Set up toolchain ${{ matrix.target }}
@@ -4359,6 +4378,7 @@ jobs:
     steps:
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
 
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -4407,6 +4427,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
 
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *resetGitHubDirectory
       - *createLocalRefs
 
@@ -4463,6 +4484,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
 
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *resetGitHubDirectory
       - *createLocalRefs
 
@@ -4512,6 +4534,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
 
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *resetGitHubDirectory
 
       - name: Set the matrix value env var
@@ -4559,6 +4582,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
 
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *resetGitHubDirectory
 
       - uses: ./.github/actions/clean
@@ -4600,6 +4624,7 @@ jobs:
           permissions: ${{ inputs.token_scope }}
 
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *resetGitHubDirectory
 
       - uses: ./.github/actions/always
@@ -4652,6 +4677,7 @@ jobs:
       - *setupAwsCli
       - *getGitHubAppToken
       - *checkoutVersionedSha
+      - *checkoutSubmodules
       - *randomDelay # Why do people always forget that you need to add a little jitter?
       - *configureAWSCredentials
       - *getAWSCallerIdentity

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -205,6 +205,8 @@
     # or the merge commit if the PR is internal
     name: Reset .github directory to ${{ github.ref }}
     env:
+      # Use whichever credentials are available at this point.
+      # For public repos, this may only be the automatic actions token.
       GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
     # Use bash without tracing to avoid leaking secrets
     shell: bash
@@ -221,6 +223,28 @@
       auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
       git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
       git checkout FETCH_HEAD -- .github
+
+  - &checkoutSubmodules
+    name: Checkout submodules recursively
+    env:
+      # Use whichever credentials are available at this point.
+      # For public repos, this may only be the automatic actions token.
+      GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+    # Use bash without tracing to avoid leaking secrets
+    shell: bash
+    # Create base64 encoded auth header
+    #
+    # Use git-c for non-persistent credential configuration
+    #
+    # The git -c option sets a configuration value for a single Git command invocation.
+    # It does not modify any configuration files or persist the setting beyond this specific command.
+    #
+    # This approach ensures that the authentication credentials are used securely for this
+    # specific operation without risk of unintended persistence or exposure in configuration files.
+    run: |
+      auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
+      git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+      git submodule update --init --recursive
 
   # Resolve tag, semver, sha, and description of current git working copy.
   # tag is the latest tag that points to the current commit.

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -226,24 +226,21 @@
   - &checkoutSubmodules
     name: Checkout submodules recursively
     env:
-      # Use whichever credentials are available at this point.
-      # For public repos, this may only be the automatic actions token.
+      # This will be used by Git for HTTPS authentication
       GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
     # Use bash without tracing to avoid leaking secrets
     shell: bash
-    # Create base64 encoded auth header
-    #
-    # Use git-c for non-persistent credential configuration
-    #
-    # The git -c option sets a configuration value for a single Git command invocation.
-    # It does not modify any configuration files or persist the setting beyond this specific command.
-    #
-    # This approach ensures that the authentication credentials are used securely for this
-    # specific operation without risk of unintended persistence or exposure in configuration files.
     run: |
-      auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
-      git -c "http.https://github.com/.extraheader=Authorization: basic ${auth_header}" fetch origin ${{ github.ref }}
+      # Configure Git to use a temporary credential helper
+      git config --local credential.helper '!f() { echo "username=x-access-token"; echo "password=$GIT_AUTH_TOKEN"; }; f'
+
       git submodule update --init --recursive
+
+      # After you're done, remove the credential helper configuration
+      git config --local --unset credential.helper
+
+      # For extra safety, you can also unset any cached credentials
+      git credential reject
 
   # Resolve tag, semver, sha, and description of current git working copy.
   # tag is the latest tag that points to the current commit.


### PR DESCRIPTION
This allows a default fetch depth of 1 for all
repos which vastly improves clone time for each job.

It also prepares for future changes where we can
use app authentication for private submodules
only on private repos.