### PR TITLE
Support digest pinning for binfmt version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -61,7 +61,7 @@
 				"/flowzone.yml/"
 			],
 			"matchStrings": [
-				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*[\"']?(?<currentValue>[^@\"'\\s]+)(?:@(?<currentDigest>sha256:[0-9a-f]+))?[\"']?\\s"
 			]
 		}
 	]

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3154,7 +3154,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
         env:
           LOG_LEVEL: debug
-          BINFMT_VERSION: qemu-v10.2.3-68
+          BINFMT_VERSION: qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
         with:
           platforms: ${{ matrix.platform }}
           image: tonistiigi/binfmt:${{ env.BINFMT_VERSION }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -580,7 +580,7 @@
     env:
       LOG_LEVEL: debug
       # renovate: datasource=docker depName=tonistiigi/binfmt versioning=regex:^(?<compatibility>.*)-v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-(?<build>\d+)$
-      BINFMT_VERSION: qemu-v10.2.3-68
+      BINFMT_VERSION: qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
     with:
       platforms: ${{ matrix.platform }}
       # https://hub.docker.com/r/tonistiigi/binfmt


### PR DESCRIPTION
Add an optional currentDigest capture group to the custom regex manager so Renovate can pin and maintain the SHA256 digest alongside the binfmt tag. The tag and digest are captured separately, so the inline versioning regex only ever parses the bare tag. Seed the current index digest.

Change-type: patch

---

Should resolve this error preventing the pinDependencies branch from being created
<img width="819" height="131" alt="image" src="https://github.com/user-attachments/assets/c8b67dd9-54c6-4a3a-99e7-37437961f27e" />
