### PR TITLE
Always post deploy notes even for unedited release notes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -703,7 +703,7 @@ jobs:
             }
 
             // Check if PR is from Renovate
-            const isRenovate = (pr.labels || []).some(label => ((typeof label === 'string' ? label : label.name) || '').toLowerCase() === 'renovate');
+            const isRenovate = pr.labels?.some(label => (typeof label === 'string' ? label : label.name)?.toLowerCase() === 'renovate') === true;
             const renovateReleaseNotesMatch = pr.body.match(/### Release Notes([\s\S]*?)---/);
 
             if (isRenovate && renovateReleaseNotesMatch != null && renovateReleaseNotesMatch[1]) {
@@ -730,7 +730,7 @@ jobs:
                 .map(line => `* ${line.replace(/^> -|^-/, '')}`)
                 .join('\n');
 
-              const releaseNotesComment = `#release-notes ${pr.title}\n\nNotable changes\n* [only keep the important and rephrase, leaving this in place will avoid posting release notes]\n${notableChangesFormatted}\n\n${releaseNotesBody}`;
+              const releaseNotesComment = `#release-notes ${pr.title}\n\nNotable changes\n* [only keep the important and rephrase, leaving this in place will allow the comment to be clobbered]\n${notableChangesFormatted}\n\n${releaseNotesBody}`;
               core.setOutput('comment', releaseNotesComment);
 
               return releaseNotes;
@@ -872,7 +872,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: flowzone-app[bot]
-          body-regex: \* \[only keep the important and rephrase(, leaving this in place will avoid posting release notes)?\]
+          body-regex: \* \[only keep the important and rephrase(, leaving this in place will allow the comment to be clobbered)?\]
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         if: |
@@ -955,8 +955,7 @@ jobs:
           vars.ZULIP_TOPIC != '' &&
           vars.ZULIP_BOT_EMAIL != '' &&
           vars.ZULIP_API_URL != '' &&
-          steps.find_edited_comment.outcome == 'success' &&
-          steps.find_edited_comment.outputs.comment-id == ''
+          steps.find_comment.outputs.comment-body
         continue-on-error: true
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1434,7 +1434,7 @@ jobs:
                 .map(line => `* ${line.replace(/^> -|^-/, '')}`)
                 .join('\n');
 
-              const releaseNotesComment = `#release-notes ${pr.title}\n\nNotable changes\n* [only keep the important and rephrase, leaving this in place will avoid posting release notes]\n${notableChangesFormatted}\n\n${releaseNotesBody}`;
+              const releaseNotesComment = `#release-notes ${pr.title}\n\nNotable changes\n* [only keep the important and rephrase, leaving this in place will allow the comment to be clobbered]\n${notableChangesFormatted}\n\n${releaseNotesBody}`;
               core.setOutput('comment', releaseNotesComment);
 
               return releaseNotes;
@@ -1584,7 +1584,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "flowzone-app[bot]"
-          body-regex: '\* \[only keep the important and rephrase(, leaving this in place will avoid posting release notes)?\]'
+          body-regex: '\* \[only keep the important and rephrase(, leaving this in place will allow the comment to be clobbered)?\]'
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
       # to prevent clobbering edited comments, run only if no previous draft comment is
@@ -1646,8 +1646,8 @@ jobs:
           vars.ZULIP_TOPIC != '' &&
           vars.ZULIP_BOT_EMAIL != '' &&
           vars.ZULIP_API_URL != '' &&
-          steps.find_edited_comment.outcome == 'success' &&
-          steps.find_edited_comment.outputs.comment-id == ''
+          steps.find_comment.outputs.comment-body
+
         continue-on-error: true
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}


### PR DESCRIPTION
This change is to ensure we don't filter release content based
on whether a human has reviewed the release notes content or not.

If the repo has enabled the release_notes input for an environment,
that is enough to toggle the tag and release notes generation for all
merges as long as there are notable changes detected.

This currently only impacts two internal repositories.

See: https://balena.fibery.io/Work/Improvement/Push-deploy-notes-for-all-production-merges-3267
See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Procedure/Deploy-a-component-to-production-312