### PR TITLE
Use python version available on runner to install lambda dependencies.

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -5370,16 +5370,9 @@ jobs:
           fi
 
           echo "caps=${caps}" >> "${GITHUB_OUTPUT}"
-      - name: Setup python
-        id: setup-python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
-        with:
-          cache: pip
-          python-version: 3.11
       - name: Install cfn-lint
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install cfn-lint==1.35.3
+          pip3 install cfn-lint==1.35.3
       - name: Lint template
         run: |
           ignore_from_meta="$(cat <"${TEMPLATE_FILE}" | yq e .Metadata.cfn-lint.config.ignore_checks[] -)"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4702,15 +4702,9 @@ jobs:
 
           echo "caps=${caps}" >> "${GITHUB_OUTPUT}"
 
-      - <<: *setupPython
-        with:
-          cache: "pip" # caching pip dependencies
-          python-version: 3.11
-
       - name: Install cfn-lint
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install cfn-lint==1.35.3
+          pip3 install cfn-lint==1.35.3
 
       - name: Lint template
         run: |


### PR DESCRIPTION
This skips python installation for every CloudFormation test job and uses the pre-installed python version of the runner for preparing the dependencies of Lambda functions deployed for CloudFormation stacks. This avoids the chance of a python installation failing which causes the entire flowzone workflow to fail.

Change-type: patch