### PR TITLE
Remove extra docker draft publish tags

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2902,8 +2902,6 @@ jobs:
             org.opencontainers.image.version=${{ needs.versioned_source.outputs.semver }}
             org.opencontainers.image.ref.name=${{ matrix.target }}
           tags: |
-            type=raw,value=${{ github.base_ref || github.ref_name }}
-            type=raw,value=${{ github.event.pull_request.head.sha }}
             type=raw,value=build-${{ github.event.pull_request.head.sha }}
             type=raw,value=build-${{ github.event.pull_request.head.ref }}
           flavor: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -462,8 +462,6 @@
         ${{ matrix.image }}
       labels: *dockerMetaLabels
       tags: |
-        type=raw,value=${{ github.base_ref || github.ref_name }}
-        type=raw,value=${{ github.event.pull_request.head.sha }}
         type=raw,value=build-${{ github.event.pull_request.head.sha }}
         type=raw,value=build-${{ github.event.pull_request.head.ref }}
       flavor: |


### PR DESCRIPTION
Draft PRs should not publish with the base branch as a tag, and
the extra SHA tag without the build- prefix was redundant and we want
to encourage the use of the tags with build- prefix only.

Change-type: minor

## Release Notes

Removed two extra Docker tags on publish of draft releases.
1. The base ref name which never should have been used for draft publish and was likely an oversight.
2. The head SHA without `-build` prefix. If you were using just the SHA tag before then you need to append the `build-` prefix going forward.