### PR TITLE
Switch to nodejs 24 as the default for node steps

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -487,7 +487,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         env:
-          NODE_VERSION: 20.19.4
+          NODE_VERSION: 24.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install versioning tools
@@ -2410,7 +2410,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         env:
-          NODE_VERSION: 20.19.4
+          NODE_VERSION: 24.6.0
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
@@ -2419,7 +2419,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         env:
-          NODE_VERSION: 20.19.4
+          NODE_VERSION: 24.6.0
         with:
           node-version: ${{ matrix.node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
@@ -2543,7 +2543,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         env:
-          NODE_VERSION: 20.19.4
+          NODE_VERSION: 24.6.0
         with:
           node-version: ${{ fromJSON(needs.is_npm.outputs.node_versions)[0] }}
       - run: npm install
@@ -2603,7 +2603,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         env:
-          NODE_VERSION: 20.19.4
+          NODE_VERSION: 24.6.0
         with:
           node-version: ${{ needs.is_npm.outputs.max_node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
@@ -2667,7 +2667,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         env:
-          NODE_VERSION: 20.19.4
+          NODE_VERSION: 24.6.0
         with:
           node-version: ${{ needs.is_npm.outputs.max_node_version }}
           registry-url: ${{ env.NPM_REGISTRY }}
@@ -4010,7 +4010,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         env:
-          NODE_VERSION: 20.19.4
+          NODE_VERSION: 24.6.0
         with:
           node-version: ${{ needs.is_npm.outputs.max_node_version || '22.x' }}
       - name: Docusaurus Builder

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -579,8 +579,8 @@
     name: Setup Node.js
     uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
     env:
-      # renovate: datasource=node-version depName=node packageName=node-20.x
-      NODE_VERSION: 20.19.4
+      # renovate: datasource=node-version depName=node packageName=node-24.x
+      NODE_VERSION: 24.6.0
     with:
       node-version: ${{ env.NODE_VERSION }}
 


### PR DESCRIPTION
This also brings npm 11 for faster installs. Any steps that require an older nodejs version should be explicit about that dependency

Change-type: patch