### PR TITLE
Use the SHAs when fetching extra refs for merge events

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2272,21 +2272,6 @@ jobs:
               core.warning(`Failed to parse CloudFormation templates: ${error.message}`);
               core.setOutput('enabled', 'false');
             }
-      - name: Fetch extra refs for local diffs
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
-        env:
-          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref || github.event.head_commit.id }}
-        with:
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-            const { spawnSync } = require('child_process');
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.BASE_REF], { stdio: 'inherit' });
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.HEAD_REF], { stdio: 'inherit' });
       - name: Generate stacks matrix
         id: cloudformation_stacks
         if: steps.validate_files.outputs.enabled == 'true' || steps.validate_input.outputs.enabled == 'true'
@@ -2295,10 +2280,18 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           TEMPLATES_JSON: ${{ steps.validate_files.outputs.result || steps.validate_input.outputs.result }}
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         with:
           script: |
-            const { execSync } = require('child_process');
-            const { format } = require('util');
+            const { spawnSync } = require('child_process');
+
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
+
+            // Fetch the BASE and HEAD refs to ensure we can diff them
+            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.BASE_SHA], { stdio: 'inherit' });
+            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.HEAD_SHA], { stdio: 'inherit' });
 
             // Parse the JSON input
             const stacks = JSON.parse(process.env.TEMPLATES_JSON);
@@ -2318,14 +2311,12 @@ jobs:
 
             // Get modified files between BASE and HEAD
             const getModifiedFiles = () => {
-              const diff = execSync(
-                format('sh -c "git diff --submodule=diff %s %s | sed -rn \'s|^--- a/(.*)$|\\1|p\'"',
-                  process.env.BASE_SHA,
-                  process.env.HEAD_SHA
-                ),
+              const diff = spawnSync(
+                'sh',
+                ['-c', `git diff --submodule=diff ${process.env.BASE_SHA} ${process.env.HEAD_SHA} | sed -rn \'s|^--- a/(.*)$|\\1|p\'`],
                 { encoding: 'utf8' }
               );
-              return diff.split('\n').filter(f => f != null && !!f.trim())
+              return diff.stdout.split('\n').filter(f => f != null && !!f.trim())
             };
 
             let modifiedFiles = getModifiedFiles();

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -225,33 +225,6 @@
         const { spawnSync } = require('child_process');
         spawnSync('git', ['-c', authConfig, 'submodule', 'update', '--init', '--recursive'], { stdio: 'inherit' });
 
-  # Fetch base and head refs for local diffs, including submodules if required.
-  - &fetchExtraRefs
-    name: Fetch extra refs for local diffs
-    uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-    # if: needs.versioned_source.outputs.has_submodules == 'true'
-    env:
-      # Here we must use the app token to account for private submodules.
-      GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
-      BASE_REF: ${{ github.event.pull_request.base.ref || github.ref }}
-      HEAD_REF: ${{ github.event.pull_request.head.ref || github.event.head_commit.id }}
-    with:
-      # Use git-c for non-persistent credential configuration
-      #
-      # The git -c option sets a configuration value for a single Git command invocation.
-      # It does not modify any configuration files or persist the setting beyond this specific command.
-      #
-      # This approach ensures that the authentication credentials are used securely for this
-      # specific operation without risk of unintended persistence or exposure in configuration files.
-      script: |
-        const token = process.env.GIT_AUTH_TOKEN;
-        const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-        const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-        const { spawnSync } = require('child_process');
-        spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.BASE_REF], { stdio: 'inherit' });
-        spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.HEAD_REF], { stdio: 'inherit' });
-
   - &loginWithDockerHub
     name: Login to Docker Hub
     continue-on-error: true
@@ -2785,8 +2758,6 @@ jobs:
               core.setOutput('enabled', 'false');
             }
 
-      - *fetchExtraRefs
-
       - name: Generate stacks matrix
         id: cloudformation_stacks
         if: steps.validate_files.outputs.enabled == 'true' || steps.validate_input.outputs.enabled == 'true'
@@ -2795,10 +2766,19 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           TEMPLATES_JSON: ${{ steps.validate_files.outputs.result || steps.validate_input.outputs.result }}
+          # Use the app token to account for private submodules
+          GIT_AUTH_TOKEN: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         with:
           script: |
-            const { execSync } = require('child_process');
-            const { format } = require('util');
+            const { spawnSync } = require('child_process');
+
+            const token = process.env.GIT_AUTH_TOKEN;
+            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
+            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
+
+            // Fetch the BASE and HEAD refs to ensure we can diff them
+            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.BASE_SHA], { stdio: 'inherit' });
+            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.HEAD_SHA], { stdio: 'inherit' });
 
             // Parse the JSON input
             const stacks = JSON.parse(process.env.TEMPLATES_JSON);
@@ -2818,14 +2798,12 @@ jobs:
 
             // Get modified files between BASE and HEAD
             const getModifiedFiles = () => {
-              const diff = execSync(
-                format('sh -c "git diff --submodule=diff %s %s | sed -rn \'s|^--- a/(.*)$|\\1|p\'"',
-                  process.env.BASE_SHA,
-                  process.env.HEAD_SHA
-                ),
+              const diff = spawnSync(
+                'sh',
+                ['-c', `git diff --submodule=diff ${process.env.BASE_SHA} ${process.env.HEAD_SHA} | sed -rn \'s|^--- a/(.*)$|\\1|p\'`],
                 { encoding: 'utf8' }
               );
-              return diff.split('\n').filter(f => f != null && !!f.trim())
+              return diff.stdout.split('\n').filter(f => f != null && !!f.trim())
             };
 
             let modifiedFiles = getModifiedFiles();


### PR DESCRIPTION
This way it aligns with the same refs being used by the git diff
command in the subsequent git diff step.

Also, the refs may not exist on merge but the SHAs should.

Re-fixes: https://github.com/product-os/flowzone/pull/1570 and https://github.com/product-os/flowzone/pull/1567

Test run: https://github.com/balena-io/environment-playground/actions/runs/17960041230/job/51133279750