### PR TITLE
Add support for Cargo workspaces

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1880,20 +1880,16 @@ jobs:
           fi
       - name: Check private
         if: steps.cargo_yml.outputs.enabled == 'true'
-        uses: dangdennis/toml-action@ef528766b9af3dc473cb3f768a1646160ffb2645
         id: cargo_publish
-        with:
-          file: Cargo.toml
-          field: package.publish
-          working-directory: ${{ inputs.working_directory }}
+        run: |
+          RESULT=$(yq -oj Cargo.toml | jq -r '(.package.publish == true) or (.workspace.package.publish == true)')
+          echo "value=$RESULT" >> "${GITHUB_OUTPUT}"
       - name: Get MSRV
         if: steps.cargo_yml.outputs.enabled == 'true'
-        uses: dangdennis/toml-action@ef528766b9af3dc473cb3f768a1646160ffb2645
         id: rust_version
-        with:
-          file: Cargo.toml
-          field: package.rust-version
-          working-directory: ${{ inputs.working_directory }}
+        run: |
+          RESULT=$(yq -oj Cargo.toml | jq -r '(.package."rust-version" // .workspace.package."rust-version") | select(. != null)')
+          echo "value=$RESULT" >> "${GITHUB_OUTPUT}"
   is_balena:
     name: Is balena
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ If your `pyproject.toml` file contains a `packages` property under `[tool.poetry
 
 If a `Cargo.toml` file is found in the root of the repository, Flowzone will run tests on the code formatting (using `cargo fmt` and `cargo clippy`) and then run tests for a set of target architectures given in `cargo_targets`. In order to disable Rust testing, set the value of that variable to `""`.
 
+Flowzone fully supports [Cargo Workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html). Note though that Flowzone follows Cargo's default behavior so if your `Cargo.toml` specifies a workspace with a root package, Flowzone will test and publish that root package alone, ignoring other crates in your workspace. In the future, Flowzone may get support for publishing all workspace crates regardless of the existence of a root package.
+
 For cross building targets, flowzone uses [cross](https://github.com/cross-rs/cross). This also means that further build options (e.g. [pre-build hooks](https://github.com/cross-rs/cross#pre-build-hook)) can be defined by adding a `Cross.toml` file to the local repository.
 
 When `rust_binaries` is set to `true`, Flowzone will also build release artifacts for each target architecture given in `cargo_targets` and upload the artifacts to the GitHub release.

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2507,21 +2507,17 @@ jobs:
 
       - name: Check private
         if: steps.cargo_yml.outputs.enabled == 'true'
-        uses: dangdennis/toml-action@ef528766b9af3dc473cb3f768a1646160ffb2645 # v1.3.0
         id: cargo_publish
-        with:
-          file: "Cargo.toml"
-          field: "package.publish"
-          working-directory: ${{ inputs.working_directory }}
+        run: |
+          RESULT=$(yq -oj Cargo.toml | jq -r '(.package.publish == true) or (.workspace.package.publish == true)')
+          echo "value=$RESULT" >> "${GITHUB_OUTPUT}"
 
       - name: Get MSRV
         if: steps.cargo_yml.outputs.enabled == 'true'
-        uses: dangdennis/toml-action@ef528766b9af3dc473cb3f768a1646160ffb2645 # v1.3.0
         id: rust_version
-        with:
-          file: "Cargo.toml"
-          field: "package.rust-version"
-          working-directory: ${{ inputs.working_directory }}
+        run: |
+          RESULT=$(yq -oj Cargo.toml | jq -r '(.package."rust-version" // .workspace.package."rust-version") | select(. != null)')
+          echo "value=$RESULT" >> "${GITHUB_OUTPUT}"
 
   # check for balena.yml in source
   is_balena:


### PR DESCRIPTION
This adds support for Cargo’s “Virtual Workspace”: https://doc.rust-lang.org/cargo/reference/workspaces.html

If `Cargo.toml` defines a `[workspace]` section, Flowzone now looks for the fields `publish`, `version` and `rust-version` in the `[workspace.package]` section.

If a `[package]` section exists, it takes precedence over the workspace and the project is assumed to be a regular Cargo crate.

Change-type: minor