### PR TITLE
Replace shallow checkouts with versioned source artifact

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -442,7 +442,8 @@ jobs:
             core.setFailed("Legacy branch protection rules detected!\n\n" +
               "Switching to Rulesets is required to allow GitHub Apps to bypass branch rules.\n\n" +
               "See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets");
-      - name: Checkout pull request head sha
+      - if: github.event.pull_request.state == 'open'
+        name: Checkout pull request head sha
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
@@ -450,8 +451,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
-        if: github.event.pull_request.state == 'open'
-      - name: Checkout ${{ github.sha }}
+      - if: github.event.pull_request.state != 'open'
+        name: Checkout ${{ github.sha }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
@@ -459,7 +460,6 @@ jobs:
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           persist-credentials: false
-        if: github.event.pull_request.state != 'open'
       - name: Describe git state
         id: git_describe
         run: |
@@ -727,8 +727,7 @@ jobs:
       run:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
       comment: ${{ steps.format_release_notes.outputs.comment }}
@@ -827,6 +826,7 @@ jobs:
           CURRENT_TAG: ${{ needs.versioned_source.outputs.tag }}
         with:
           result-encoding: string
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           script: |
             // Get all tags sorted by version in descending order
             const { data: tags } = await github.rest.repos.listTags({
@@ -1055,17 +1055,18 @@ jobs:
     if: github.event.action != 'closed'
     needs:
       - event_types
-    permissions:
-      contents: read
+      - versioned_source
+    permissions: {}
     steps:
-      - name: Checkout source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Download versioned source
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          token: ${{ github.token }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: versioned-source
+          path: ${{ runner.temp }}
+      - name: Extract versioned source
+        shell: pwsh
+        working-directory: .
+        run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
       - name: Add problem matcher
         run: |
           curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json > ${{ runner.temp }}/actionlint-matcher.json
@@ -1086,9 +1087,18 @@ jobs:
       )
     needs:
       - event_types
-    permissions:
-      contents: read
+      - versioned_source
+    permissions: {}
     steps:
+      - name: Download versioned source
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: versioned-source
+          path: ${{ runner.temp }}
+      - name: Extract versioned source
+        shell: pwsh
+        working-directory: .
+        run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
       - name: Generate GitHub App installation token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         if: inputs.app_id
@@ -1104,14 +1114,6 @@ jobs:
               "metadata": "read",
               "security_events": "write"
             }
-      - name: Checkout source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          token: ${{ github.token }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - id: octoscan
         name: Run octoscan
         uses: synacktiv/action-octoscan@6b1cf2343893dfb9e5f75652388bd2dc83f456b0
@@ -1201,20 +1203,21 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
+      - versioned_source
     if: |
       contains(needs.file_list.outputs.root, '.pre-commit-config.yaml') &&
       github.event.action != 'closed'
-    permissions:
-      contents: read
+    permissions: {}
     steps:
-      - name: Checkout source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Download versioned source
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          token: ${{ github.token }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: versioned-source
+          path: ${{ runner.temp }}
+      - name: Extract versioned source
+        shell: pwsh
+        working-directory: .
+        run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
       - name: Setup python
         id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
@@ -1227,6 +1230,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
+      - versioned_source
     if: |
       contains(needs.file_list.outputs.workdir, 'package.json') &&
       (
@@ -1237,8 +1241,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       npm: "true"
       has_npm_lockfile: ${{ contains(needs.file_list.outputs.workdir, 'package-lock.json') || contains(needs.file_list.outputs.workdir, 'npm-shrinkwrap.json') }}
@@ -1252,14 +1255,15 @@ jobs:
       NODE_VERSIONS: "[]"
       PACKAGE_JSON_PATH: ${{ inputs.working_directory }}/package.json
     steps:
-      - name: Checkout source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Download versioned source
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          token: ${{ github.token }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: versioned-source
+          path: ${{ runner.temp }}
+      - name: Extract versioned source
+        shell: pwsh
+        working-directory: .
+        run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
       - name: Process package.json
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         id: package_json
@@ -1355,6 +1359,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
+      - versioned_source
     if: |
       (
         inputs.docker_images ||
@@ -1368,8 +1373,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
         shell: bash --noprofile --norc -eo pipefail -x {0}
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       docker_images: ${{ steps.docker_publish.outputs.images }}
       docker_images_crlf: ${{ steps.docker_publish.outputs.images_crlf }}
@@ -1378,14 +1382,15 @@ jobs:
       docker_test_matrix: ${{ steps.docker_test.outputs.result }}
       docker_publish_matrix: ${{ steps.docker_publish.outputs.result }}
     steps:
-      - name: Checkout source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Download versioned source
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          fetch-depth: 1
-          submodules: false
-          persist-credentials: false
-          token: ${{ github.token }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: versioned-source
+          path: ${{ runner.temp }}
+      - name: Extract versioned source
+        shell: pwsh
+        working-directory: .
+        run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
       - name: Setup buildx
         id: setup_buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -672,7 +672,7 @@ jobs:
         id: auth_header
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GIT_AUTH_TOKEN: ${{ github.token }}
         with:
           result-encoding: string
           script: |
@@ -1805,7 +1805,8 @@ jobs:
       run:
         working-directory: .
         shell: bash --noprofile --norc -eo pipefail -x {0}
-    permissions: {}
+    permissions:
+      contents: read
     outputs:
       custom_test: ${{ steps.custom.outputs.test }}
       custom_publish: ${{ steps.custom.outputs.publish }}
@@ -1825,6 +1826,26 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
+      - name: Create base64 encoded auth header
+        id: auth_header
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          GIT_AUTH_TOKEN: ${{ github.token }}
+        with:
+          result-encoding: string
+          script: |
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            core.setSecret(authHeader);
+            core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
+            return authHeader;
+      - name: Reset .github directory to ${{ github.ref }}
+        env:
+          AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
+          REF: ${{ github.ref }}
+        run: |
+          git -c "${AUTH_CONFIG}" fetch origin "${REF}"
+          git checkout FETCH_HEAD -- .github
       - id: custom_test_values
         if: contains(inputs.custom_test_matrix, '{') != true
         name: Build JSON list from comma-separated input
@@ -4038,6 +4059,26 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
+      - name: Create base64 encoded auth header
+        id: auth_header
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          GIT_AUTH_TOKEN: ${{ github.token }}
+        with:
+          result-encoding: string
+          script: |
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            core.setSecret(authHeader);
+            core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
+            return authHeader;
+      - name: Reset .github directory to ${{ github.ref }}
+        env:
+          AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
+          REF: ${{ github.ref }}
+        run: |
+          git -c "${AUTH_CONFIG}" fetch origin "${REF}"
+          git checkout FETCH_HEAD -- .github
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4091,6 +4132,26 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
+      - name: Create base64 encoded auth header
+        id: auth_header
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          GIT_AUTH_TOKEN: ${{ github.token }}
+        with:
+          result-encoding: string
+          script: |
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            core.setSecret(authHeader);
+            core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
+            return authHeader;
+      - name: Reset .github directory to ${{ github.ref }}
+        env:
+          AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
+          REF: ${{ github.ref }}
+        run: |
+          git -c "${AUTH_CONFIG}" fetch origin "${REF}"
+          git checkout FETCH_HEAD -- .github
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4138,6 +4199,26 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
+      - name: Create base64 encoded auth header
+        id: auth_header
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          GIT_AUTH_TOKEN: ${{ github.token }}
+        with:
+          result-encoding: string
+          script: |
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            core.setSecret(authHeader);
+            core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
+            return authHeader;
+      - name: Reset .github directory to ${{ github.ref }}
+        env:
+          AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
+          REF: ${{ github.ref }}
+        run: |
+          git -c "${AUTH_CONFIG}" fetch origin "${REF}"
+          git checkout FETCH_HEAD -- .github
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4186,6 +4267,26 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
+      - name: Create base64 encoded auth header
+        id: auth_header
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          GIT_AUTH_TOKEN: ${{ github.token }}
+        with:
+          result-encoding: string
+          script: |
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            core.setSecret(authHeader);
+            core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
+            return authHeader;
+      - name: Reset .github directory to ${{ github.ref }}
+        env:
+          AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
+          REF: ${{ github.ref }}
+        run: |
+          git -c "${AUTH_CONFIG}" fetch origin "${REF}"
+          git checkout FETCH_HEAD -- .github
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -4229,6 +4330,26 @@ jobs:
         shell: pwsh
         working-directory: .
         run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
+      - name: Create base64 encoded auth header
+        id: auth_header
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          GIT_AUTH_TOKEN: ${{ github.token }}
+        with:
+          result-encoding: string
+          script: |
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            core.setSecret(authHeader);
+            core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
+            return authHeader;
+      - name: Reset .github directory to ${{ github.ref }}
+        env:
+          AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
+          REF: ${{ github.ref }}
+        run: |
+          git -c "${AUTH_CONFIG}" fetch origin "${REF}"
+          git checkout FETCH_HEAD -- .github
       - uses: ./.github/actions/always
         with:
           json: ${{ toJSON(inputs) }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -134,32 +134,6 @@
     token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
     persist-credentials: false
 
-  - &checkoutPullRequestHeadSha
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
-    # https://github.com/actions/checkout
-    name: Checkout pull request head sha
-    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    with:
-      fetch-depth: 0
-      submodules: "recursive"
-      # fallback to an invalid ref if the checkout ref is undefined
-      ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
-      <<: *checkoutAuth
-
-  - &checkoutEventSha
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
-    # https://github.com/actions/checkout
-    name: Checkout ${{ github.sha }}
-    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    with:
-      fetch-depth: 0
-      submodules: "recursive"
-      # fallback to an invalid ref if the checkout ref is undefined
-      ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
-      <<: *checkoutAuth
-
   - &downloadVersionedSource # https://github.com/actions/download-artifact
     name: Download versioned source
     uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -173,21 +147,6 @@
     shell: pwsh
     working-directory: .
     run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
-
-  - &shallowCheckout # https://github.com/actions/checkout
-    name: Checkout source
-    uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    with:
-      # Disable submodules and deep cloning.
-      fetch-depth: 1
-      submodules: false
-      # Do not persist credentials.
-      persist-credentials: false
-      # Use the automatic actions token with contents:read permissions
-      token: ${{ github.token }}
-      # Use the tip of the pull request branch for pull request (target) events.
-      # Use the event sha for other events.
-      ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   - &loginWithDockerHub
     name: Login to Docker Hub
@@ -1116,13 +1075,33 @@ jobs:
       # want to be able test the changes in isolation, and we already require that branches
       # be rebased before testing merging via branch rules.
       # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
-      - <<: *checkoutPullRequestHeadSha
-        if: github.event.pull_request.state == 'open'
+      - if: github.event.pull_request.state == 'open'
+        # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+        # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+        # https://github.com/actions/checkout
+        name: Checkout pull request head sha
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          submodules: "recursive"
+          # fallback to an invalid ref if the checkout ref is undefined
+          ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
+          <<: *checkoutAuth
 
       # Checkout the event sha for closed/merged PRs.
       # This is the merge commit sha for PRs and the tagged commit sha for tags.
-      - <<: *checkoutEventSha
-        if: github.event.pull_request.state != 'open'
+      - if: github.event.pull_request.state != 'open'
+        # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+        # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+        # https://github.com/actions/checkout
+        name: Checkout ${{ github.sha }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          submodules: "recursive"
+          # fallback to an invalid ref if the checkout ref is undefined
+          ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
+          <<: *checkoutAuth
 
       # The current commit sha is needed as the parent sha for the versioned commit
       # and/or as default tag & semver if versioning is disabled.
@@ -1427,8 +1406,8 @@ jobs:
 
     <<: *rootWorkingDirectory
 
-    permissions:
-      contents: read
+    # No permissions needed for this job.
+    permissions: {}
 
     outputs:
       body: ${{ steps.format_release_notes.outputs.body }}
@@ -1455,6 +1434,8 @@ jobs:
         continue-on-error: true
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          # This step requires "pull_request: read" permissions which are not included in
+          # the default "restricted" policy of the automatic github.token.
           github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           result-encoding: string
           script: |
@@ -1529,6 +1510,10 @@ jobs:
           CURRENT_TAG: ${{ needs.versioned_source.outputs.tag }}
         with:
           result-encoding: string
+          # This step only requires "contents: read", but we are using the generated app
+          # token to remain aligned with the format_release_notes step above. No other reason.
+          # Otherwise, this step could use the automatic github.token without issue.
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           script: |
             // Get all tags sorted by version in descending order
             const { data: tags } = await github.rest.repos.listTags({
@@ -1740,21 +1725,14 @@ jobs:
     # Run this early in the workflow, as soon as we've validated event types
     needs:
       - event_types
+      - versioned_source
 
-    permissions:
-      contents: read # Used for checkout
+    # No permissions needed for this job.
+    permissions: {}
 
     steps:
-      # No need for the Flowzone Installation App token here as we are not cloning
-      # submodules so the automatic actions token scoped to the repo is fine.
-
-      # Disable submodules and deep cloning.
-      # Do not persist credentials.
-      # Use the automatic actions token with contents:read permissions.
-      # Use the tip of the pull request branch for pull request (target) events.
-      # Use the event sha for other events.
-      # https://github.com/actions/checkout
-      - *shallowCheckout
+      - *downloadVersionedSource
+      - *extractVersionedSource
 
       # https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md
       - name: Add problem matcher
@@ -1788,11 +1766,15 @@ jobs:
     # Run this early in the workflow, as soon as we've validated event types
     needs:
       - event_types
+      - versioned_source
 
-    permissions:
-      contents: read # required for checkout without submodules
+    # No permissions needed for this job.
+    permissions: {}
 
     steps:
+      - *downloadVersionedSource
+      - *extractVersionedSource
+
       - <<: *getGitHubAppToken
         with:
           <<: *getGitHubAppTokenWith
@@ -1803,14 +1785,6 @@ jobs:
               "metadata": "read",
               "security_events": "write"
             }
-
-      # Disable submodules and deep cloning.
-      # Do not persist credentials.
-      # Use the automatic actions token with contents:read permissions.
-      # Use the tip of the pull request branch for pull request (target) events.
-      # Use the event sha for other events.
-      # https://github.com/actions/checkout
-      - *shallowCheckout
 
       # https://github.com/synacktiv/octoscan
       # https://github.com/synacktiv/action-octoscan
@@ -1943,24 +1917,18 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
+      - versioned_source
     # Do not run on PR close or merge events.
     if: |
       contains(needs.file_list.outputs.root, '.pre-commit-config.yaml') &&
       github.event.action != 'closed'
 
-    # No need for the Flowzone Installation App token here as we are not cloning
-    # submodules so the automatic actions token scoped to the repo is fine.
-    permissions:
-      contents: read # Required to checkout source project, without submodules
+    # No permissions needed for this job.
+    permissions: {}
 
     steps:
-      # Disable submodules and deep cloning.
-      # Do not persist credentials.
-      # Use the automatic actions token with contents:read permissions.
-      # Use the tip of the pull request branch for pull request (target) events.
-      # Use the event sha for other events.
-      # https://github.com/actions/checkout
-      - *shallowCheckout
+      - *downloadVersionedSource
+      - *extractVersionedSource
 
       # https://github.com/actions/setup-python
       - *setupPython
@@ -1975,6 +1943,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
+      - versioned_source
     # Do not run on PR close events.
     if: |
       contains(needs.file_list.outputs.workdir, 'package.json') &&
@@ -1985,10 +1954,8 @@ jobs:
 
     <<: *customWorkingDirectory
 
-    # No need for the Flowzone Installation App token here as we are not cloning
-    # submodules so the automatic actions token scoped to the repo is fine.
-    permissions:
-      contents: read # Required to checkout source project, without submodules
+    # No permissions needed for this job.
+    permissions: {}
 
     outputs:
       npm: "true"
@@ -2005,13 +1972,8 @@ jobs:
       PACKAGE_JSON_PATH: "${{ inputs.working_directory }}/package.json"
 
     steps:
-      # Disable submodules and deep cloning.
-      # Do not persist credentials.
-      # Use the automatic actions token with contents:read permissions.
-      # Use the tip of the pull request branch for pull request (target) events.
-      # Use the event sha for other events.
-      # https://github.com/actions/checkout
-      - *shallowCheckout
+      - *downloadVersionedSource
+      - *extractVersionedSource
 
       - name: Process package.json
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -2110,6 +2072,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
       - file_list
+      - versioned_source
     # Do not run on PR close events.
     # Match any of the following file globs:
     #  docker-bake{.override,}.{json,hcl}
@@ -2127,10 +2090,8 @@ jobs:
 
     <<: *customWorkingDirectory
 
-    # No need for the Flowzone Installation App token here as we are not cloning
-    # submodules so the automatic actions token scoped to the repo is fine.
-    permissions:
-      contents: read # Required to checkout source project, without submodules
+    # No permissions needed for this job.
+    permissions: {}
 
     outputs:
       docker_images: ${{ steps.docker_publish.outputs.images }}
@@ -2141,13 +2102,8 @@ jobs:
       docker_publish_matrix: ${{ steps.docker_publish.outputs.result }}
 
     steps:
-      # Disable submodules and deep cloning.
-      # Do not persist credentials.
-      # Use the automatic actions token with contents:read permissions.
-      # Use the tip of the pull request branch for pull request (target) events.
-      # Use the event sha for other events.
-      # https://github.com/actions/checkout
-      - *shallowCheckout
+      - *downloadVersionedSource
+      - *extractVersionedSource
 
       - <<: *setupBuildx
         env:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -148,6 +148,43 @@
     working-directory: .
     run: tar --extract --file ${{ runner.temp }}/versioned_source.tar.zst
 
+  # Create base64 encoded auth header for use in git CLI commands.
+  # Required github.token with contents: read
+  - &createAuthHeader
+    name: Create base64 encoded auth header
+    id: auth_header
+    uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+    env:
+      GIT_AUTH_TOKEN: ${{ github.token }}
+    with:
+      result-encoding: string
+      script: |
+        const token = process.env.GIT_AUTH_TOKEN;
+        const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+        core.setSecret(authHeader);
+        core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
+        return authHeader;
+
+  # Reset the .github directory to the GitHub ref.
+  # For security, this is the tip of BASE if the event is pull_request_target
+  # or the merge commit if the PR is internal.
+  # Depends on createAuthHeader.
+  - &resetGithubDirectory
+    name: Reset .github directory to ${{ github.ref }}
+    env:
+      AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
+      REF: ${{ github.ref }}
+    # Use git-c for non-persistent credential configuration
+    #
+    # The git -c option sets a configuration value for a single Git command invocation.
+    # It does not modify any configuration files or persist the setting beyond this specific command.
+    #
+    # This approach ensures that the authentication credentials are used securely for this
+    # specific operation without risk of unintended persistence or exposure in configuration files.
+    run: |
+      git -c "${AUTH_CONFIG}" fetch origin "${REF}"
+      git checkout FETCH_HEAD -- .github
+
   - &loginWithDockerHub
     name: Login to Docker Hub
     continue-on-error: true
@@ -1009,6 +1046,7 @@ jobs:
 
     permissions:
       # Required to inspect commits in branches for linear history
+      # Also required to reset the workspace to the versioned commit.
       contents: read
 
     outputs:
@@ -1317,19 +1355,7 @@ jobs:
       #     <<: *checkoutAuth
 
       # Create base64 encoded auth header
-      - name: Create base64 encoded auth header
-        id: auth_header
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        env:
-          GIT_AUTH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-        with:
-          result-encoding: string
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            core.setSecret(authHeader);
-            core.setOutput('config', `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`);
-            return authHeader;
+      - *createAuthHeader
 
       # Reset the local workspace to the versioned commit we just created
       # and add a local annotated tag.
@@ -1359,20 +1385,7 @@ jobs:
       # Reset the .github directory to the GitHub ref
       # For security, this is the tip of BASE if the event is pull_request_target
       # or the merge commit if the PR is internal
-      - name: Reset .github directory to ${{ github.ref }}
-        env:
-          AUTH_CONFIG: ${{ steps.auth_header.outputs.config }}
-          REF: ${{ github.ref }}
-        # Use git-c for non-persistent credential configuration
-        #
-        # The git -c option sets a configuration value for a single Git command invocation.
-        # It does not modify any configuration files or persist the setting beyond this specific command.
-        #
-        # This approach ensures that the authentication credentials are used securely for this
-        # specific operation without risk of unintended persistence or exposure in configuration files.
-        run: |
-          git -c "${AUTH_CONFIG}" fetch origin "${REF}"
-          git checkout FETCH_HEAD -- .github
+      - *resetGithubDirectory
 
       # Compress versioned source to maintain file permissions and case-sensitivity
       # https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
@@ -2550,7 +2563,8 @@ jobs:
 
     <<: *rootWorkingDirectory
 
-    permissions: {}
+    permissions:
+      contents: read # Required to read and reset the .github directory
 
     outputs:
       custom_test: ${{ steps.custom.outputs.test }}
@@ -2566,6 +2580,12 @@ jobs:
     steps:
       - *downloadVersionedSource
       - *extractVersionedSource
+
+      # Reset the .github directory to the GitHub ref
+      # For security, this is the tip of BASE if the event is pull_request_target
+      # or the merge commit if the PR is internal
+      - *createAuthHeader
+      - *resetGithubDirectory
 
       # FIXME: remove this handling of deprecated comma-separated values
       - id: custom_test_values
@@ -4359,6 +4379,12 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
+      # Reset the .github directory to the GitHub ref
+      # For security, this is the tip of BASE if the event is pull_request_target
+      # or the merge commit if the PR is internal
+      - *createAuthHeader
+      - *resetGithubDirectory
+
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4408,6 +4434,12 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
+      # Reset the .github directory to the GitHub ref
+      # For security, this is the tip of BASE if the event is pull_request_target
+      # or the merge commit if the PR is internal
+      - *createAuthHeader
+      - *resetGithubDirectory
+
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4450,6 +4482,12 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
+      # Reset the .github directory to the GitHub ref
+      # For security, this is the tip of BASE if the event is pull_request_target
+      # or the merge commit if the PR is internal
+      - *createAuthHeader
+      - *resetGithubDirectory
+
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4491,6 +4529,12 @@ jobs:
       - *downloadVersionedSource
       - *extractVersionedSource
 
+      # Reset the .github directory to the GitHub ref
+      # For security, this is the tip of BASE if the event is pull_request_target
+      # or the merge commit if the PR is internal
+      - *createAuthHeader
+      - *resetGithubDirectory
+
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -4525,6 +4569,12 @@ jobs:
 
       - *downloadVersionedSource
       - *extractVersionedSource
+
+      # Reset the .github directory to the GitHub ref
+      # For security, this is the tip of BASE if the event is pull_request_target
+      # or the merge commit if the PR is internal
+      - *createAuthHeader
+      - *resetGithubDirectory
 
       - uses: ./.github/actions/always
         with:


### PR DESCRIPTION
We want to avoid superfluous source checkouts and instead rely on the sanitized versioned source artifact.

This also applies to a future state where versioning is performed externally by a dedicated app, and the job(s) checkout the versioned commit branch.

See: https://balena.fibery.io/Work/Project/Make-Flowzone-secrets-conditional-1398