### PR TITLE
Disable renovate bumps to buildx v0.26.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,10 @@
 		{
 			"matchPackageNames": ["node-22.x"],
 			"allowedVersions": "22"
+		},
+		{
+			"matchPackageNames": ["docker/buildx"],
+			"allowedVersions": "!/v0.26.0/"
 		}
 	],
 	"customManagers": [


### PR DESCRIPTION
See: https://github.com/docker/buildx/issues/3328

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/Failing-Run-docker-compose-tests-CI-check-108