### PR TITLE
Dry-run cargo publish when applicable

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4376,6 +4376,9 @@ jobs:
         run: cross -v clippy --all-targets --all-features --target ${{ matrix.target }} -- -D warnings
       - name: Run tests for toolchain ${{ matrix.target }}
         run: cross -v test --all-targets --all-features --locked --target ${{ matrix.target }}
+      - name: Dry-run crate publish
+        if: needs.is_cargo.outputs.cargo_publish != 'false'
+        run: cross -v publish --dry-run
       - name: Generate metadata
         id: meta
         run: |

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4207,6 +4207,10 @@ jobs:
       - name: Run tests for toolchain ${{ matrix.target }}
         run: cross -v test --all-targets --all-features --locked --target ${{ matrix.target }}
 
+      - name: Dry-run crate publish
+        if: needs.is_cargo.outputs.cargo_publish != 'false'
+        run: cross -v publish --dry-run
+
       - name: Generate metadata
         id: meta
         run: |


### PR DESCRIPTION
This prevents errors happening on the merge event when it's too late to fix them. See
https://github.com/balena-io-modules/mahler-rs/actions/runs/16677452649/job/47207588810 as an example

Change-type: patch