### PR TITLE
Restore submodule fetch for yocto-based versioning

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -461,7 +461,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
-          submodules: "false"
+          submodules: recursive
           ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
@@ -470,7 +470,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
-          submodules: "false"
+          submodules: recursive
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1158,7 +1158,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          submodules: "false"
+          # Recursively fetch submodules for yocto-based versioning
+          submodules: "recursive"
           # fallback to an invalid ref if the checkout ref is undefined
           ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
           <<: *checkoutAuth
@@ -1173,7 +1174,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          submodules: "false"
+          # Recursively fetch submodules for yocto-based versioning
+          submodules: "recursive"
           # fallback to an invalid ref if the checkout ref is undefined
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
           <<: *checkoutAuth


### PR DESCRIPTION
Submodules are required to get the meta-balena version in yocto-based device repos.

Change-type: patch