### PR TITLE
Use a separate optional token for checkout steps

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -454,13 +454,27 @@ jobs:
             core.setFailed("Legacy branch protection rules detected!\n\n" +
               "Switching to Rulesets is required to allow GitHub Apps to bypass branch rules.\n\n" +
               "See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets");
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
       - name: Checkout pull request head sha
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           submodules: recursive
           ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
         if: github.event.pull_request.state == 'open'
       - name: Checkout ${{ github.sha }}
@@ -469,7 +483,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
         if: github.event.pull_request.state != 'open'
       - name: Describe git state
@@ -1591,10 +1605,10 @@ jobs:
       pypi_publish: ${{ steps.python_poetry.outputs.pypi_publish }}
       python_sbom: ${{ inputs.generate_sbom }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -1612,7 +1626,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Identify Poetry project
         id: python_poetry
@@ -1694,10 +1708,10 @@ jobs:
       cargo_sbom: ${{ inputs.generate_sbom }}
       cargo_publish: ${{ steps.cargo_publish.outputs.value }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -1715,7 +1729,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - id: cargo_targets
         name: Build JSON list from comma-separated input
@@ -1763,10 +1777,10 @@ jobs:
     outputs:
       balena_slugs: ${{ steps.balena_slugs.outputs.result }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -1784,7 +1798,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - id: balena_slugs
         name: Build JSON list from comma-separated input
@@ -1820,10 +1834,10 @@ jobs:
       custom_publish_matrix: ${{ steps.custom_publish_matrix.outputs.json || inputs.custom_publish_matrix }}
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.json || inputs.custom_finalize_matrix }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -1841,11 +1855,11 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
         env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         shell: bash
         run: |
           auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
@@ -1975,10 +1989,10 @@ jobs:
       stacks: ${{ steps.cloudformation_stacks.outputs.matrix }}
       includes: ${{ steps.cloudformation_stacks.outputs.includes }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -1996,7 +2010,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Install yaml module
         run: |
@@ -2175,10 +2189,10 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -2196,7 +2210,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -2303,10 +2317,10 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     permissions: {}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -2324,7 +2338,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -2540,10 +2554,10 @@ jobs:
     permissions:
       packages: read
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -2561,7 +2575,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -3076,10 +3090,10 @@ jobs:
       max-parallel: ${{ fromJSON(inputs.max_parallel) }}
       matrix: ${{ fromJSON(needs.is_docker.outputs.docker_publish_matrix) }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -3097,7 +3111,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Sanitize docker strings
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
@@ -3309,10 +3323,10 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -3330,7 +3344,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - uses: balena-io/deploy-to-balena-action@a4eb179bbb33c30c348c2840b35c048819a188bd
         id: balena_deploy
@@ -3378,10 +3392,10 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -3399,7 +3413,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -3473,10 +3487,10 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     permissions: {}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -3494,7 +3508,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -3564,10 +3578,10 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     permissions: {}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -3585,7 +3599,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -3641,10 +3655,10 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     permissions: {}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -3662,7 +3676,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Setup python
         id: setup-python
@@ -3701,10 +3715,10 @@ jobs:
       (github.event.action != 'closed' || github.event.pull_request.merged == true)
     permissions: {}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -3712,10 +3726,8 @@ jobs:
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
-              "metadata": "read",
               "contents": "read",
-              "issues": "read",
-              "pull_requests": "write"
+              "metadata": "read"
             }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -3724,7 +3736,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -3769,6 +3781,22 @@ jobs:
           DEPLOYMENT_URL: ${{ steps.deploy_cf_pages.outputs.deployment-url }}
         run: |
           echo "cloudflare_deployment_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
+      - name: Generate GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id
+        id: gh_app_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "metadata": "read",
+              "contents": "read",
+              "issues": "read",
+              "pull_requests": "write"
+            }
       - name: Find Cloudflare Pages link comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: find_cf_comment
@@ -3869,6 +3897,20 @@ jobs:
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -3876,7 +3918,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Download release artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -3924,6 +3966,29 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     permissions: {}
     steps:
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
+      - name: Checkout versioned commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
+          fetch-tags: true
+          submodules: recursive
+          ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
+          persist-credentials: false
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         if: inputs.app_id
@@ -3938,15 +4003,6 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-      - name: Checkout versioned commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: ${{ needs.versioned_source.outputs.depth || 0 }}
-          fetch-tags: true
-          submodules: recursive
-          ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          persist-credentials: false
       - name: Download release notes
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
@@ -4007,10 +4063,10 @@ jobs:
       sha_tag: ${{ steps.meta.outputs.sha_tag }}
       version_tag: ${{ steps.meta.outputs.version_tag }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -4028,7 +4084,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -4079,10 +4135,10 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     permissions: {}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -4100,7 +4156,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -4167,10 +4223,10 @@ jobs:
       matrix:
         target: ${{ fromJSON(needs.is_cargo.outputs.cargo_targets) }}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -4188,7 +4244,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Create local tag for draft version
         if: github.event.pull_request.state == 'open' && inputs.disable_versioning != true
@@ -4232,10 +4288,10 @@ jobs:
         shell: bash --noprofile --norc -eo pipefail -x {0}
     permissions: {}
     steps:
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -4253,7 +4309,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -4301,6 +4357,20 @@ jobs:
           installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -4308,11 +4378,11 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
         env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         shell: bash
         run: |
           auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
@@ -4376,6 +4446,20 @@ jobs:
           installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -4383,11 +4467,11 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
         env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         shell: bash
         run: |
           auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
@@ -4445,6 +4529,20 @@ jobs:
           installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -4452,11 +4550,11 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
         env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         shell: bash
         run: |
           auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
@@ -4511,6 +4609,20 @@ jobs:
           installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -4518,11 +4630,11 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
         env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         shell: bash
         run: |
           auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
@@ -4572,6 +4684,20 @@ jobs:
           installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
+        with:
+          app_id: ${{ inputs.app_id }}
+          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permissions: |-
+            {
+              "contents": "read",
+              "metadata": "read"
+            }
       - name: Checkout versioned commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -4579,11 +4705,11 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Reset .github directory to ${{ github.ref }}
         env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         shell: bash
         run: |
           auth_header=$(printf "x-access-token:${GIT_AUTH_TOKEN}" | base64 | tr -d '\n')
@@ -4629,10 +4755,10 @@ jobs:
         uses: product-os/setup-awscli-action@b5e9d5a0afb5b62fb8fb8bb079dcd84354cef03d
         with:
           version: 2.15.43
-      - name: Generate GitHub App installation token
+      - name: (Private Repo) Generate Read-Only GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
+        if: inputs.app_id && github.event.repository.private
+        id: checkout_token
         with:
           app_id: ${{ inputs.app_id }}
           installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
@@ -4650,7 +4776,7 @@ jobs:
           fetch-tags: true
           submodules: recursive
           ref: ${{ needs.versioned_source.outputs.sha || '¯ (ツ)_/¯' }}
-          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Random delay
         run: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -16,7 +16,7 @@
     uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
     if: inputs.app_id
     id: gh_app_token
-    with: &getGitHubAppTokenWith
+    with: &appInstallationCreds
       app_id: ${{ inputs.app_id }}
       installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
       installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
@@ -130,8 +130,27 @@
         });
         return ref;
 
+  # If the repo is private, generate a read-only GitHub App installation token
+  # for the checkout step as there may be private submodules that cannot be fetched
+  # with the automatic GitHub Actions token.
+  - &getCheckoutToken # https://github.com/tibdex/github-app-token
+    name: (Private Repo) Generate Read-Only GitHub App installation token
+    uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+    if: inputs.app_id && github.event.repository.private
+    id: checkout_token
+    with:
+      app_id: ${{ inputs.app_id }}
+      installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
+      installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
+      private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      permissions: >-
+        {
+          "contents": "read",
+          "metadata": "read"
+        }
+
   - &checkoutAuth
-    token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+    token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
     persist-credentials: false
 
   - &checkoutPullRequestMergeRef
@@ -185,6 +204,7 @@
       ref: "${{ needs.versioned_source.outputs.sha || '¯\_(ツ)_/¯' }}"
       <<: *checkoutAuth
 
+  # Shallow checkout does not include submodules and always uses the automatic GitHub Actions token.
   - &shallowCheckout # https://github.com/actions/checkout
     name: Checkout source
     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -205,7 +225,7 @@
     # or the merge commit if the PR is internal
     name: Reset .github directory to ${{ github.ref }}
     env:
-      GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
     # Use bash without tracing to avoid leaking secrets
     shell: bash
     # Create base64 encoded auth header
@@ -1092,7 +1112,7 @@ jobs:
 
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # pull_requests: write is required to create or update pull request comments
           permissions: >-
             {
@@ -1151,7 +1171,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # contents: write is required to push git commit and tag references
           # This GitHub App should also be added to exceptions in branch rulesets in order to
           # bypass branch rules and push versioned commits directly to the main branch.
@@ -1190,6 +1210,8 @@ jobs:
             core.setFailed("Legacy branch protection rules detected!\n\n" +
               "Switching to Rulesets is required to allow GitHub Apps to bypass branch rules.\n\n" +
               "See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets");
+
+      - *getCheckoutToken
 
       # Checkout the tip of the pull request branch for open PRs.
       # The default behaviour for GitHub Actions is to checkout the merge commit but we
@@ -1407,7 +1429,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           permissions: >-
             {
               "contents": "read",
@@ -1586,7 +1608,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # contents: write is required to create or update pull request comments
           # pull_requests: write is required to create or update pull request comments
           permissions: >-
@@ -1760,7 +1782,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # security_events: write is required to upload SARIF files
           permissions: >-
             {
@@ -2410,7 +2432,7 @@ jobs:
       python_sbom: ${{ inputs.generate_sbom }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
 
       - name: Identify Poetry project
@@ -2496,7 +2518,7 @@ jobs:
       cargo_publish: ${{ steps.cargo_publish.outputs.value }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
 
       - id: cargo_targets
@@ -2541,7 +2563,7 @@ jobs:
       balena_slugs: ${{ steps.balena_slugs.outputs.result }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
 
       - id: balena_slugs
@@ -2573,7 +2595,7 @@ jobs:
       custom_finalize_matrix: ${{ steps.custom_finalize_matrix.outputs.json || inputs.custom_finalize_matrix }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
 
@@ -2684,7 +2706,7 @@ jobs:
 
     steps:
 
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
 
       - name: Install yaml module
@@ -2876,7 +2898,7 @@ jobs:
       version_tag: ${{ steps.meta.outputs.version_tag }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -2996,7 +3018,7 @@ jobs:
     permissions: {}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -3147,7 +3169,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # need permissions to push to docs branch and publish to github pages
           permissions: >-
             {
@@ -3211,7 +3233,7 @@ jobs:
       packages: read # pull private base images from ghcr.io
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
       - *sanitizeDockerStrings
@@ -3542,7 +3564,7 @@ jobs:
     #   packages: write # push manifests to ghcr.io
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *sanitizeDockerStrings
       - *dockerFinalMetadata
@@ -3614,7 +3636,7 @@ jobs:
     <<: *customWorkingDirectory
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - uses: balena-io/deploy-to-balena-action@a4eb179bbb33c30c348c2840b35c048819a188bd # v2.0.111
         id: balena_deploy
@@ -3671,7 +3693,7 @@ jobs:
       version_tag: ${{ steps.meta.outputs.version_tag }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -3746,7 +3768,7 @@ jobs:
     permissions: {}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -3802,7 +3824,7 @@ jobs:
     permissions: {}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -3841,7 +3863,7 @@ jobs:
     permissions: {}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
 
       - *setupPython
@@ -3883,17 +3905,7 @@ jobs:
     permissions: {}
 
     steps:
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # pull_requests: write is required to create or update pull request comments
-          permissions: >-
-            {
-              "metadata": "read",
-              "contents": "read",
-              "issues": "read",
-              "pull_requests": "write"
-            }
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -3940,6 +3952,18 @@ jobs:
         run: |
           echo "cloudflare_deployment_url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
 
+      - <<: *getGitHubAppToken
+        with:
+          <<: *appInstallationCreds
+          # pull_requests: write is required to create or update pull request comments
+          permissions: >-
+            {
+              "metadata": "read",
+              "contents": "read",
+              "issues": "read",
+              "pull_requests": "write"
+            }
+
       - name: Find Cloudflare Pages link comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find_cf_comment
@@ -3980,7 +4004,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # contents:write permissions for managing releases
           permissions: >-
             {
@@ -4017,7 +4041,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # contents:write permissions for managing releases
           permissions: >-
             {
@@ -4026,6 +4050,8 @@ jobs:
             }
 
       - *deleteDraftGitHubRelease
+
+      - *getCheckoutToken
       - *checkoutVersionedSha
 
       # https://github.com/actions/download-artifact
@@ -4080,17 +4106,18 @@ jobs:
     permissions: {}
 
     steps:
+      - *getCheckoutToken
+      - *checkoutVersionedSha
+
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # contents:write permissions for managing releases
           permissions: >-
             {
               "contents": "write",
               "metadata": "read"
             }
-
-      - *checkoutVersionedSha
 
       # https://github.com/actions/download-artifact
       - name: Download release notes
@@ -4159,7 +4186,7 @@ jobs:
       version_tag: ${{ steps.meta.outputs.version_tag }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -4214,7 +4241,7 @@ jobs:
     permissions: {}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -4274,7 +4301,7 @@ jobs:
         target: ${{ fromJSON(needs.is_cargo.outputs.cargo_targets) }}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *createLocalRefs
 
@@ -4323,7 +4350,7 @@ jobs:
     permissions: {}
 
     steps:
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
 
       - name: Set up toolchain
@@ -4368,10 +4395,11 @@ jobs:
       - *rejectExternalCustomActions
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # use permissions from the token_scope input
           permissions: ${{ inputs.token_scope }}
 
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
       - *createLocalRefs
@@ -4424,10 +4452,11 @@ jobs:
 
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # use permissions from the token_scope input
           permissions: ${{ inputs.token_scope }}
 
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
       - *createLocalRefs
@@ -4473,10 +4502,11 @@ jobs:
 
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # use permissions from the token_scope input
           permissions: ${{ inputs.token_scope }}
 
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
 
@@ -4520,10 +4550,11 @@ jobs:
 
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # use permissions from the token_scope input
           permissions: ${{ inputs.token_scope }}
 
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
 
@@ -4561,10 +4592,11 @@ jobs:
 
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # use permissions from the token_scope input
           permissions: ${{ inputs.token_scope }}
 
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *resetGitHubDirectory
 
@@ -4616,7 +4648,7 @@ jobs:
 
     steps:
       - *setupAwsCli
-      - *getGitHubAppToken
+      - *getCheckoutToken
       - *checkoutVersionedSha
       - *randomDelay # Why do people always forget that you need to add a little jitter?
       - *configureAWSCredentials
@@ -4985,7 +5017,7 @@ jobs:
     steps:
       - <<: *getGitHubAppToken
         with:
-          <<: *getGitHubAppTokenWith
+          <<: *appInstallationCreds
           # contents: write is required to enable automerge on a pull request
           permissions: >-
             {


### PR DESCRIPTION
This token will only be generated if the repo is private, in order to clone private submodules.

Otherwise the automatic GitHub Actions token will be used.

Change-type: minor