### PR TITLE
Flag unsafe fork PR checkout required by checkout v7

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -458,6 +458,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - if: github.event.pull_request.state != 'open'
@@ -467,6 +468,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Describe git state
@@ -1047,6 +1049,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Update versioned tag reference
@@ -1104,6 +1107,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Update versioned tag reference
@@ -1243,6 +1247,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -1370,6 +1375,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -1602,6 +1608,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -1887,6 +1894,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -2047,6 +2055,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -2138,6 +2147,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -2219,6 +2229,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Update versioned tag reference
@@ -2392,6 +2403,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -2625,6 +2637,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -2773,6 +2786,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -3050,6 +3064,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -3581,6 +3596,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -3838,6 +3854,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -3931,6 +3948,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4079,6 +4097,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4223,6 +4242,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4353,6 +4373,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4471,6 +4492,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4647,6 +4669,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4757,6 +4780,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4873,6 +4897,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -4974,6 +4999,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5083,6 +5109,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5168,6 +5195,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5252,6 +5280,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5361,6 +5390,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5464,6 +5494,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5564,6 +5595,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5659,6 +5691,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules
@@ -5760,6 +5793,7 @@ jobs:
           fetch-tags: false
           submodules: false
           ref: ${{ needs.versioned_source.outputs.sha }}
+          allow-unsafe-pr-checkout: true
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
       - name: Checkout submodules

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -167,6 +167,8 @@
       submodules: false
       # This ref was pushed by the versioned source job.
       ref: ${{ needs.versioned_source.outputs.sha }}
+      # FIXME(#1855): running fork PR code in the pull_request_target trusted context.
+      allow-unsafe-pr-checkout: true
       <<: *checkoutAuth
 
   # Update the local tag ref so that it may be consumed by build steps that need to know the version of the source.
@@ -1222,6 +1224,8 @@ jobs:
           submodules: "recursive"
           # fallback to an invalid ref if the checkout ref is undefined
           ref: ${{ github.event.pull_request.head.sha || '¯\_(ツ)_/¯' }}
+          # FIXME(#1855): running fork PR code in the pull_request_target trusted context.
+          allow-unsafe-pr-checkout: true
           <<: *checkoutAuth
 
       # Checkout the event sha for closed/merged PRs.
@@ -1238,6 +1242,8 @@ jobs:
           submodules: "recursive"
           # fallback to an invalid ref if the checkout ref is undefined
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
+          # FIXME(#1855): running fork PR code in the pull_request_target trusted context.
+          allow-unsafe-pr-checkout: true
           <<: *checkoutAuth
 
       # The current commit sha is needed as the parent sha for the versioned commit


### PR DESCRIPTION
checkout v7 refuses to check out fork PR code under pull_request_target unless allow-unsafe-pr-checkout is set. Set it on the three fork-code checkouts to stay on v7, and mark each with a FIXME pointing at the rearchitecture tracking issue so the trust boundary gets fixed properly.

Change-type: patch
See: https://github.com/product-os/flowzone/issues/1855

> **Note**
> There is a real risk that enabling this flag will expose us to more AI and bot pwn targeted attacks as scanners will see it and target repos using it. Being a shared workflow helps a bit, but any AI will quickly determine that all of our repos use this shared workflow.