### PR TITLE
Revert to per-job versioned source checkout

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1136,7 +1136,7 @@ jobs:
         uses: synacktiv/action-octoscan@6b1cf2343893dfb9e5f75652388bd2dc83f456b0
         with:
           filter_triggers: allnopr
-          disable_rules: shellcheck,local-action,runner-label,dangerous-write
+          disable_rules: shellcheck,local-action,runner-label,dangerous-write,dangerous-checkout
       - name: Upload SARIF file to GitHub
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         continue-on-error: true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1782,7 +1782,7 @@ jobs:
           # external: https://github.com/synacktiv/octoscan/blob/3f7fd6e563be43432cef874c82a7714f67a8ef92/common/helpers.go#L69
           # allnopr: https://github.com/synacktiv/octoscan/blob/3f7fd6e563be43432cef874c82a7714f67a8ef92/common/helpers.go#L76
           filter_triggers: allnopr
-          disable_rules: shellcheck,local-action,runner-label,dangerous-write
+          disable_rules: shellcheck,local-action,runner-label,dangerous-write,dangerous-checkout
 
       # The codeql-action/upload-sarif action uses internal endpoints and does not work with app installation tokens
       # so here we use the github-script action to upload the SARIF file to GitHub via the REST API


### PR DESCRIPTION
Reverts https://github.com/product-os/flowzone/pull/1489

Unfortunately artifact download on EU self-hosted runners is
very slow compared to git checkouts, so after some use in production
we decided to roll back this change.

Still we can use a dedicated token for the checkout step with fixed
permissions.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Flowzone-job-time-increased-by-30-70-on-large-repos-98

We can fix these CodeQL security warnings if we bet on this:
https://balena.fibery.io/Work/Project/Remove-insecure-event-triggers-from-Flowzone-1398