### PR TITLE
Encode short-release-notes as string

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -794,7 +794,7 @@ jobs:
           USER_DEFINED: ${{ steps.format_release_notes.outputs.body }}
           CURRENT_TAG: ${{ needs.versioned_source.outputs.tag }}
         with:
-          result-encoding: json
+          result-encoding: string
           script: |
             // Get all tags sorted by version in descending order
             const { data: tags } = await github.rest.repos.listTags({

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1494,7 +1494,7 @@ jobs:
           USER_DEFINED: ${{ steps.format_release_notes.outputs.body }}
           CURRENT_TAG: ${{ needs.versioned_source.outputs.tag }}
         with:
-          result-encoding: json
+          result-encoding: string
           script: |
             // Get all tags sorted by version in descending order
             const { data: tags } = await github.rest.repos.listTags({


### PR DESCRIPTION
The job step was encoding as JSON, resulting in additional escaped characters when publishing the notes to balenaCloud.

See this as an example https://dashboard.balena-cloud.com/apps/1667443/releases/3416828/summary

Change-type: patch

## Release notes

Fixes release notes being encoded as JSON which was affecting the preview of the balenaCloud release