### PR TITLE
Remove the custom token_scope input

### DIFF
--- a/.github/actions/always/action.yml
+++ b/.github/actions/always/action.yml
@@ -27,15 +27,3 @@ runs:
         echo "${INPUTS}"
         echo "${SECRETS}"
         echo "${VARIABLES}"
-
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      if: ${{ fromJSON(inputs.json).app_id }}
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: organization
-        installation_retrieval_payload: ${{ github.repository_owner }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/clean/action.yml
+++ b/.github/actions/clean/action.yml
@@ -27,15 +27,3 @@ runs:
         echo "${INPUTS}"
         echo "${SECRETS}"
         echo "${VARIABLES}"
-
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      if: ${{ fromJSON(inputs.json).app_id }}
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: organization
-        installation_retrieval_payload: ${{ github.repository_owner }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/finalize/action.yml
+++ b/.github/actions/finalize/action.yml
@@ -27,15 +27,3 @@ runs:
         echo "${INPUTS}"
         echo "${SECRETS}"
         echo "${VARIABLES}"
-
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      if: ${{ fromJSON(inputs.json).app_id }}
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: organization
-        installation_retrieval_payload: ${{ github.repository_owner }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -52,18 +52,6 @@ runs:
         git submodule
         git --no-pager tag --list --sort=-version:refname "v*.*.*" --merged
 
-    # https://github.com/marketplace/actions/github-app-token
-    - name: Generate GitHub App installation token
-      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-      if: ${{ fromJSON(inputs.json).app_id }}
-      id: gh_app_installation_token
-      with:
-        app_id: ${{ fromJSON(inputs.json).app_id }}
-        installation_retrieval_mode: organization
-        installation_retrieval_payload: ${{ github.repository_owner }}
-        private_key: ${{ fromJSON(inputs.secrets).GH_APP_PRIVATE_KEY }}
-        permissions: ${{ fromJSON(inputs.json).token_scope }}
-
     # https://github.com/actions/runner-images/discussions/7191#discussioncomment-8351370
     # https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
     # https://github.com/ankidroid/Anki-Android/commit/3a5ecaa9837691817022d11b0dbe383b8e82d9fe

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -102,18 +102,6 @@ on:
         type: string
         required: false
         default: ${{ github.repository_owner }}
-      token_scope:
-        description: Ephemeral token scope(s)
-        type: string
-        required: false
-        default: |-
-          {
-            "contents": "write",
-            "metadata": "read",
-            "packages": "write",
-            "pages": "write",
-            "pull_requests": "read"
-          }
       jobs_timeout_minutes:
         description: Timeout for the job(s).
         type: number
@@ -4043,16 +4031,6 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
-          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4106,16 +4084,6 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
-          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4163,16 +4131,6 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
-          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4221,16 +4179,6 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
-          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -4274,16 +4222,6 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
-      - name: Generate GitHub App installation token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        if: inputs.app_id
-        id: gh_app_token
-        with:
-          app_id: ${{ inputs.app_id }}
-          installation_retrieval_mode: ${{ inputs.token_retrieval_mode }}
-          installation_retrieval_payload: ${{ inputs.token_retrieval_payload }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          permissions: ${{ inputs.token_scope }}
       - uses: ./.github/actions/always
         with:
           json: ${{ toJSON(inputs) }}

--- a/README.md
+++ b/README.md
@@ -192,18 +192,6 @@ jobs:
       # Required: false
       token_retrieval_payload: ${{ github.repository_owner }}
 
-      # Ephemeral token scope(s)
-      # Type: string
-      # Required: false
-      token_scope: >
-        {
-          "contents": "write",
-          "metadata": "read",
-          "packages": "write",
-          "pages": "write",
-          "pull_requests": "read"
-        }
-
       # Timeout for the job(s).
       # Type: number
       # Required: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -787,20 +787,6 @@ on:
         type: string
         required: false
         default: ${{ github.repository_owner }}
-      token_scope:
-        description: "Ephemeral token scope(s)"
-        type: string
-        required: false
-        # https://github.com/organizations/product-os/settings/installations/34040165
-        # https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-a-scoped-access-token
-        default: >-
-          {
-            "contents": "write",
-            "metadata": "read",
-            "packages": "write",
-            "pages": "write",
-            "pull_requests": "read"
-          }
       jobs_timeout_minutes:
         description: "Timeout for the job(s)."
         type: number
@@ -4416,12 +4402,6 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4471,12 +4451,6 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4519,12 +4493,6 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4566,12 +4534,6 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
-
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -4606,12 +4568,6 @@ jobs:
 
       - *downloadVersionedSource
       - *extractVersionedSource
-
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # use permissions from the token_scope input
-          permissions: ${{ inputs.token_scope }}
 
       - uses: ./.github/actions/always
         with:


### PR DESCRIPTION
[No workflows are using this input](https://github.com/search?type=code&q=path%3A.github%2Fworkflows%2Fflowzone.yml+token_scope+NOT+is%3Aarchived), and instead we use the automatic GITHUB_TOKEN with a custom permissions block in the calling workflow.

This removes 5 instances of token generation that was otherwise unused.

Change-type: major

See: https://balena.fibery.io/Work/Project/Make-Flowzone-secrets-conditional-1398

![image](https://github.com/user-attachments/assets/484b76f6-5ab8-48ba-8924-20df40a7ea46)
