### PR TITLE
Disable separation of majors for for dawidd6/action-download-artifact…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,6 +43,13 @@
 			"matchManagers": ["github-actions"],
 			"matchUpdateTypes": ["minor", "patch", "digest"],
 			"groupName": null
+		},
+		{
+			"description": "Disable separation of majors for dawidd6/action-download-artifact action (only ships majors)",
+			"matchManagers": ["github-actions"],
+			"matchPackageNames": ["dawidd6/action-download-artifact"],
+			"separateMultipleMajor": false,
+			"automerge": true
 		}
 	],
 	"customManagers": [


### PR DESCRIPTION
… action

This action now only ships majors, and it takes up our entire pipeline to separate them.

V4 Versioning Change: https://github.com/dawidd6/action-download-artifact/releases/tag/v4

**Rate-limited Renovate queue after the change**
<img width="700" height="505" alt="image" src="https://github.com/user-attachments/assets/868ade86-d9c1-4510-ae33-dca8d90f03d7" />
