### PR TITLE
Update versionist token to include all repos in org

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -354,6 +354,7 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: read
+          owner: ${{ github.repository_owner }}
       - name: Reject HEAD branches containing merge commits
         if: github.event.pull_request.state == 'open'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1090,6 +1090,8 @@ jobs:
           permission-administration: read
           permission-contents: write
           permission-pull-requests: read
+          # Get permissions for all repos in this org for nested changelogs
+          owner: ${{ github.repository_owner }}
 
       - *rejectNonLinearHead
       - *rejectNonLinearMerge


### PR DESCRIPTION
This is required for nested changelogs and was broken when we moved to the new token action.

Change-type: patch

Fixes failures like [this](https://github.com/balena-io/remote-workers/actions/runs/18283532064/job/52054952709?pr=280)