### PR TITLE
Use only first occurrence of `name = *` in Cargo.toml

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4373,7 +4373,7 @@ jobs:
       - name: Generate metadata
         id: meta
         run: |
-          package="$(grep '^name = \"' Cargo.toml | awk -F[\"\"] '{print $2}')"
+          package="$(grep '^name = \"' Cargo.toml | awk -F[\"\"] '{print $2; exit}')"
           version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo "${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
           sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4199,7 +4199,7 @@ jobs:
       - name: Generate metadata
         id: meta
         run: |
-          package="$(grep '^name = \"' Cargo.toml | awk -F[\"\"] '{print $2}')"
+          package="$(grep '^name = \"' Cargo.toml | awk -F[\"\"] '{print $2; exit}')"
           version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo "${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
           sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
There may be multiple sections in Cargo.toml including `name =` which will metadata generation to [fail](https://github.com/balena-io-experimental/helios/actions/runs/16228039292/job/45824579468). This channge updates parsing of Cargo.toml to read only the first instance of `name` assuming that will belong to the `package` section.

Change-type: patch