### PR TITLE
Replace check-engine with inline semver for Node 26 check

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1592,8 +1592,8 @@ jobs:
         id: check_engine_26
         run: |
           node_version="$(node --version)"
-          # If checking the engine passes, or if it fails outright (ie no engines specified) then we accept this version
-          if npx -q -y -- check-engine@1 || ! npx -q -y -- check-engine@1 --ignore
+          range="$(node -p 'require("./package.json").engines?.node || ""')"
+          if [ -z "$range" ] || npx -q -y -- semver -r "$range" "$node_version" >/dev/null
           then
             echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"
           fi

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2113,8 +2113,16 @@ jobs:
           # renovate: datasource=node-version depName=node-26 packageName=node-26.x
           NODE_VERSION: 26.1.0
 
+      # check-engine@1 does not work with Node 26 due to ESM/CommonJS issues
       - <<: *checkEngine
         id: check_engine_26
+        run: |
+          node_version="$(node --version)"
+          range="$(node -p 'require("./package.json").engines?.node || ""')"
+          if [ -z "$range" ] || npx -q -y -- semver -r "$range" "$node_version" >/dev/null
+          then
+            echo "node_version=${node_version}" >> "${GITHUB_OUTPUT}"
+          fi
 
       # Fails if no versions were matched
       # https://github.com/actions/github-script


### PR DESCRIPTION
check-engine@1 bundles an old yargs whose unextensioned entrypoint Node 26 loads as ESM, which then throws on its internal require() call. The package has not seen updates since 2024-09-24. For the Node 26 step only, do the engines.node check inline with `node -p` + the semver CLI.

Closes: https://github.com/product-os/flowzone/issues/1762
Change-type: patch