### PR TITLE
Ignore errors on upload of docker gha cache

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2973,7 +2973,7 @@ jobs:
           targets: ${{ matrix.target }}
           set: |
             *.platform=${{ matrix.platform }}
-            *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.platform }},ignore-error=true
             *.cache-from=type=gha,scope=${{ matrix.target }}-${{ matrix.platform }}
             *.cache-from=${{join(fromJSON(steps.test_meta.outputs.json || '{}').tags || fromJSON('[]'),',')}}
           load: true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3327,9 +3327,12 @@ jobs:
             ${{ env.DOCKER_BAKE_FILE }}
             ${{ steps.test_meta.outputs.bake-file }}
           targets: ${{ matrix.target }}
+          # Ignore cache-to errors as long as the build succeeds
+          # https://github.com/docker/bake-action/issues/313#issuecomment-2827973726
+          # https://github.com/moby/buildkit/pull/3430
           set: |
             *.platform=${{ matrix.platform }}
-            *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.platform }}
+            *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.platform }},ignore-error=true
             *.cache-from=type=gha,scope=${{ matrix.target }}-${{ matrix.platform }}
             *.cache-from=${{join(fromJSON(steps.test_meta.outputs.json || '{}').tags || fromJSON('[]'),',')}}
           load: true


### PR DESCRIPTION
As long as the build succeeds, we don't want to block the pipeline on caching issues. Especially on projects with very large image layers where cache failures are more common.

We see this failure quite often on [this repo](https://github.com/product-os/github-runner-vm), likely because it generates a 2GB+ rootfs layer at build time
and Flowzone attempts to cache all layers via GHA.

```
 > exporting to GitHub Actions Cache:
------
ERROR: failed to solve: error writing layer blob: GET https://productionresultssa16.blob.core.windows.net/actions-cache/d00-700429531
--------------------------------------------------------------------------------
RESPONSE 404: 404 The specified blob does not exist.
ERROR CODE: BlobNotFound
```

See: https://github.com/docker/bake-action/issues/313#issuecomment-2827973726

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/ARM-GitHub-runners-unable-to-register,-hitting-rate-limit-105