### PR TITLE
Remove CARGO_REGISTRY enviroment variable

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -263,7 +263,6 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 env:
   NPM_REGISTRY: https://registry.npmjs.org
-  CARGO_REGISTRY: crates.io
 jobs:
   event_types:
     name: Event Types
@@ -4585,10 +4584,9 @@ jobs:
           git update-ref "refs/tags/${TAG}" "${SHA}"
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Publish crate to ${{ env.CARGO_REGISTRY }}
+      - name: Publish crate to cargo registry
         if: needs.is_cargo.outputs.cargo_publish != 'false'
         env:
-          CARGO_REGISTRY_DEFAULT: ${{ env.CARGO_REGISTRY }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           if [ -n "$CARGO_REGISTRY_TOKEN" ]; then

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1000,7 +1000,6 @@ concurrency:
 
 env:
   NPM_REGISTRY: "https://registry.npmjs.org"
-  CARGO_REGISTRY: crates.io
 
 jobs:
   event_types:
@@ -4337,10 +4336,9 @@ jobs:
       - name: Set up toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Publish crate to ${{ env.CARGO_REGISTRY }}
+      - name: Publish crate to cargo registry
         if: needs.is_cargo.outputs.cargo_publish != 'false'
         env:
-          CARGO_REGISTRY_DEFAULT: ${{ env.CARGO_REGISTRY }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           if [ -n "$CARGO_REGISTRY_TOKEN" ]; then


### PR DESCRIPTION
This was being passed to the `cargo_finalize` job as `CARGO_REGISTRY_DEFAULT` but that is the wrong way to set alternate registries. That variable is a valid configuration but it must not point to an URL, it must point to a registry name configured in Cargo.toml. In fact, all the registry configuration may be configured via Cargo.toml, making the variable a redundant interface.

Change-type: patch
See: https://doc.rust-lang.org/cargo/reference/registries.html#using-an-alternate-registry