### PR TITLE
Remove tag push events from release notes generation

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -686,9 +686,9 @@ jobs:
     needs:
       - versioned_source
     if: |
-      needs.versioned_source.outputs.tag != '' &&
+      inputs.disable_versioning != true &&
       (
-        github.event.action != 'closed' ||
+        github.event.pull_request.state == 'open' ||
         github.event.pull_request.merged == true
       )
     defaults:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1382,15 +1382,12 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - versioned_source
-    # On tag push events, we only want to generate release notes if versioning is disabled.
-    # On pull_request events, we want to generate release notes if versioning is enabled.
+    # Only generate release notes on pull_request events, and only if versioning is enabled.
     # Skip pull_request closed events, but allow pull_request merged events.
-    # By filtering on the tag output of versioned_source, we can ensure that this job
-    # only runs when versioning is enabled, or when a tag is pushed.
     if: |
-        needs.versioned_source.outputs.tag != '' &&
+        inputs.disable_versioning != true &&
         (
-          github.event.action != 'closed' ||
+          github.event.pull_request.state == 'open' ||
           github.event.pull_request.merged == true
         )
 


### PR DESCRIPTION
Tag push events are only somewhat supported, and there is no situation where this ever would have worked since we need to look at the PR body and commits to generate notes.

Tag push logs:
![image](https://github.com/user-attachments/assets/9dd88984-013b-4e3b-831c-a0d55adc9aa8)
