### PR TITLE
Never run fork PRs with secrets (trust boundary Phase 1)

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -30,11 +30,20 @@ runs:
 
     - name: Check vars from environment
       shell: bash
+      env:
+        FLOWZONE_TEST_VAR: ${{ fromJSON(inputs.variables).FLOWZONE_TEST_VAR }}
+        FLOWZONE_TEST_SECRET: ${{ fromJSON(inputs.secrets).FLOWZONE_TEST_SECRET }}
       run: |
         echo "environment=${environment}"
-        echo "FLOWZONE_TEST_VAR=${{ fromJSON(inputs.variables).FLOWZONE_TEST_VAR }}"
-        echo "FLOWZONE_TEST_SECRET=${{ fromJSON(inputs.secrets).FLOWZONE_TEST_SECRET }}"
-        test "${{ fromJSON(inputs.variables).FLOWZONE_TEST_VAR }}" = "Flowzone says hi!"
+        echo "FLOWZONE_TEST_VAR=${FLOWZONE_TEST_VAR}"
+        echo "FLOWZONE_TEST_SECRET=${FLOWZONE_TEST_SECRET}"
+        # Fork PRs run with no secrets or variables, so only assert passthrough when the value
+        # is present (i.e. the trusted internal lane); skip the assertion on forks.
+        if [ -n "${FLOWZONE_TEST_VAR}" ]; then
+          test "${FLOWZONE_TEST_VAR}" = "Flowzone says hi!"
+        else
+          echo "::notice::no variables/secrets provided (fork PR); skipping passthrough assertion"
+        fi
 
     # Resolve tag, semver, sha, and description of current git working copy.
     - name: Describe git state
@@ -44,7 +53,11 @@ runs:
         set -x
         tag="$(git tag --points-at HEAD | tail -n1)"
 
-        npx -q -y -- semver -c -l "${tag}"
+        # Fork runs are unversioned, so there is no tag at HEAD; only coerce a semver when a tag
+        # exists. This step is diagnostic and must not fail the job.
+        if [ -n "${tag}" ]; then
+          npx -q -y -- semver -c -l "${tag}"
+        fi
         git describe --tags --always --dirty | cat
         git rev-parse HEAD
         git submodule

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2922,8 +2922,10 @@ jobs:
     needs:
       - event_types
       - is_npm
+      - npm_test
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm == 'true' &&
       needs.is_npm.outputs.npm_private != 'true'
@@ -2949,7 +2951,14 @@ jobs:
           permission-metadata: read
           permission-contents: read
           permission-actions: read
+      - name: Download npm artifact (same run)
+        if: github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          path: ${{ runner.temp }}/npm
+          name: npm-${{ github.event.head_commit.id }}
       - name: Download npm artifact from last run
+        if: github.event_name != 'push' || needs.event_types.outputs.fork_merge != 'true'
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
           github_token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -2980,8 +2989,10 @@ jobs:
     needs:
       - event_types
       - is_npm
+      - npm_test
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm_docs == 'true'
       )
@@ -3007,7 +3018,14 @@ jobs:
           permission-metadata: read
           permission-pages: write
           permission-contents: write
+      - name: Download npm docs artifact (same run)
+        if: github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          path: ${{ runner.temp }}/docs
+          name: docs-${{ github.event.head_commit.id }}
       - name: Download npm docs artifact from last run
+        if: github.event_name != 'push' || needs.event_types.outputs.fork_merge != 'true'
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
           github_token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -281,13 +281,12 @@ jobs:
           echo "::error::External workflows can not be used with 'pull_request' events. \
             Please contact a member of the organization for assistance."
           exit 1
-      - name: Reject internal pull_request events on pull_request_target
-        if: |
-          github.event_name == 'pull_request_target' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+      - name: Reject pull_request_target events
+        if: github.event_name == 'pull_request_target'
         run: |
-          echo "::error::Internal workflows should not be used with 'pull_request_target' events. \
-            Please consult the documentation for more information."
+          echo "::error::Flowzone no longer runs on 'pull_request_target' events. External (fork) \
+            contributions are being migrated to a 'pull_request' + 'push' flow that never exposes \
+            secrets to untrusted code. See the Flowzone trust-boundary documentation."
           exit 1
       - name: Reject missing secrets
         run: |

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -253,6 +253,9 @@ jobs:
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     outputs:
       trusted: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      merged_pr: ${{ steps.push_class.outputs.merged_pr }}
+      fork_merge: ${{ steps.push_class.outputs.fork_merge == 'true' }}
+      push_finalize: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || steps.push_class.outputs.fork_merge == 'true' }}
     if: |
       (
         (
@@ -264,8 +267,10 @@ jobs:
           github.event.action == 'closed'
         )
       ) || (
-        github.event_name == 'push' &&
-        startsWith(github.ref, 'refs/tags/')
+        github.event_name == 'push' && (
+          startsWith(github.ref, 'refs/tags/') ||
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        )
       )
     strategy:
       fail-fast: true
@@ -273,7 +278,8 @@ jobs:
         include:
           - event_name: ${{ github.event_name }}
             event_action: ${{ github.event.action }}
-    permissions: {}
+    permissions:
+      pull-requests: read
     steps:
       - name: Reject pull_request_target events
         if: github.event_name == 'pull_request_target'
@@ -290,6 +296,22 @@ jobs:
             false
           fi
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Classify push merge
+        id: push_class
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              ...context.repo,
+              commit_sha: context.sha,
+            });
+            const merged = prs.find((pr) => pr.merged_at != null);
+            if (!merged) return;
+            core.setOutput("merged_pr", merged.number);
+            if (merged.head.repo.full_name !== context.payload.repository.full_name) {
+              core.setOutput("fork_merge", "true");
+            }
       - name: Log GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -6241,7 +6241,7 @@ jobs:
             exit 1
           fi
   all_jobs:
-    name: All jobs
+    name: All jobs${{ github.event_name == 'pull_request_target' && ' (pull_request_target)' || '' }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     permissions: {}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4770,16 +4770,14 @@ jobs:
       - versioned_source
       - release_notes
     if: |
+      !failure() && !cancelled() &&
       needs.event_types.outputs.trusted == 'true' && (
       (
-        (
-          github.event.pull_request.merged == true &&
-          inputs.disable_versioning == false
-        ) || (
-          github.event_name == 'push' &&
-          needs.event_types.outputs.push_finalize == 'true' &&
-          inputs.disable_versioning == true
-        )
+        github.event.pull_request.merged == true &&
+        inputs.disable_versioning == false
+      ) || (
+        github.event_name == 'push' &&
+        needs.event_types.outputs.push_finalize == 'true'
       )
       )
     defaults:
@@ -4844,12 +4842,21 @@ jobs:
           private-key: ${{ steps.decode.outputs.private-key }}
           permission-metadata: read
           permission-contents: write
+      - name: Download release artifacts
+        if: github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          path: ${{ runner.temp }}/artifacts
+          pattern: gh-release-*
+          merge-multiple: true
       - name: Download release notes
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: ${{ runner.temp }}
           name: release-notes
       - name: Finalize GitHub release (if any)
+        if: github.event_name != 'push'
         env:
           GH_DEBUG: "true"
           GH_PAGER: cat
@@ -4877,6 +4884,22 @@ jobs:
           else
             echo "No release found for the current PR"
           fi
+      - name: Create GitHub release
+        if: |
+          github.event_name == 'push' &&
+          needs.event_types.outputs.fork_merge == 'true' &&
+          needs.versioned_source.outputs.tag != ''
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
+        with:
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          name: ${{ needs.versioned_source.outputs.tag }}
+          tag_name: ${{ needs.versioned_source.outputs.tag }}
+          draft: false
+          prerelease: ${{ inputs.github_prerelease }}
+          make_latest: ${{ inputs.github_prerelease == false }}
+          generate_release_notes: true
+          files: ${{ runner.temp }}/artifacts/*
+          fail_on_unmatched_files: false
   cargo_test:
     name: Test rust
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3577,8 +3577,10 @@ jobs:
       - event_types
       - is_docker
       - versioned_source
+      - docker_publish
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_docker.outputs.docker_publish_matrix != ''
       )
@@ -6203,8 +6205,10 @@ jobs:
     needs:
       - event_types
       - is_cloudformation
+      - cloudformation_test
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -3229,7 +3229,9 @@ jobs:
           echo "COMPOSE_FILE=${{ runner.temp }}/docker-compose.yml" >> "${GITHUB_ENV}"
           echo "COMPOSE_ENV_FILE=${{ runner.temp }}/.env" >> "${GITHUB_ENV}"
       - name: Add COMPOSE_VARS to compose env file
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event.pull_request.head.repo.full_name == github.repository ||
+          (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
         shell: bash
@@ -3513,7 +3515,10 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
         if: |
           ( matrix.region != '' || inputs.aws_region != '' ) &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          (
+            github.event.pull_request.head.repo.full_name == github.repository ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          )
         continue-on-error: true
         with:
           role-to-assume: ${{ matrix.role || inputs.aws_iam_role }}
@@ -3755,7 +3760,10 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
         if: |
           ( matrix.region != '' || inputs.aws_region != '' ) &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          (
+            github.event.pull_request.head.repo.full_name == github.repository ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          )
         continue-on-error: true
         with:
           role-to-assume: ${{ matrix.role || inputs.aws_iam_role }}
@@ -5919,7 +5927,10 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
         if: |
           ( matrix.region != '' || inputs.aws_region != '' ) &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          (
+            github.event.pull_request.head.repo.full_name == github.repository ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          )
         continue-on-error: true
         with:
           role-to-assume: ${{ matrix.role || inputs.aws_iam_role }}
@@ -6260,7 +6271,10 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
         if: |
           ( matrix.region != '' || inputs.aws_region != '' ) &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          (
+            github.event.pull_request.head.repo.full_name == github.repository ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          )
         continue-on-error: true
         with:
           role-to-assume: ${{ matrix.role || inputs.aws_iam_role }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2587,10 +2587,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
       - versioned_source
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_npm.outputs.npm == 'true'
     defaults:
       run:
@@ -2868,6 +2872,7 @@ jobs:
     if: |
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
+      github.event.pull_request.state == 'open' &&
       needs.npm_test.result == 'success' &&
       needs.is_npm.outputs.npm_private != 'true'
       )
@@ -3026,10 +3031,14 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_docker
       - versioned_source
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_docker.outputs.docker_bake_json != ''
     defaults:
       run:
@@ -3267,7 +3276,7 @@ jobs:
             type=raw,value=${{ github.base_ref || github.ref_name }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
             type=raw,value=${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
             type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
-            type=raw,value=build-${{ github.event.pull_request.head.ref }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
+            type=raw,value=build-${{ github.event.pull_request.head.ref || github.ref_name }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
           flavor: |
             latest=false
       - name: Enable hardware execution
@@ -3411,7 +3420,7 @@ jobs:
             org.opencontainers.image.ref.name=${{ matrix.target }}
           tags: |
             type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-            type=raw,value=build-${{ github.event.pull_request.head.ref }}
+            type=raw,value=build-${{ github.event.pull_request.head.ref || github.ref_name }}
           flavor: |
             latest=false
             prefix=${{ steps.strings.outputs.prefix }}
@@ -4873,10 +4882,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cargo
       - versioned_source
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_cargo.outputs.cargo == 'true'
     defaults:
       run:
@@ -5777,7 +5790,10 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -250,7 +250,7 @@ jobs:
   event_types:
     name: Event Types
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     if: |
       (
         (
@@ -295,29 +295,6 @@ jobs:
             echo '::error::Must specify either FLOWZONE_APP_PRIVATE_KEY, GH_APP_PRIVATE_KEY, or FLOWZONE_TOKEN.'
             false
           fi
-      - name: Decode private key
-        if: inputs.app_id
-        id: decode
-        uses: product-os/decode-private-key@e51369845773d30f258072c37a0086b3b46c0b4f
-        with:
-          secret: ${{ secrets.FLOWZONE_APP_PRIVATE_KEY || secrets.GH_APP_PRIVATE_KEY }}
-      - name: Generate GitHub App installation token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        if: inputs.app_id
-        id: gh_app_token
-        with:
-          client-id: ${{ inputs.app_id }}
-          private-key: ${{ steps.decode.outputs.private-key }}
-          permission-metadata: read
-          permission-contents: read
-          permission-issues: read
-          permission-pull-requests: write
-      - name: Wait for approval on pull_request_target events
-        if: github.event_name == 'pull_request_target' && github.event.pull_request.merged != true
-        uses: product-os/review-commit-action@3caab52f4a41ad395c033ac667d1ba4d23d57f6e
-        with:
-          allow-authors: false
-          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
       - name: Log GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -628,7 +628,7 @@ jobs:
       - name: Update git reference (force)
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          REF: heads/${{ github.base_ref }}
+          REF: heads/${{ github.base_ref || github.event.repository.default_branch }}
           SHA: ${{ steps.create_commit.outputs.sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
@@ -643,7 +643,10 @@ jobs:
             });
             return ref;
         if: |
-          github.event.pull_request.merged &&
+          (
+            github.event.pull_request.merged ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          ) &&
           steps.create_commit.outputs.sha &&
           needs.event_types.outputs.trusted == 'true'
       - name: Create git reference
@@ -663,7 +666,10 @@ jobs:
             });
             return ref;
         if: |
-          github.event.pull_request.merged &&
+          (
+            github.event.pull_request.merged ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          ) &&
           steps.create_tag.outputs.sha &&
           needs.event_types.outputs.trusted == 'true'
   release_notes:

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2913,7 +2913,7 @@ jobs:
       - is_npm
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm == 'true' &&
       needs.is_npm.outputs.npm_private != 'true'
       )
@@ -2971,7 +2971,7 @@ jobs:
       - is_npm
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm_docs == 'true'
       )
     defaults:
@@ -3564,7 +3564,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_docker.outputs.docker_publish_matrix != ''
       )
     defaults:
@@ -4347,7 +4347,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_python.outputs.python_poetry == 'true' &&
       needs.is_python.outputs.pypi_publish == 'true'
       )
@@ -4762,6 +4762,7 @@ jobs:
           inputs.disable_versioning == false
         ) || (
           github.event_name == 'push' &&
+          needs.event_types.outputs.push_finalize == 'true' &&
           inputs.disable_versioning == true
         )
       )
@@ -5178,7 +5179,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_cargo.outputs.cargo == 'true'
       )
     defaults:
@@ -5468,7 +5469,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_custom.outputs.custom_finalize == 'true'
       )
     strategy:
@@ -6159,7 +6160,7 @@ jobs:
       - is_cloudformation
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -585,7 +585,7 @@ jobs:
         if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_commit
         env:
-          MESSAGE: ${{ steps.versionist.outputs.tag }}
+          MESSAGE: ${{ steps.versionist.outputs.tag }} [skip ci]
           TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2679,8 +2679,8 @@ jobs:
           package="$(jq -r '.name' package.json)"
           version="$(jq -r '.version' package.json)"
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
+          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -2725,7 +2725,7 @@ jobs:
         if: needs.is_npm.outputs.npm_private != 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: npm-${{ github.event.pull_request.head.sha }}
+          name: npm-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
       - name: Generate docs (if present)
@@ -2739,7 +2739,7 @@ jobs:
         if: needs.is_npm.outputs.npm_docs == 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: docs-${{ github.event.pull_request.head.sha }}
+          name: docs-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}/docs.tar.zst
           retention-days: 90
   npm_sbom:
@@ -2880,7 +2880,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}
+          name: npm-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         env:
@@ -3265,8 +3265,8 @@ jobs:
             type=raw,value=latest
             type=raw,value=latest,prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
             type=raw,value=${{ github.base_ref || github.ref_name }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
-            type=raw,value=${{ github.event.pull_request.head.sha }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
-            type=raw,value=build-${{ github.event.pull_request.head.sha }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
+            type=raw,value=${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
+            type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
             type=raw,value=build-${{ github.event.pull_request.head.ref }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
           flavor: |
             latest=false
@@ -3410,7 +3410,7 @@ jobs:
             org.opencontainers.image.version=${{ needs.versioned_source.outputs.semver }}
             org.opencontainers.image.ref.name=${{ matrix.target }}
           tags: |
-            type=raw,value=build-${{ github.event.pull_request.head.sha }}
+            type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
             type=raw,value=build-${{ github.event.pull_request.head.ref }}
           flavor: |
             latest=false
@@ -4044,8 +4044,8 @@ jobs:
           package=$(grep '^name =' pyproject.toml | sed 's/name = "\(.*\)"/\1/')
           version=$(grep '^version =' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
+          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -4325,7 +4325,7 @@ jobs:
         run: |
           package="$(poetry version --no-ansi | awk '{print $1}')"
           version="$(poetry version --no-ansi | awk '{print $2}')"
-          commit_sha="$(echo ${{ github.event.pull_request.head.sha }} | tr "a-z" "A-Z")"
+          commit_sha="$(echo ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | tr "a-z" "A-Z")"
           decimal_sha="$(echo "ibase=16; $commit_sha" | bc)"
           version_tag="${version}-dev${decimal_sha}"
 
@@ -4971,8 +4971,8 @@ jobs:
           packages="$(cargo metadata --no-deps --format-version 1 | jq -c '[.packages[] | .targets[] | select(.kind[] == "bin") | .name]')"
           version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo "${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
+          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
 
           {
             echo "packages=${packages}" ;

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -251,6 +251,8 @@ jobs:
     name: Event Types
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    outputs:
+      trusted: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     if: |
       (
         (
@@ -273,14 +275,6 @@ jobs:
             event_action: ${{ github.event.action }}
     permissions: {}
     steps:
-      - name: Reject external pull_request events on pull_request
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "::error::External workflows can not be used with 'pull_request' events. \
-            Please contact a member of the organization for assistance."
-          exit 1
       - name: Reject pull_request_target events
         if: github.event_name == 'pull_request_target'
         run: |
@@ -295,6 +289,7 @@ jobs:
             echo '::error::Must specify either FLOWZONE_APP_PRIVATE_KEY, GH_APP_PRIVATE_KEY, or FLOWZONE_TOKEN.'
             false
           fi
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       - name: Log GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
@@ -350,7 +345,7 @@ jobs:
         if: github.event.pull_request.state == 'open'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
-          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           result-encoding: json
           script: |
             const { data: commits } = await github.rest.pulls.listCommits({
@@ -365,7 +360,7 @@ jobs:
         if: github.event.pull_request.merged
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
-          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           result-encoding: json
           script: |
             console.debug(`Merge commit SHA: ${context.sha}`)

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2237,21 +2237,6 @@ jobs:
           SHA: ${{ needs.versioned_source.outputs.tag_sha }}
         run: |
           git update-ref "refs/tags/${TAG}" "${SHA}"
-      - name: Reset .github directory to ${{ github.ref }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        if: github.event_name == 'pull_request_target'
-        env:
-          GIT_AUTH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref }}
-        with:
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-            const { spawnSync } = require('child_process');
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.REF, '--no-recurse-submodules', '--no-tags'], { stdio: 'inherit' });
-            spawnSync('git', ['checkout', 'FETCH_HEAD', '--', '.github'], { stdio: 'inherit' });
       - id: custom_test_values
         if: contains(inputs.custom_test_matrix, '{') != true
         name: Build JSON list from comma-separated input
@@ -5389,21 +5374,6 @@ jobs:
           SHA: ${{ needs.versioned_source.outputs.tag_sha }}
         run: |
           git update-ref "refs/tags/${TAG}" "${SHA}"
-      - name: Reset .github directory to ${{ github.ref }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        if: github.event_name == 'pull_request_target'
-        env:
-          GIT_AUTH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref }}
-        with:
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-            const { spawnSync } = require('child_process');
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.REF, '--no-recurse-submodules', '--no-tags'], { stdio: 'inherit' });
-            spawnSync('git', ['checkout', 'FETCH_HEAD', '--', '.github'], { stdio: 'inherit' });
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -5501,21 +5471,6 @@ jobs:
           SHA: ${{ needs.versioned_source.outputs.tag_sha }}
         run: |
           git update-ref "refs/tags/${TAG}" "${SHA}"
-      - name: Reset .github directory to ${{ github.ref }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        if: github.event_name == 'pull_request_target'
-        env:
-          GIT_AUTH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref }}
-        with:
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-            const { spawnSync } = require('child_process');
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.REF, '--no-recurse-submodules', '--no-tags'], { stdio: 'inherit' });
-            spawnSync('git', ['checkout', 'FETCH_HEAD', '--', '.github'], { stdio: 'inherit' });
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -5607,21 +5562,6 @@ jobs:
           SHA: ${{ needs.versioned_source.outputs.tag_sha }}
         run: |
           git update-ref "refs/tags/${TAG}" "${SHA}"
-      - name: Reset .github directory to ${{ github.ref }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        if: github.event_name == 'pull_request_target'
-        env:
-          GIT_AUTH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref }}
-        with:
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-            const { spawnSync } = require('child_process');
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.REF, '--no-recurse-submodules', '--no-tags'], { stdio: 'inherit' });
-            spawnSync('git', ['checkout', 'FETCH_HEAD', '--', '.github'], { stdio: 'inherit' });
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -5710,21 +5650,6 @@ jobs:
           SHA: ${{ needs.versioned_source.outputs.tag_sha }}
         run: |
           git update-ref "refs/tags/${TAG}" "${SHA}"
-      - name: Reset .github directory to ${{ github.ref }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        if: github.event_name == 'pull_request_target'
-        env:
-          GIT_AUTH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref }}
-        with:
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-            const { spawnSync } = require('child_process');
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.REF, '--no-recurse-submodules', '--no-tags'], { stdio: 'inherit' });
-            spawnSync('git', ['checkout', 'FETCH_HEAD', '--', '.github'], { stdio: 'inherit' });
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -5805,21 +5730,6 @@ jobs:
           SHA: ${{ needs.versioned_source.outputs.tag_sha }}
         run: |
           git update-ref "refs/tags/${TAG}" "${SHA}"
-      - name: Reset .github directory to ${{ github.ref }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        if: github.event_name == 'pull_request_target'
-        env:
-          GIT_AUTH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref }}
-        with:
-          script: |
-            const token = process.env.GIT_AUTH_TOKEN;
-            const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-            const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-            const { spawnSync } = require('child_process');
-            spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.REF, '--no-recurse-submodules', '--no-tags'], { stdio: 'inherit' });
-            spawnSync('git', ['checkout', 'FETCH_HEAD', '--', '.github'], { stdio: 'inherit' });
       - uses: ./.github/actions/always
         with:
           json: ${{ toJSON(inputs) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -324,14 +324,14 @@ jobs:
       GH_REPO: ${{ github.repository }}
     steps:
       - name: Decode private key
-        if: inputs.app_id
+        if: inputs.app_id && needs.event_types.outputs.trusted == 'true'
         id: decode
         uses: product-os/decode-private-key@e51369845773d30f258072c37a0086b3b46c0b4f
         with:
           secret: ${{ secrets.FLOWZONE_APP_PRIVATE_KEY || secrets.GH_APP_PRIVATE_KEY }}
       - name: Generate GitHub App installation token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        if: inputs.app_id
+        if: inputs.app_id && needs.event_types.outputs.trusted == 'true'
         id: gh_app_token
         with:
           client-id: ${{ inputs.app_id }}
@@ -392,7 +392,7 @@ jobs:
             return hasSubmodules;
       - name: Check for legacy branch protection
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        if: inputs.app_id && inputs.disable_versioning != true && github.event.pull_request.state == 'open'
+        if: inputs.app_id && inputs.disable_versioning != true && github.event.pull_request.state == 'open' && needs.event_types.outputs.trusted == 'true'
         with:
           github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           script: |
@@ -415,7 +415,7 @@ jobs:
               "See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets");
       - name: Generate GitHub App installation token for checkout
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        if: inputs.app_id && steps.has_submodules.outputs.result == 'true'
+        if: inputs.app_id && steps.has_submodules.outputs.result == 'true' && needs.event_types.outputs.trusted == 'true'
         id: checkout_token
         with:
           client-id: ${{ inputs.app_id }}
@@ -468,7 +468,7 @@ jobs:
       - name: Generate changelog
         if: inputs.disable_versioning != true
         env:
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         run: |
           if [ ! -f .versionbot/CHANGELOG.yml ]
           then
@@ -479,7 +479,7 @@ jobs:
         if: inputs.disable_versioning != true
         id: versionist
         env:
-          GITHUB_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         with:
           result-encoding: json
           script: |
@@ -501,7 +501,7 @@ jobs:
             core.setOutput('tag', `v${version}`);
             return version;
       - name: Create blobs and tree objects
-        if: inputs.disable_versioning != true
+        if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_tree
         env:
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
@@ -560,7 +560,7 @@ jobs:
             core.setOutput('sha', tree.sha);
             return tree;
       - name: Create commit object
-        if: inputs.disable_versioning != true
+        if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_commit
         env:
           MESSAGE: ${{ steps.versionist.outputs.tag }}
@@ -602,7 +602,7 @@ jobs:
             });
             core.setOutput('sha', tag.sha);
             return tag;
-        if: inputs.disable_versioning != true
+        if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
       - name: Update git reference (force)
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -622,7 +622,8 @@ jobs:
             return ref;
         if: |
           github.event.pull_request.merged &&
-          steps.create_commit.outputs.sha
+          steps.create_commit.outputs.sha &&
+          needs.event_types.outputs.trusted == 'true'
       - name: Create git reference
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -641,18 +642,22 @@ jobs:
             return ref;
         if: |
           github.event.pull_request.merged &&
-          steps.create_tag.outputs.sha
+          steps.create_tag.outputs.sha &&
+          needs.event_types.outputs.trusted == 'true'
   release_notes:
     name: Generate release notes
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       inputs.disable_versioning != true &&
       (
         github.event.pull_request.state == 'open' ||
         github.event.pull_request.merged == true
+      )
       )
     defaults:
       run:
@@ -833,13 +838,16 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - release_notes
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       inputs.release_notes == true &&
       (
         github.event.action != 'closed' ||
         github.event.pull_request.merged == true
+      )
       )
     defaults:
       run:
@@ -1103,6 +1111,7 @@ jobs:
           disable_rules: shellcheck,local-action,runner-label,dangerous-write,dangerous-checkout
       - name: Upload SARIF file to GitHub
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        if: needs.event_types.outputs.trusted == 'true'
         continue-on-error: true
         env:
           sarif_file: ${{ steps.octoscan.outputs.sarif_output }}
@@ -2710,10 +2719,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     continue-on-error: true
     needs:
+      - event_types
       - is_npm
       - npm_test
       - versioned_source
-    if: ${{ needs.is_npm.outputs.npm == 'true' && needs.is_npm.outputs.npm_sbom == 'true' }}
+    if: ${{ needs.event_types.outputs.trusted == 'true' && ( needs.is_npm.outputs.npm == 'true' && needs.is_npm.outputs.npm_sbom == 'true' ) }}
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -2820,6 +2830,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
       - npm_test
       - custom_test
@@ -2827,9 +2838,11 @@ jobs:
       - cargo_test
       - python_test
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.npm_test.result == 'success' &&
       needs.is_npm.outputs.npm_private != 'true'
+      )
     defaults:
       run:
         working-directory: .
@@ -2874,11 +2887,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_npm.outputs.npm == 'true' &&
       needs.is_npm.outputs.npm_private != 'true'
+      )
     defaults:
       run:
         working-directory: .
@@ -2929,10 +2945,13 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_npm.outputs.npm_docs == 'true'
+      )
     defaults:
       run:
         working-directory: .
@@ -3269,6 +3288,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - is_docker
       - npm_test
@@ -3277,9 +3297,11 @@ jobs:
       - cargo_test
       - python_test
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.docker_test.result == 'success' &&
       needs.is_docker.outputs.docker_publish_matrix != ''
+      )
     defaults:
       run:
         working-directory: .
@@ -3515,11 +3537,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_docker
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_docker.outputs.docker_publish_matrix != ''
+      )
     defaults:
       run:
         working-directory: .
@@ -3761,6 +3786,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_balena
       - npm_test
       - custom_test
@@ -3770,9 +3796,11 @@ jobs:
       - versioned_source
       - release_notes
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
       (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      )
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(inputs.max_parallel) }}
@@ -4016,10 +4044,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     continue-on-error: true
     needs:
+      - event_types
       - is_python
       - python_test
       - versioned_source
-    if: needs.is_python.outputs.python_poetry == 'true' && needs.is_python.outputs.python_sbom == 'true'
+    if: needs.event_types.outputs.trusted == 'true' && ( needs.is_python.outputs.python_poetry == 'true' && needs.is_python.outputs.python_sbom == 'true' )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -4152,6 +4181,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_python
       - npm_test
       - custom_test
@@ -4160,10 +4190,12 @@ jobs:
       - python_test
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.python_test.result == 'success' &&
       needs.is_python.outputs.python_poetry == 'true' &&
       needs.is_python.outputs.pypi_publish == 'true'
+      )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -4288,12 +4320,15 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_python
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_python.outputs.python_poetry == 'true' &&
       needs.is_python.outputs.pypi_publish == 'true'
+      )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -4404,6 +4439,7 @@ jobs:
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
     needs:
+      - event_types
       - file_list
       - is_npm
       - npm_test
@@ -4413,9 +4449,11 @@ jobs:
       - python_test
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() && needs.versioned_source.result == 'success' &&
       inputs.cloudflare_website != '' &&
       (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      )
     permissions:
       contents: read
     steps:
@@ -4539,8 +4577,10 @@ jobs:
     needs:
       - event_types
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       github.event.action == 'closed' &&
       github.event.pull_request.merged == false
+      )
     defaults:
       run:
         working-directory: .
@@ -4575,6 +4615,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - release_notes
       - npm_publish
@@ -4585,9 +4626,11 @@ jobs:
       - python_sbom
       - cargo_sbom
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       github.event.pull_request.state == 'open' &&
       needs.versioned_source.outputs.tag != ''
+      )
     defaults:
       run:
         working-directory: .
@@ -4686,9 +4729,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - release_notes
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (
         (
           github.event.pull_request.merged == true &&
@@ -4697,6 +4742,7 @@ jobs:
           github.event_name == 'push' &&
           inputs.disable_versioning == true
         )
+      )
       )
     defaults:
       run:
@@ -4911,10 +4957,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     continue-on-error: true
     needs:
+      - event_types
       - is_cargo
       - cargo_test
       - versioned_source
-    if: needs.is_cargo.outputs.cargo == 'true' && needs.is_cargo.outputs.cargo_sbom == 'true'
+    if: needs.event_types.outputs.trusted == 'true' && ( needs.is_cargo.outputs.cargo == 'true' && needs.is_cargo.outputs.cargo_sbom == 'true' )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -5104,11 +5151,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cargo
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_cargo.outputs.cargo == 'true'
+      )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -5279,6 +5329,7 @@ jobs:
     runs-on: ${{ matrix.os || fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - npm_test
       - custom_test
@@ -5287,9 +5338,11 @@ jobs:
       - python_test
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       github.event.pull_request.state == 'open' &&
       needs.is_custom.outputs.custom_publish == 'true'
+      )
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(inputs.max_parallel) }}
@@ -5388,11 +5441,14 @@ jobs:
     runs-on: ${{ matrix.os || fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_custom.outputs.custom_finalize == 'true'
+      )
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(inputs.max_parallel) }}
@@ -5496,12 +5552,15 @@ jobs:
         os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       github.event.action == 'closed' &&
       github.event.pull_request.merged == false &&
       needs.is_custom.outputs.custom_clean == 'true'
+      )
     steps:
       - name: Reject external custom actions
         if: |
@@ -5684,13 +5743,16 @@ jobs:
         include: ${{ fromJSON(needs.is_cloudformation.outputs.includes) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cloudformation
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       github.event.pull_request.state == 'open' &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'
+      )
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
@@ -6071,12 +6133,15 @@ jobs:
         include: ${{ fromJSON(needs.is_cloudformation.outputs.includes) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cloudformation
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'
+      )
     env:
       AWS_RETRY_MODE: adaptive
       AWS_MAX_ATTEMPTS: 10
@@ -6302,13 +6367,16 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - all_jobs
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.all_jobs.result == 'success' &&
       github.event.pull_request.state == 'open' &&
       inputs.toggle_auto_merge == true &&
       github.event.pull_request.user.type != 'Bot'
+      )
     permissions: {}
     steps:
       - name: Decode private key

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -194,7 +194,7 @@ on:
         required: false
         default: false
       restrict_custom_actions:
-        description: Do not execute custom actions for external contributors. Only remove this restriction if custom actions have been vetted as secure.
+        description: Deprecated and ignored. Fork pull requests now run without secrets, so custom actions no longer need to be restricted on forks (custom test runs on forks; custom publish/finalize/always stay trusted-only). Remove this input; it will be dropped in a future release.
         type: boolean
         required: false
         default: true
@@ -312,6 +312,10 @@ jobs:
             if (merged.head.repo.full_name !== context.payload.repository.full_name) {
               core.setOutput("fork_merge", "true");
             }
+      - name: Warn on deprecated restrict_custom_actions
+        if: inputs.restrict_custom_actions == false
+        run: |
+          echo "::warning::The 'restrict_custom_actions' input is deprecated and no longer has any effect. Fork pull requests run without secrets, so custom test actions run on forks (custom publish/finalize/always remain trusted-only). Please remove this input from your caller workflow."
       - name: Log GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
@@ -5304,10 +5308,14 @@ jobs:
     runs-on: ${{ matrix.os || fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - versioned_source
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_custom.outputs.custom_test == 'true'
     strategy:
       fail-fast: false
@@ -5315,15 +5323,6 @@ jobs:
       matrix: ${{ fromJSON(needs.is_custom.outputs.custom_test_matrix) }}
     environment: ${{ matrix.environment }}
     steps:
-      - name: Reject external custom actions
-        if: |
-          github.event.pull_request.state == 'open' &&
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          inputs.restrict_custom_actions == true
-        run: |
-          echo "::error::Custom actions are disabled for external contributors and will be skipped. \
-            Please contact a member of the organization for assistance."
-          exit 1
       - name: Deployment environment
         if: ${{ matrix.environment != '' }}
         run: |
@@ -5403,7 +5402,10 @@ jobs:
     if: |
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_custom.outputs.custom_publish == 'true'
       )
     strategy:
@@ -5412,15 +5414,6 @@ jobs:
       matrix: ${{ fromJSON(needs.is_custom.outputs.custom_publish_matrix) }}
     environment: ${{ matrix.environment }}
     steps:
-      - name: Reject external custom actions
-        if: |
-          github.event.pull_request.state == 'open' &&
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          inputs.restrict_custom_actions == true
-        run: |
-          echo "::error::Custom actions are disabled for external contributors and will be skipped. \
-            Please contact a member of the organization for assistance."
-          exit 1
       - name: Deployment environment
         if: ${{ matrix.environment != '' }}
         run: |
@@ -5492,8 +5485,10 @@ jobs:
       - event_types
       - is_custom
       - versioned_source
+      - custom_publish
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_custom.outputs.custom_finalize == 'true'
       )
@@ -5503,15 +5498,6 @@ jobs:
       matrix: ${{ fromJSON(needs.is_custom.outputs.custom_finalize_matrix) }}
     environment: ${{ matrix.environment }}
     steps:
-      - name: Reject external custom actions
-        if: |
-          github.event.pull_request.state == 'open' &&
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          inputs.restrict_custom_actions == true
-        run: |
-          echo "::error::Custom actions are disabled for external contributors and will be skipped. \
-            Please contact a member of the organization for assistance."
-          exit 1
       - name: Deployment environment
         if: ${{ matrix.environment != '' }}
         run: |
@@ -5595,15 +5581,6 @@ jobs:
       needs.is_custom.outputs.custom_clean == 'true'
       )
     steps:
-      - name: Reject external custom actions
-        if: |
-          github.event.pull_request.state == 'open' &&
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          inputs.restrict_custom_actions == true
-        run: |
-          echo "::error::Custom actions are disabled for external contributors and will be skipped. \
-            Please contact a member of the organization for assistance."
-          exit 1
       - name: Decode private key
         if: inputs.app_id
         id: decode
@@ -5665,6 +5642,7 @@ jobs:
         os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - custom_test
       - custom_publish
       - custom_finalize
@@ -5672,18 +5650,10 @@ jobs:
       - is_custom
       - versioned_source
     if: |
-      always() &&
+      !cancelled() &&
+      needs.event_types.outputs.trusted == 'true' &&
       needs.is_custom.outputs.custom_always == 'true'
     steps:
-      - name: Reject external custom actions
-        if: |
-          github.event.pull_request.state == 'open' &&
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          inputs.restrict_custom_actions == true
-        run: |
-          echo "::error::Custom actions are disabled for external contributors and will be skipped. \
-            Please contact a member of the organization for assistance."
-          exit 1
       - name: Decode private key
         if: inputs.app_id
         id: decode

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,12 @@
 name: Tests
 
 on:
+  # Internal and fork PRs both run here with no secrets on forks; fork publishing happens on
+  # the push to the default branch after merge. pull_request_target is intentionally gone.
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  pull_request_target:
-    types: [opened, synchronize, closed]
+  push:
     branches: [main, master]
 
 # Simulate a "restricted" org/enterprise policy of read-only GITHUB_TOKEN access.
@@ -28,7 +29,10 @@ permissions:
   # packages: read
   packages: write # Allow Flowzone to publish to ghcr.io
   pages: none
-  pull-requests: none
+  # Flowzone's event_types classifies the PR a push merged ("Classify push merge"); the
+  # reusable workflow declares pull-requests: read, so the caller must grant it or the call
+  # fails at startup.
+  pull-requests: read
   repository-projects: none
   security-events: none
   statuses: none
@@ -37,15 +41,6 @@ jobs:
   flowzone:
     name: Flowzone
     uses: ./.github/workflows/flowzone.yml
-    # prevent duplicate workflow executions for pull_request and pull_request_target
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event_name == 'pull_request'
-      ) || (
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event_name == 'pull_request_target'
-      )
     secrets: inherit
     with:
       working_directory: ./tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,4 +70,3 @@ jobs:
           "environment": ["test"]
         }
       release_notes: true
-      restrict_custom_actions: false

--- a/README.md
+++ b/README.md
@@ -49,27 +49,20 @@ DO NOT EDIT MANUALLY - This section is auto-generated from flowzone.yml
 name: Flowzone
 
 on:
+  # Internal and fork PRs both run here; forks run with no secrets.
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  # allow external contributions to use secrets within trusted code
-  pull_request_target:
-    types: [opened, synchronize, closed]
+  # Fork contributions publish on the push to the default branch after merge, rebuilt from the
+  # merged commit (see "External Contributions" in the README). Drop this trigger to keep fork
+  # support test-only. Internal PRs do not need it.
+  push:
     branches: [main, master]
 
 jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
-    # prevent duplicate workflow executions for pull_request and pull_request_target
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event_name == 'pull_request'
-      ) || (
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event_name == 'pull_request_target'
-      )
 
     # Workflows in the same org or enterprise can use the inherit keyword to implicitly pass secrets
     secrets: inherit
@@ -357,15 +350,20 @@ You can read more about the available merge methods [here](https://docs.github.c
 
 ### External Contributions
 
-Flowzone supports external contributions (ie. PRs from forks) to your repository by using [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) events in addition to `pull_request`. This allows access to secrets normally available to members of the organization or the repository.
+Flowzone runs external contributions (PRs from forks) **without secrets**. A fork `pull_request` builds and tests in an untrusted lane: GitHub [withholds secrets and issues a read-only token](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) for workflows triggered by a fork PR, so no registry, cloud, or deploy credentials are ever exposed to fork-authored code. There is no approval gate and no [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) — untrusted code never runs in the base repository's trusted context.
 
-To mitigate the risk of secrets being exposed by malicious pull requests, we have taken the following steps in the Flowzone workflow.
+Because forks have no secrets, they cannot publish during the PR. **Fork contributions publish on the `push` to the default branch after merge**, rebuilt from the merged (trusted) commit — never from bytes uploaded by the fork. Internal PRs are unchanged — they run on `pull_request` with full secrets and finalize on merge.
 
-- Trusted code includes the Flowzone workflow itself and cannot be modified by pull requests.
-- Untrusted or arbitrary code can be called by Flowzone (eg. npm scripts) but does not expose any secrets in the environment at these points.
-- Custom actions are disabled for external contributors by default and can be enabled via `restrict_custom_actions` after the custom action has been vetted to not leak secrets to untrusted code.
+Consequences and limits:
 
-See the [usage examples](#usage) to get started and allow external contributions to your repo.
+- **Breaking change — callers must update to support forks.** The old caller snippet routed fork PRs to `pull_request_target` with an `if:` condition. Flowzone no longer runs on `pull_request_target`, so that routing now rejects fork PRs (and on the pre-migration Flowzone it fails to check out the fork). Adopt the new [usage](#usage) snippet: removing the `pull_request_target` trigger and its routing `if:` sends fork PRs to the no-secrets `pull_request` lane (enables fork **testing**), and adding the `push` trigger enables fork **publishing**. Until a caller updates, its fork PRs do not run through Flowzone.
+- **No secrets during a fork PR.** Fork PRs that rely on private submodules or `COMPOSE_VARS`-backed compose tests cannot fully run those steps during review; the trusted merge lane rebuilds them with credentials. This is inherent to a no-secrets model.
+- **Publish-path failures surface at merge, not during review**, since forks cannot draft-publish while the PR is open.
+- **Custom actions** stay disabled for forks by default; enable via `restrict_custom_actions` only after vetting that the action does not leak secrets to untrusted code.
+- **Auto-merge is internal-only** (it needs an app token). For fork auto-merge, install [bulldozer](https://github.com/palantir/bulldozer) and configure a per-repo `.bulldozer.yml`.
+- **Self-hosted runners and forks.** `runs_on`/`docker_runs_on` are caller inputs and Flowzone does not override them. A fork job may use self-hosted runners **only if they are ephemeral and isolated** — provisioned just-in-time, torn down per job, with no persistent tool-cache or disk and no reachable internal network or IAM. The risk is persistent runner state bridging an untrusted fork job into a later trusted one; Flowzone cannot enforce this, so it is org runner-group policy (see [#534](https://github.com/product-os/flowzone/issues/534)). Also enable "Require approval for all outside collaborators".
+
+See the [usage examples](#usage) to get started, and [docs/trust-boundary.md](docs/trust-boundary.md) for the full design and rationale.
 
 ### Commit Message
 

--- a/README.md
+++ b/README.md
@@ -285,8 +285,10 @@ jobs:
       # Required: false
       github_prerelease: false
 
-      # Do not execute custom actions for external contributors. Only remove this restriction if
-      # custom actions have been vetted as secure.
+      # Deprecated and ignored. Fork pull requests now run without secrets, so custom actions no
+      # longer need to be restricted on forks (custom test runs on forks; custom
+      # publish/finalize/always stay trusted-only). Remove this input; it will be dropped in a
+      # future release.
       # Type: boolean
       # Required: false
       restrict_custom_actions: true
@@ -359,7 +361,7 @@ Consequences and limits:
 - **Breaking change — callers must update to support forks.** The old caller snippet routed fork PRs to `pull_request_target` with an `if:` condition. Flowzone no longer runs on `pull_request_target`, so that routing now rejects fork PRs (and on the pre-migration Flowzone it fails to check out the fork). Adopt the new [usage](#usage) snippet: removing the `pull_request_target` trigger and its routing `if:` sends fork PRs to the no-secrets `pull_request` lane (enables fork **testing**), and adding the `push` trigger enables fork **publishing**. Until a caller updates, its fork PRs do not run through Flowzone.
 - **No secrets during a fork PR.** Fork PRs that rely on private submodules or `COMPOSE_VARS`-backed compose tests cannot fully run those steps during review; the trusted merge lane rebuilds them with credentials. This is inherent to a no-secrets model.
 - **Publish-path failures surface at merge, not during review**, since forks cannot draft-publish while the PR is open.
-- **Custom actions** stay disabled for forks by default; enable via `restrict_custom_actions` only after vetting that the action does not leak secrets to untrusted code.
+- **Custom actions.** `custom_test` runs on forks (as untrusted code with no secrets, so there is nothing for it to leak); `custom_publish`, `custom_finalize`, and `custom_always` run only on trusted lanes. Write custom test actions so they tolerate absent secrets. (The `restrict_custom_actions` input is deprecated and ignored — it existed only to keep fork custom code out of the trusted `pull_request_target` context, which no longer exists. Flowzone warns if it is set; it will be removed in a future release.)
 - **Auto-merge is internal-only** (it needs an app token). For fork auto-merge, install [bulldozer](https://github.com/palantir/bulldozer) and configure a per-repo `.bulldozer.yml`.
 - **Self-hosted runners and forks.** `runs_on`/`docker_runs_on` are caller inputs and Flowzone does not override them. A fork job may use self-hosted runners **only if they are ephemeral and isolated** — provisioned just-in-time, torn down per job, with no persistent tool-cache or disk and no reachable internal network or IAM. The risk is persistent runner state bridging an untrusted fork job into a later trusted one; Flowzone cannot enforce this, so it is org runner-group policy (see [#534](https://github.com/product-os/flowzone/issues/534)). Also enable "Require approval for all outside collaborators".
 

--- a/build.js
+++ b/build.js
@@ -37,27 +37,20 @@ function injectYamlIntoMarkdown(startTag, endTag) {
 name: Flowzone
 
 on:
+  # Internal and fork PRs both run here; forks run with no secrets.
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  # allow external contributions to use secrets within trusted code
-  pull_request_target:
-    types: [opened, synchronize, closed]
+  # Fork contributions publish on the push to the default branch after merge, rebuilt from the
+  # merged commit (see "External Contributions" in the README). Drop this trigger to keep fork
+  # support test-only. Internal PRs do not need it.
+  push:
     branches: [main, master]
 
 jobs:
   flowzone:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
-    # prevent duplicate workflow executions for pull_request and pull_request_target
-    if: |
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event_name == 'pull_request'
-      ) || (
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event_name == 'pull_request_target'
-      )
 
     # Workflows in the same org or enterprise can use the inherit keyword to implicitly pass secrets
     secrets: inherit

--- a/docs/trust-boundary.md
+++ b/docs/trust-boundary.md
@@ -1,0 +1,109 @@
+# Flowzone trust boundary
+
+This document describes how Flowzone keeps secrets away from untrusted (fork) code, and how a
+fork contribution still builds, tests, and publishes. It is the maintainer-facing companion to
+the "External Contributions" section of the [README](../README.md).
+
+## The problem it replaces
+
+Flowzone used to give fork PRs access to secrets via `pull_request_target` plus a review-gate:
+a maintainer approved a reaction before merge. Untrusted fork code ran in the base repository's
+trusted context — its `GITHUB_TOKEN`, secrets, cache scope, and runner access — with only human
+vigilance between a fork and the org's registry, cloud, and deploy credentials. That is the
+"pwn request" anti-pattern: a boundary held by a person, not by structure.
+
+The redesign removes `pull_request_target` entirely and makes the trust boundary structural:
+**a fork never runs with secrets.** Secrets only ever appear on trusted lanes, selected by
+event, not by review.
+
+## One trust boundary per job, selected by event
+
+| Event | Actor | Behaviour |
+| --- | --- | --- |
+| `pull_request` | internal branch | Full pipeline with secrets; draft on open, finalize on merge. **Unchanged.** |
+| `pull_request` | **fork** | Build and test with **no secrets** (GitHub withholds them and issues a read-only token). No versioning, no publishes. |
+| `push` | default branch, **fork merge** | **Rebuild + publish + finalize** from the merged (trusted) commit. Where fork contributions publish. |
+| `push` | default branch, internal merge | Quiet skip — already finalized on the internal PR's `pull_request` lane. |
+| `push` | tags / direct | Trusted release path. **Unchanged.** |
+| `pull_request_target` | any | **Rejected** at the event gate. |
+
+The lane is decided in the `event_types` job and exported as outputs the rest of the workflow
+gates on:
+
+- `trusted` — `true` on everything except a fork `pull_request`. Secret-consuming jobs and
+  steps gate on this so they skip (not fail) on the untrusted fork lane.
+- `fork_merge` — `true` when a `push` to the default branch merged a PR that came from a fork.
+  Set by the `Classify push merge` step, which looks up the PR associated with the pushed commit
+  (`GET /repos/{}/commits/{sha}/pulls`).
+- `push_finalize` — `true` for tag pushes and fork merges; gates the finalize path on `push`.
+  Internal merges and direct pushes are `false` (no double-publish).
+
+## Why a fork merge rebuilds
+
+A fork's `pull_request` run has no secrets, so it publishes nothing during review. On merge, the
+`push` to the default branch runs the **whole pipeline in one run**: the test jobs rebuild from
+the merged commit, the publishers push, and the finalize jobs promote. This is structurally
+different from the internal flow, which splits work across two runs (open → draft-publish,
+merge → finalize).
+
+The rebuild is deliberate. Reusing a fork PR's uploaded artifact would let a fork publish bytes
+that do not match its reviewed source, built under its own workflow — a supply-chain break. So
+the fork-merge push downloads **same-run** artifacts produced by the rebuild; the cross-run
+artifact lookup (`dawidd6/action-download-artifact`, keyed by commit SHA) is used only on the
+internal-merge and tag lanes, whose artifact was built in a trusted earlier run.
+
+On this lane there is no reviewer for a "draft", so pure-draft steps are skipped: the GitHub
+release is created directly by `github_finalize` (not promoted from a draft), and the npm /
+PyPI draft publishes do not run (the finalize jobs publish the final release). Docker keeps
+publish + finalize, because `docker_finalize` retags the `build-<sha>` images that
+`docker_publish` pushes — Docker has registry tags, not a draft-vs-final artifact.
+
+## Migration
+
+- **Fork testing** requires a caller change. The previous caller snippet routed fork PRs to
+  `pull_request_target` with an `if:` condition, so a fork's `pull_request` invocation was
+  filtered out. Flowzone no longer runs on `pull_request_target`, so callers must adopt the new
+  [usage](../README.md#usage) snippet — removing the `pull_request_target` trigger and its
+  routing `if:` — to send fork PRs to the no-secrets `pull_request` lane.
+- **Fork publishing** additionally requires the `push` trigger on the default branch.
+- **Internal PRs** are unchanged. A caller that keeps the old `pull_request` +
+  `pull_request_target` wiring keeps working for internal PRs: the `pull_request_target`
+  invocation is filtered out by the caller `if:` (and if it does run, Flowzone rejects it and
+  its `all_jobs` is the non-required per-event context, so it never gates). Removing the dead
+  trigger is otherwise a mechanical follow-up.
+- **Caller permissions.** Most callers need no permission change. A caller that explicitly pins
+  a restrictive `permissions:` block must include `pull-requests: read` — `event_types`
+  declares it for the push-merge PR lookup, and a reusable-workflow call fails at startup if the
+  caller granted less. Callers that do not pin the permission inherit enough by default.
+
+## Accepted limitations
+
+- Fork PRs cannot run steps that need secrets (private submodules, `COMPOSE_VARS`-backed compose
+  tests) during review; the trusted merge lane rebuilds them with credentials.
+- Fork publish-path bugs surface at merge, not during review, because forks cannot draft-publish.
+- Repos that never add the `push` trigger get fork test-only.
+- `push`-merge runs share the default-branch concurrency group with `cancel-in-progress: false`;
+  GitHub keeps one pending run per group, so stacked merges can drop a pending publish. Re-run the
+  workflow for the affected merge commit.
+- Custom jobs are not rebuilt on the fork-merge push. Unlike the npm/docker/cargo test lanes,
+  `custom_test` and `custom_publish` run only on the `pull_request` lane, while `custom_finalize`
+  runs on the push — so a custom publish→finalize handoff is unsupported for fork contributions
+  (a self-contained `custom_finalize` still runs). The custom lane is left this way because the
+  action bodies are caller-defined and custom actions are fork-disabled by default via
+  `restrict_custom_actions`.
+
+## Runners
+
+`runs_on` / `docker_runs_on` are caller inputs and Flowzone does not override them. A fork job
+may use self-hosted runners **only if they are ephemeral and isolated**: provisioned
+just-in-time, torn down per job, with no persistent tool-cache or disk and no reachable internal
+network or IAM. The real risk is persistent runner state bridging an untrusted fork job into a
+later trusted one. Flowzone cannot enforce this (it is infrastructure config), so it is org
+runner-group policy — see [#534](https://github.com/product-os/flowzone/issues/534) — together
+with "Require approval for all outside collaborators".
+
+## Auto-merge
+
+Flowzone's auto-merge is internal-only; it needs an app token that the fork lane does not have.
+For fork auto-merge, install [bulldozer](https://github.com/palantir/bulldozer) (a GitHub App
+that merges on label/config as itself) and add a per-repo `.bulldozer.yml`.

--- a/docs/trust-boundary.md
+++ b/docs/trust-boundary.md
@@ -56,7 +56,9 @@ On this lane there is no reviewer for a "draft", so pure-draft steps are skipped
 release is created directly by `github_finalize` (not promoted from a draft), and the npm /
 PyPI draft publishes do not run (the finalize jobs publish the final release). Docker keeps
 publish + finalize, because `docker_finalize` retags the `build-<sha>` images that
-`docker_publish` pushes — Docker has registry tags, not a draft-vs-final artifact.
+`docker_publish` pushes — Docker has registry tags, not a draft-vs-final artifact. Custom jobs
+likewise run test → publish → finalize on this lane, since a caller's `custom_finalize` may
+consume its `custom_publish` output (the action bodies are caller-defined).
 
 ## Migration
 
@@ -75,6 +77,11 @@ publish + finalize, because `docker_finalize` retags the `build-<sha>` images th
   a restrictive `permissions:` block must include `pull-requests: read` — `event_types`
   declares it for the push-merge PR lookup, and a reusable-workflow call fails at startup if the
   caller granted less. Callers that do not pin the permission inherit enough by default.
+- **`restrict_custom_actions` is deprecated.** It only existed to keep fork custom code out of
+  the trusted `pull_request_target` context; forks now run without secrets, so it has no effect.
+  `custom_test` runs on forks; `custom_publish`/`custom_finalize`/`custom_always` are
+  trusted-only. Flowzone logs a `::warning::` when the input is set; remove it from callers (it
+  will be dropped in a future release).
 
 ## Accepted limitations
 
@@ -85,12 +92,6 @@ publish + finalize, because `docker_finalize` retags the `build-<sha>` images th
 - `push`-merge runs share the default-branch concurrency group with `cancel-in-progress: false`;
   GitHub keeps one pending run per group, so stacked merges can drop a pending publish. Re-run the
   workflow for the affected merge commit.
-- Custom jobs are not rebuilt on the fork-merge push. Unlike the npm/docker/cargo test lanes,
-  `custom_test` and `custom_publish` run only on the `pull_request` lane, while `custom_finalize`
-  runs on the push — so a custom publish→finalize handoff is unsupported for fork contributions
-  (a self-contained `custom_finalize` still runs). The custom lane is left this way because the
-  action bodies are caller-defined and custom actions are fork-disabled by default via
-  `restrict_custom_actions`.
 
 ## Runners
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1057,9 +1057,7 @@ jobs:
   event_types:
     name: Event Types
     runs-on: ubuntu-24.04
-    # Wait up to 60 min for workflow approvals on forks.
-    # App Installation tokens expire in 1h either way.
-    timeout-minutes: 60
+    timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     if: |
       (
         (
@@ -1088,27 +1086,6 @@ jobs:
       - *rejectExternalPullRequest
       - *rejectPullRequestTarget
       - *rejectMissingSecrets
-
-      - *decodePrivateKey
-      - <<: *getGitHubAppToken
-        with:
-          <<: *getGitHubAppTokenWith
-          # pull_requests: write is required to create or update pull request comments
-          permission-contents: read
-          permission-issues: read
-          permission-pull-requests: write
-
-      # Combining pull_request_target workflow trigger with an explicit checkout of an
-      # untrusted PR is a dangerous practice that may lead to repository compromise.
-      # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
-      # This action requires approvals via reactions for each workflow run.
-      # https://github.com/product-os/review-commit-action
-      - name: Wait for approval on pull_request_target events
-        if: github.event_name == 'pull_request_target' && github.event.pull_request.merged != true
-        uses: product-os/review-commit-action@3caab52f4a41ad395c033ac667d1ba4d23d57f6e # v0.3.2
-        with:
-          allow-authors: false
-          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
       - *logGitHubContext
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -500,14 +500,17 @@
         Please contact a member of the organization for assistance."
       exit 1
 
-  - &rejectInternalPullRequestTarget
-    name: Reject internal pull_request events on pull_request_target
-    if: |
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+  - &rejectPullRequestTarget
+    name: Reject pull_request_target events
+    # Flowzone no longer runs on pull_request_target. Fork code must never execute in the
+    # base repo's trusted (secret-bearing) context, so we refuse the event outright at the
+    # gate, before any job checks out a ref. External contributions are moving to a
+    # pull_request (no secrets) + push (trusted merge) flow.
+    if: github.event_name == 'pull_request_target'
     run: |
-      echo "::error::Internal workflows should not be used with 'pull_request_target' events. \
-        Please consult the documentation for more information."
+      echo "::error::Flowzone no longer runs on 'pull_request_target' events. External (fork) \
+        contributions are being migrated to a 'pull_request' + 'push' flow that never exposes \
+        secrets to untrusted code. See the Flowzone trust-boundary documentation."
       exit 1
 
   - &rejectNonLinearHead
@@ -1083,7 +1086,7 @@ jobs:
 
     steps:
       - *rejectExternalPullRequest
-      - *rejectInternalPullRequestTarget
+      - *rejectPullRequestTarget
       - *rejectMissingSecrets
 
       - *decodePrivateKey

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -490,16 +490,6 @@
         exit 1
       fi
 
-  - &rejectExternalPullRequest
-    name: Reject external pull_request events on pull_request
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    run: |
-      echo "::error::External workflows can not be used with 'pull_request' events. \
-        Please contact a member of the organization for assistance."
-      exit 1
-
   - &rejectPullRequestTarget
     name: Reject pull_request_target events
     # Flowzone no longer runs on pull_request_target. Fork code must never execute in the
@@ -522,7 +512,9 @@
     if: github.event.pull_request.state == 'open'
     uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
     with:
-      github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      # Fall back to github.token on the fork lane: forks have no app token or secrets, and
+      # listing PR commits only needs read access, which the read-only fork token has.
+      github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
       result-encoding: json
       script: |
         const { data: commits } = await github.rest.pulls.listCommits({
@@ -546,7 +538,8 @@
     if: github.event.pull_request.merged
     uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
     with:
-      github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+      # Fall back to github.token on the fork lane (read-only is enough to read the commit).
+      github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
       result-encoding: json
       script: |
         console.debug(`Merge commit SHA: ${context.sha}`)
@@ -1058,6 +1051,11 @@ jobs:
     name: Event Types
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
+    outputs:
+      # Trusted (secret-bearing) contexts: internal PRs and pushes to the base repo.
+      # A fork pull_request receives no secrets from GitHub, so it is untrusted and
+      # secret-consuming jobs must skip on it (see downstream `needs.event_types.outputs.trusted`).
+      trusted: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     if: |
       (
         (
@@ -1083,9 +1081,13 @@ jobs:
     permissions: {}
 
     steps:
-      - *rejectExternalPullRequest
       - *rejectPullRequestTarget
-      - *rejectMissingSecrets
+      # Fork pull_request runs receive no secrets by design, so only require them on
+      # trusted lanes (internal PRs and pushes). This mirrors event_types.outputs.trusted.
+      - <<: *rejectMissingSecrets
+        if: >-
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
 
       - *logGitHubContext
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3733,8 +3733,14 @@ jobs:
       - event_types
       - is_docker
       - versioned_source
+      - docker_publish
+    # docker_finalize retags the build-<sha> images docker_publish pushes, so on the fork-merge
+    # push (same run) it must wait for docker_publish. On internal merges and tag pushes
+    # docker_publish is skipped (the images were pushed in the open-PR run), so tolerate
+    # skipped (but not failed) needs.
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_docker.outputs.docker_publish_matrix != ''
       )
@@ -5215,8 +5221,14 @@ jobs:
     needs:
       - event_types
       - is_cloudformation
+      - cloudformation_test
+    # cloudformation_finalize executes the change sets cloudformation_test creates, so on the
+    # fork-merge push (same run) it must wait for cloudformation_test. On internal merges the
+    # change sets were created in the open-PR run and cloudformation_test is skipped, so
+    # tolerate skipped (but not failed) needs.
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1409,7 +1409,12 @@ jobs:
         if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_commit
         env:
-          MESSAGE: ${{ steps.versionist.outputs.tag }}
+          # [skip ci] avoids recursion: this versioned commit becomes the default-branch HEAD
+          # when updateGitReference pushes it, and that push is made with the app token, which
+          # (unlike github.token) does re-trigger workflows. GitHub skips a push run whose HEAD
+          # commit message contains a skip directive, so the redundant run never starts. This
+          # does not affect the current run's publish/finalize (those run from the merge commit).
+          MESSAGE: ${{ steps.versionist.outputs.tag }} [skip ci]
           TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3283,8 +3283,13 @@ jobs:
     needs:
       - event_types
       - is_npm
+      - npm_test
+    # npm_test rebuilds and uploads the artifact on the fork-merge push, so wait for it there.
+    # On internal merges and tag pushes npm_test is skipped (the artifact is fetched cross-run
+    # below), so tolerate skipped (but not failed) needs.
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm == 'true' &&
       needs.is_npm.outputs.npm_private != 'true'
@@ -3304,9 +3309,21 @@ jobs:
           permission-contents: read
           permission-actions: read
 
+      # On the fork-merge push the artifact was rebuilt in this same run (a fork PR's own
+      # artifact is never reused), so download it directly instead of the cross-run lookup.
+      - name: Download npm artifact (same run)
+        if: github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/npm
+          name: npm-${{ github.event.head_commit.id }}
+
+      # Internal merges and tag pushes promote the artifact built in the open-PR (or tag) run,
+      # so look it up cross-run by commit sha.
       # https://github.com/dawidd6/action-download-artifact
       # TODO: what if this is a tag event and PR artifacts do not exist?
       - name: Download npm artifact from last run
+        if: github.event_name != 'push' || needs.event_types.outputs.fork_merge != 'true'
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -3342,8 +3359,12 @@ jobs:
     needs:
       - event_types
       - is_npm
+      - npm_test
+    # See npm_finalize: npm_test rebuilds the docs artifact on the fork-merge push; tolerate it
+    # being skipped on internal merges and tag pushes (fetched cross-run below).
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm_docs == 'true'
       )
@@ -3361,9 +3382,20 @@ jobs:
           permission-pages: write
           permission-contents: write
 
+      # On the fork-merge push the docs artifact was rebuilt in this same run, so download it
+      # directly instead of the cross-run lookup.
+      - name: Download npm docs artifact (same run)
+        if: github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/docs
+          name: docs-${{ github.event.head_commit.id }}
+
+      # Internal merges and tag pushes promote the artifact built in the open-PR (or tag) run.
       # https://github.com/dawidd6/action-download-artifact
       # TODO: what if this is a tag event and PR artifacts do not exist?
       - name: Download npm docs artifact from last run
+        if: github.event_name != 'push' || needs.event_types.outputs.fork_merge != 'true'
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1437,20 +1437,30 @@ jobs:
           SHA: ${{ steps.create_commit.outputs.sha }}
 
       # update the existing branch(head) name reference(pointer) to the new commit object sha
+      # A merged internal PR fires this on its pull_request closed event; a merged fork PR has
+      # no secrets on its pull_request lane, so its versioned commit is created and pushed here
+      # on the fork-merge push instead. On push github.base_ref is empty, so fall back to the
+      # default branch that the push landed on.
       - <<: *updateGitReference
         if: |
-          github.event.pull_request.merged &&
+          (
+            github.event.pull_request.merged ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          ) &&
           steps.create_commit.outputs.sha &&
           needs.event_types.outputs.trusted == 'true'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-          REF: "heads/${{ github.base_ref }}"
+          REF: "heads/${{ github.base_ref || github.event.repository.default_branch }}"
           SHA: ${{ steps.create_commit.outputs.sha }}
 
       # create a new tag name reference(pointer) to the new tag object sha
       - <<: *createGitReference
         if: |
-          github.event.pull_request.merged &&
+          (
+            github.event.pull_request.merged ||
+            (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+          ) &&
           steps.create_tag.outputs.sha &&
           needs.event_types.outputs.trusted == 'true'
         env:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1,7 +1,4 @@
 .flowzone:
-  - &ifInternalPullRequest # check if the PR is from a fork by comparing the repository name
-    if: github.event.pull_request.head.repo.full_name == github.repository
-
   - &ifExternalPullRequest # check if the PR is from a fork by comparing the repository name
     if: github.event.pull_request.head.repo.full_name != github.repository
 
@@ -34,10 +31,14 @@
     name: Configure AWS credentials
     id: aws_credentials
     uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-    # skip if the PR is from a fork or aws region is unset
+    # Only on trusted lanes (internal PR or fork-merge push) and when an aws region is set;
+    # a fork's pull_request gets no credentials. Every consumer has event_types in its needs.
     if: |
       ( matrix.region != '' || inputs.aws_region != '' ) &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (
+        github.event.pull_request.head.repo.full_name == github.repository ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      )
     continue-on-error: true
     with:
       role-to-assume: ${{ matrix.role || inputs.aws_iam_role }}
@@ -3490,9 +3491,12 @@ jobs:
           echo "COMPOSE_FILE=${{ runner.temp }}/docker-compose.yml" >> "${GITHUB_ENV}"
           echo "COMPOSE_ENV_FILE=${{ runner.temp }}/.env" >> "${GITHUB_ENV}"
 
-      # these secrets are being used in untrusted user code so only allow for internal PRs
+      # These secrets run inside user code, so only expose them on trusted lanes: internal PRs
+      # and the fork-merge push (where the code is already merged), never a fork's own PR.
       - name: Add COMPOSE_VARS to compose env file
-        <<: *ifInternalPullRequest
+        if: |
+          github.event.pull_request.head.repo.full_name == github.repository ||
+          (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
         env:
           COMPOSE_VARS: ${{ secrets.COMPOSE_VARS }}
         # do not use shell tracing to avoid leaking secrets

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -3268,7 +3268,7 @@ jobs:
       - is_npm
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm == 'true' &&
       needs.is_npm.outputs.npm_private != 'true'
       )
@@ -3327,7 +3327,7 @@ jobs:
       - is_npm
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_npm.outputs.npm_docs == 'true'
       )
 
@@ -3713,7 +3713,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_docker.outputs.docker_publish_matrix != ''
       )
 
@@ -4053,7 +4053,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_python.outputs.python_poetry == 'true' &&
       needs.is_python.outputs.pypi_publish == 'true'
       )
@@ -4310,6 +4310,7 @@ jobs:
           inputs.disable_versioning == false
         ) || (
           github.event_name == 'push' &&
+          needs.event_types.outputs.push_finalize == 'true' &&
           inputs.disable_versioning == true
         )
       )
@@ -4582,7 +4583,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_cargo.outputs.cargo == 'true'
       )
 
@@ -4735,7 +4736,7 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_custom.outputs.custom_finalize == 'true'
       )
 
@@ -5149,7 +5150,7 @@ jobs:
       - is_cloudformation
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      (github.event.pull_request.merged == true || github.event_name == 'push') &&
+      (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1,12 +1,7 @@
 .flowzone:
-  - &ifExternalPullRequest # check if the PR is from a fork by comparing the repository name
-    if: github.event.pull_request.head.repo.full_name != github.repository
 
   - &ifPrivateRepository
     if: github.event.repository.private
-
-  - &ifPublicRepository
-    if: github.event.repository.private != true
 
   - &decodePrivateKey # https://github.com/product-os/decode-private-key
     name: Decode private key
@@ -183,32 +178,6 @@
     run: |
       git update-ref "refs/tags/${TAG}" "${SHA}"
 
-  # Reset the .github directory to the GitHub ref.
-  # For security, this is the tip of BASE if the event is pull_request_target
-  - &resetGithubDirectory
-    name: Reset .github directory to ${{ github.ref }}
-    uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-    if: github.event_name == 'pull_request_target'
-    env:
-      GIT_AUTH_TOKEN: ${{ github.token }}
-      REF: ${{ github.ref }}
-    with:
-      # Use git-c for non-persistent credential configuration
-      #
-      # The git -c option sets a configuration value for a single Git command invocation.
-      # It does not modify any configuration files or persist the setting beyond this specific command.
-      #
-      # This approach ensures that the authentication credentials are used securely for this
-      # specific operation without risk of unintended persistence or exposure in configuration files.
-      script: |
-        const token = process.env.GIT_AUTH_TOKEN;
-        const authHeader = Buffer.from(`x-access-token:${token}`).toString('base64');
-        const authConfig = `http.https://github.com/.extraheader=Authorization: basic ${authHeader}`;
-
-        const { spawnSync } = require('child_process');
-        spawnSync('git', ['-c', authConfig, 'fetch', 'origin', process.env.REF, '--no-recurse-submodules', '--no-tags'], { stdio: 'inherit' });
-        spawnSync('git', ['checkout', 'FETCH_HEAD', '--', '.github'], { stdio: 'inherit' });
-
   # Checkout submodules if required.
   - &checkoutSubmodules
     name: Checkout submodules
@@ -324,14 +293,6 @@
 
         // Split by delimiter (will return [''] for empty input)
         return !input ? [''] : input.split(',');
-
-  - &newlineListBuilder
-    name: Build newline-separated list from JSON list input
-    uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-    with:
-      result-encoding: string
-      script: |
-        return JSON.parse(process.env.INPUT).join('\n');
 
   - &dockerPlatformSlugMap
     PLATFORM_SLUG_MAP: >
@@ -705,11 +666,6 @@
     if: steps.aws_credentials.outcome == 'success'
     continue-on-error: true
     run: aws sts get-caller-identity
-
-  - &updateKubeconfig
-    name: Update kubeconfig
-    run: |
-      aws eks update-kubeconfig --name "$(echo "${KUBE_CTX}" | awk -F'/' '{print $2}')"
 
   - &publishSBOMArtifacts
     name: Publish SBOM artifacts
@@ -2735,11 +2691,6 @@ jobs:
       # - *checkoutSubmodules # Submodules are not supported for custom actions
       - *updateVersionedTagRef
 
-      # Reset the .github directory to the GitHub ref
-      # For security, this is the tip of BASE if the event is pull_request_target
-      # or the merge commit if the PR is internal
-      - *resetGithubDirectory
-
       # FIXME: remove this handling of deprecated comma-separated values
       - id: custom_test_values
         if: contains(inputs.custom_test_matrix, '{') != true
@@ -4756,11 +4707,6 @@ jobs:
       - *checkoutSubmodules
       - *updateVersionedTagRef
 
-      # Reset the .github directory to the GitHub ref
-      # For security, this is the tip of BASE if the event is pull_request_target
-      # or the merge commit if the PR is internal
-      - *resetGithubDirectory
-
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4817,11 +4763,6 @@ jobs:
       - *checkoutSubmodules
       - *updateVersionedTagRef
 
-      # Reset the .github directory to the GitHub ref
-      # For security, this is the tip of BASE if the event is pull_request_target
-      # or the merge commit if the PR is internal
-      - *resetGithubDirectory
-
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4871,11 +4812,6 @@ jobs:
       - *checkoutSubmodules
       - *updateVersionedTagRef
 
-      # Reset the .github directory to the GitHub ref
-      # For security, this is the tip of BASE if the event is pull_request_target
-      # or the merge commit if the PR is internal
-      - *resetGithubDirectory
-
       - name: Set the matrix value env var
         shell: bash
         run: |
@@ -4923,11 +4859,6 @@ jobs:
       - *checkoutSubmodules
       - *updateVersionedTagRef
 
-      # Reset the .github directory to the GitHub ref
-      # For security, this is the tip of BASE if the event is pull_request_target
-      # or the merge commit if the PR is internal
-      - *resetGithubDirectory
-
       - uses: ./.github/actions/clean
         with:
           json: ${{ toJSON(inputs) }}
@@ -4965,11 +4896,6 @@ jobs:
       - *checkoutVersionedCommit
       - *checkoutSubmodules
       - *updateVersionedTagRef
-
-      # Reset the .github directory to the GitHub ref
-      # For security, this is the tip of BASE if the event is pull_request_target
-      # or the merge commit if the PR is internal
-      - *resetGithubDirectory
 
       - uses: ./.github/actions/always
         with:

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1056,6 +1056,15 @@ jobs:
       # A fork pull_request receives no secrets from GitHub, so it is untrusted and
       # secret-consuming jobs must skip on it (see downstream `needs.event_types.outputs.trusted`).
       trusted: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      # On a push to the default branch, `Classify push merge` (below) looks up the PR this
+      # commit merged. fork_merge is true iff that PR came from a fork. push_finalize gates the
+      # publish/finalize path on push: true for tag pushes and fork merges; false for internal
+      # merges (already finalized on their pull_request lane) and direct pushes.
+      # merged_pr is not consumed yet; it is reserved for reconstructing release notes / PR
+      # comments on the push lane (a Phase 2 item), where the PR payload is otherwise absent.
+      merged_pr: ${{ steps.push_class.outputs.merged_pr }}
+      fork_merge: ${{ steps.push_class.outputs.fork_merge == 'true' }}
+      push_finalize: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || steps.push_class.outputs.fork_merge == 'true' }}
     if: |
       (
         (
@@ -1067,8 +1076,10 @@ jobs:
           github.event.action == 'closed'
         )
       ) || (
-        github.event_name == 'push' &&
-        startsWith(github.ref, 'refs/tags/')
+        github.event_name == 'push' && (
+          startsWith(github.ref, 'refs/tags/') ||
+          github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        )
       )
 
     strategy:
@@ -1078,7 +1089,9 @@ jobs:
           - event_name: ${{ github.event_name }}
             event_action: ${{ github.event.action }}
 
-    permissions: {}
+    permissions:
+      # Read-only PR lookup for `Classify push merge` below (uses github.token on the push lane).
+      pull-requests: read
 
     steps:
       - *rejectPullRequestTarget
@@ -1088,6 +1101,26 @@ jobs:
         if: >-
           github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository
+
+      # On a push to the default branch, find the PR (if any) this commit merged so downstream
+      # jobs can distinguish a fork merge (publish here) from an internal merge (already
+      # finalized on its pull_request lane) or a direct push (no PR -> skip).
+      - name: Classify push merge
+        id: push_class
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              ...context.repo,
+              commit_sha: context.sha,
+            });
+            const merged = prs.find((pr) => pr.merged_at != null);
+            if (!merged) return;
+            core.setOutput("merged_pr", merged.number);
+            if (merged.head.repo.full_name !== context.payload.repository.full_name) {
+              core.setOutput("fork_merge", "true");
+            }
 
       - *logGitHubContext
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4324,17 +4324,17 @@ jobs:
       - event_types
       - versioned_source
       - release_notes
+    # release_notes is skipped on the push lane, so tolerate skipped (but not failed) needs
+    # the same way github_publish does, otherwise the skip would propagate and skip this job.
     if: |
+      !failure() && !cancelled() &&
       needs.event_types.outputs.trusted == 'true' && (
       (
-        (
-          github.event.pull_request.merged == true &&
-          inputs.disable_versioning == false
-        ) || (
-          github.event_name == 'push' &&
-          needs.event_types.outputs.push_finalize == 'true' &&
-          inputs.disable_versioning == true
-        )
+        github.event.pull_request.merged == true &&
+        inputs.disable_versioning == false
+      ) || (
+        github.event_name == 'push' &&
+        needs.event_types.outputs.push_finalize == 'true'
       )
       )
 
@@ -4356,15 +4356,30 @@ jobs:
           # contents:write permissions for managing releases
           permission-contents: write
 
+      # A merged fork PR has no draft release to promote (its pull_request lane had no secrets
+      # to publish one), so download the release artifacts to attach when the release is
+      # created below.
+      - name: Download release artifacts
+        if: github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/artifacts
+          pattern: gh-release-*
+          merge-multiple: true
+
+      # release_notes does not run on the push lane, so tolerate a missing artifact there.
       # https://github.com/actions/download-artifact
       - name: Download release notes
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}
           name: release-notes
 
+      # Promote the draft release created during an internal PR to a full release.
       # https://docs.github.com/en/rest/releases
       - name: Finalize GitHub release (if any)
+        if: github.event_name != 'push'
         env:
           <<: *gitHubCliEnvironment
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
@@ -4389,6 +4404,28 @@ jobs:
           else
             echo "No release found for the current PR"
           fi
+
+      # On the fork-merge push there is no draft to promote, so create the release for the
+      # versioned tag directly (versioned_source pushed the tag on this lane). Rich release
+      # notes reconstructed from the merged PR are tracked separately; use auto-generated
+      # notes here.
+      # https://github.com/softprops/action-gh-release
+      - name: Create GitHub release
+        if: |
+          github.event_name == 'push' &&
+          needs.event_types.outputs.fork_merge == 'true' &&
+          needs.versioned_source.outputs.tag != ''
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          name: ${{ needs.versioned_source.outputs.tag }}
+          tag_name: ${{ needs.versioned_source.outputs.tag }}
+          draft: false
+          prerelease: ${{ inputs.github_prerelease }}
+          make_latest: ${{ inputs.github_prerelease == false }}
+          generate_release_notes: true
+          files: ${{ runner.temp }}/artifacts/*
+          fail_on_unmatched_files: false
 
   ###################################################
   # rust

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -258,17 +258,6 @@
     GH_PROMPT_DISABLED: "true"
     GH_REPO: "${{ github.repository }}"
 
-  - &rejectExternalCustomActions
-    name: Reject external custom actions
-    if: |
-      github.event.pull_request.state == 'open' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      inputs.restrict_custom_actions == true
-    run: |
-      echo "::error::Custom actions are disabled for external contributors and will be skipped. \
-        Please contact a member of the organization for assistance."
-      exit 1
-
   - &logGitHubContext
     name: Log GitHub context
     env:
@@ -929,7 +918,7 @@ on:
         required: false
         default: false
       restrict_custom_actions:
-        description: "Do not execute custom actions for external contributors. Only remove this restriction if custom actions have been vetted as secure."
+        description: "Deprecated and ignored. Fork pull requests now run without secrets, so custom actions no longer need to be restricted on forks (custom test runs on forks; custom publish/finalize/always stay trusted-only). Remove this input; it will be dropped in a future release."
         type: boolean
         required: false
         default: true
@@ -1078,6 +1067,15 @@ jobs:
             if (merged.head.repo.full_name !== context.payload.repository.full_name) {
               core.setOutput("fork_merge", "true");
             }
+
+      # restrict_custom_actions is deprecated and ignored: fork custom code now runs without
+      # secrets, so the old fork restriction is unnecessary. Its old default was `true`, so any
+      # caller that set the field set it to `false` (to allow forks) — warn on `false` to reach
+      # them, since a caller that never set it reads the `true` default.
+      - name: Warn on deprecated restrict_custom_actions
+        if: inputs.restrict_custom_actions == false
+        run: |
+          echo "::warning::The 'restrict_custom_actions' input is deprecated and no longer has any effect. Fork pull requests run without secrets, so custom test actions run on forks (custom publish/finalize/always remain trusted-only). Please remove this input from your caller workflow."
 
       - *logGitHubContext
 
@@ -4681,10 +4679,15 @@ jobs:
     runs-on: ${{ matrix.os || fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - versioned_source
+    # Runs on open PRs (including forks, with no secrets) and rebuilds on the fork-merge push.
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_custom.outputs.custom_test == 'true'
 
     # The permissions for custom actions are set by the calling workflow
@@ -4698,8 +4701,6 @@ jobs:
     environment: ${{ matrix.environment }}
 
     steps:
-      - *rejectExternalCustomActions
-
       - *deploymentEnvironment
       - *decodePrivateKey
       - *getCheckoutToken
@@ -4739,7 +4740,10 @@ jobs:
     if: |
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_custom.outputs.custom_publish == 'true'
       )
 
@@ -4754,8 +4758,6 @@ jobs:
     environment: ${{ matrix.environment }}
 
     steps:
-      - *rejectExternalCustomActions
-
       - *deploymentEnvironment
       - *decodePrivateKey
       - *getCheckoutToken
@@ -4786,8 +4788,13 @@ jobs:
       - event_types
       - is_custom
       - versioned_source
+      - custom_publish
+    # On the fork-merge push custom_publish rebuilds in the same run, so wait for it (a custom
+    # publish->finalize handoff). custom_publish is skipped on internal merges and tag pushes, so
+    # tolerate skipped (but not failed) needs.
     if: |
       needs.event_types.outputs.trusted == 'true' && (
+      !failure() && !cancelled() &&
       (github.event.pull_request.merged == true || (github.event_name == 'push' && needs.event_types.outputs.push_finalize == 'true')) &&
       needs.is_custom.outputs.custom_finalize == 'true'
       )
@@ -4803,8 +4810,6 @@ jobs:
     environment: ${{ matrix.environment }}
 
     steps:
-      - *rejectExternalCustomActions
-
       - *deploymentEnvironment
       - *decodePrivateKey
       - *getCheckoutToken
@@ -4851,8 +4856,6 @@ jobs:
     # and should not be overridden by Flowzone.
 
     steps:
-      - *rejectExternalCustomActions
-
       - *decodePrivateKey
       - *getCheckoutToken
       - *checkoutVersionedCommit
@@ -4875,22 +4878,24 @@ jobs:
         os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - custom_test
       - custom_publish
       - custom_finalize
       - custom_clean
       - is_custom
       - versioned_source
+    # Runs the caller's always-action regardless of the other custom jobs' results, but not
+    # when the run is cancelled. Trusted-only: a fork has no secrets for it to act on.
     if: |
-      always() &&
+      !cancelled() &&
+      needs.event_types.outputs.trusted == 'true' &&
       needs.is_custom.outputs.custom_always == 'true'
 
     # The permissions for custom actions are set by the calling workflow
     # and should not be overridden by Flowzone.
 
     steps:
-      - *rejectExternalCustomActions
-
       - *decodePrivateKey
       - *getCheckoutToken
       - *checkoutVersionedCommit

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1128,8 +1128,13 @@ jobs:
       <<: *gitHubCliEnvironment
 
     steps:
-      - *decodePrivateKey
+      # The app token is only generated on trusted lanes. A fork pull_request has no app key,
+      # so these steps skip and versioned_source falls back to github.token for checkout and
+      # skips versioning/ref-writes (git_describe still supplies the output SHA).
+      - <<: *decodePrivateKey
+        if: inputs.app_id && needs.event_types.outputs.trusted == 'true'
       - <<: *getGitHubAppToken
+        if: inputs.app_id && needs.event_types.outputs.trusted == 'true'
         with:
           <<: *getGitHubAppTokenWith
           # contents: write is required to push git commit and tag references
@@ -1162,7 +1167,7 @@ jobs:
 
       - name: Check for legacy branch protection
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        if: inputs.app_id && inputs.disable_versioning != true && github.event.pull_request.state == 'open'
+        if: inputs.app_id && inputs.disable_versioning != true && github.event.pull_request.state == 'open' && needs.event_types.outputs.trusted == 'true'
         with:
           github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           script: |
@@ -1185,7 +1190,7 @@ jobs:
               "See: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets");
 
       - <<: *getCheckoutToken
-        if: inputs.app_id && steps.has_submodules.outputs.result == 'true'
+        if: inputs.app_id && steps.has_submodules.outputs.result == 'true' && needs.event_types.outputs.trusted == 'true'
 
       # Checkout the tip of the pull request branch for open PRs.
       # The default behaviour for GitHub Actions is to checkout the merge commit but we
@@ -1245,6 +1250,8 @@ jobs:
       - *setupNode
 
       - name: Install versioning tools
+        # Runs on fork PRs too (no trusted gate) so versionist can validate commit footers
+        # on the untrusted lane; the blob/tree/commit/tag writes below stay trusted-only.
         if: inputs.disable_versioning != true
         run: |
           npm install -g \
@@ -1257,7 +1264,8 @@ jobs:
       - name: Generate changelog
         if: inputs.disable_versioning != true
         env:
-          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          # Fork PRs have no app token; fall back to the read-only github.token to read history.
+          GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         run: |
           if [ ! -f .versionbot/CHANGELOG.yml ]
           then
@@ -1267,11 +1275,15 @@ jobs:
       # https://github.com/actions/github-script
       - name: Run balena-versionist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        # Runs on fork PRs too so a missing or invalid Change-type footer fails the PR check
+        # before merge (matching internal PRs), instead of only surfacing on the post-merge
+        # push lane. The blob/tree/commit/tag writes below stay trusted-only.
         if: inputs.disable_versioning != true
         id: versionist
         env:
-          # Use to authenticate with GitHub for private nested changelogs
-          GITHUB_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          # Authenticates for private nested changelogs. Fork PRs fall back to the read-only
+          # github.token (no app token on the untrusted lane).
+          GITHUB_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
         with:
           result-encoding: json
           script: |
@@ -1298,7 +1310,7 @@ jobs:
       # https://octokit.github.io/rest.js/v21/#git-create-blob
       # https://octokit.github.io/rest.js/v21/#git-create-tree
       - name: Create blobs and tree objects
-        if: inputs.disable_versioning != true
+        if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_tree
         env:
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
@@ -1360,7 +1372,7 @@ jobs:
       # https://octokit.github.io/rest.js/v21/#git-create-commit
       # https://docs.github.com/en/rest/git/commits#create-a-commit
       - name: Create commit object
-        if: inputs.disable_versioning != true
+        if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_commit
         env:
           MESSAGE: ${{ steps.versionist.outputs.tag }}
@@ -1384,7 +1396,7 @@ jobs:
 
       # create a new tag object
       - <<: *createTagObject
-        if: inputs.disable_versioning != true
+        if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           TAG: ${{ steps.versionist.outputs.tag }}
@@ -1395,7 +1407,8 @@ jobs:
       - <<: *updateGitReference
         if: |
           github.event.pull_request.merged &&
-          steps.create_commit.outputs.sha
+          steps.create_commit.outputs.sha &&
+          needs.event_types.outputs.trusted == 'true'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           REF: "heads/${{ github.base_ref }}"
@@ -1405,7 +1418,8 @@ jobs:
       - <<: *createGitReference
         if: |
           github.event.pull_request.merged &&
-          steps.create_tag.outputs.sha
+          steps.create_tag.outputs.sha &&
+          needs.event_types.outputs.trusted == 'true'
         env:
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
           REF: "refs/tags/${{ steps.versionist.outputs.tag }}"
@@ -1416,14 +1430,17 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
     # Only generate release notes on pull_request events, and only if versioning is enabled.
     # Skip pull_request closed events, but allow pull_request merged events.
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       inputs.disable_versioning != true &&
       (
         github.event.pull_request.state == 'open' ||
         github.event.pull_request.merged == true
+      )
       )
 
     <<: *rootWorkingDirectory
@@ -1609,13 +1626,16 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - release_notes
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       inputs.release_notes == true &&
       (
         github.event.action != 'closed' ||
         github.event.pull_request.merged == true
+      )
       )
 
     <<: *rootWorkingDirectory
@@ -1828,6 +1848,9 @@ jobs:
       # https://github.com/github/codeql-action/issues/2654
       - name: Upload SARIF file to GitHub
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        # Only trusted lanes have a token with security-events: write; forks still scan
+        # (Run octoscan above) but skip the upload.
+        if: needs.event_types.outputs.trusted == 'true'
         # For now let's just continue on error as this is not a critical path
         continue-on-error: true
         env:
@@ -3094,10 +3117,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     continue-on-error: true
     needs:
+      - event_types
       - is_npm
       - npm_test
       - versioned_source
-    if: ${{ needs.is_npm.outputs.npm == 'true' && needs.is_npm.outputs.npm_sbom == 'true' }}
+    if: ${{ needs.event_types.outputs.trusted == 'true' && ( needs.is_npm.outputs.npm == 'true' && needs.is_npm.outputs.npm_sbom == 'true' ) }}
 
     <<: *customWorkingDirectory
 
@@ -3140,6 +3164,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
       - npm_test
       - custom_test
@@ -3148,9 +3173,11 @@ jobs:
       - python_test
     # allow some dependencies to be skipped
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.npm_test.result == 'success' &&
       needs.is_npm.outputs.npm_private != 'true'
+      )
 
     <<: *rootWorkingDirectory
 
@@ -3204,11 +3231,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_npm.outputs.npm == 'true' &&
       needs.is_npm.outputs.npm_private != 'true'
+      )
 
     <<: *rootWorkingDirectory
 
@@ -3260,10 +3290,13 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_npm.outputs.npm_docs == 'true'
+      )
 
     <<: *rootWorkingDirectory
 
@@ -3501,6 +3534,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - is_docker
       - npm_test
@@ -3510,9 +3544,11 @@ jobs:
       - python_test
     # allow some dependencies to be skipped
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.docker_test.result == 'success' &&
       needs.is_docker.outputs.docker_publish_matrix != ''
+      )
 
     <<: *rootWorkingDirectory
 
@@ -3639,11 +3675,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_docker
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_docker.outputs.docker_publish_matrix != ''
+      )
 
     <<: *rootWorkingDirectory
 
@@ -3709,6 +3748,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_balena
       - npm_test
       - custom_test
@@ -3719,9 +3759,11 @@ jobs:
       - release_notes
     # allow some dependencies to be skipped
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
       (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      )
 
     strategy:
       fail-fast: false
@@ -3866,10 +3908,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     continue-on-error: true
     needs:
+      - event_types
       - is_python
       - python_test
       - versioned_source
-    if: needs.is_python.outputs.python_poetry == 'true' && needs.is_python.outputs.python_sbom == 'true'
+    if: needs.event_types.outputs.trusted == 'true' && ( needs.is_python.outputs.python_poetry == 'true' && needs.is_python.outputs.python_sbom == 'true' )
 
     <<: *customWorkingDirectory
 
@@ -3919,6 +3962,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_python
       - npm_test
       - custom_test
@@ -3928,10 +3972,12 @@ jobs:
       - versioned_source
     # allow some dependencies to be skipped
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.python_test.result == 'success' &&
       needs.is_python.outputs.python_poetry == 'true' &&
       needs.is_python.outputs.pypi_publish == 'true'
+      )
 
     <<: *customWorkingDirectory
 
@@ -3969,12 +4015,15 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_python
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_python.outputs.python_poetry == 'true' &&
       needs.is_python.outputs.pypi_publish == 'true'
+      )
 
     <<: *customWorkingDirectory
 
@@ -4011,6 +4060,7 @@ jobs:
     env:
       CF_BRANCH: ${{ github.event.pull_request.head.ref || github.event.repository.default_branch }}
     needs:
+      - event_types
       - file_list
       - is_npm
       - npm_test
@@ -4022,9 +4072,11 @@ jobs:
     # allow some dependencies to be skipped
     # skip unmerged closed PRs, allow all other events
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() && needs.versioned_source.result == 'success' &&
       inputs.cloudflare_website != '' &&
       (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      )
 
     permissions:
       contents: read # Checkout versioned source
@@ -4118,8 +4170,10 @@ jobs:
     needs:
       - event_types
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       github.event.action == 'closed' &&
       github.event.pull_request.merged == false
+      )
 
     <<: *rootWorkingDirectory
 
@@ -4140,6 +4194,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - release_notes
       - npm_publish
@@ -4151,9 +4206,11 @@ jobs:
       - cargo_sbom
     # allow some dependencies to be skipped
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       github.event.pull_request.state == 'open' &&
       needs.versioned_source.outputs.tag != ''
+      )
 
     <<: *rootWorkingDirectory
 
@@ -4209,9 +4266,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - versioned_source
       - release_notes
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (
         (
           github.event.pull_request.merged == true &&
@@ -4220,6 +4279,7 @@ jobs:
           github.event_name == 'push' &&
           inputs.disable_versioning == true
         )
+      )
       )
 
     <<: *rootWorkingDirectory
@@ -4368,10 +4428,11 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     continue-on-error: true
     needs:
+      - event_types
       - is_cargo
       - cargo_test
       - versioned_source
-    if: needs.is_cargo.outputs.cargo == 'true' && needs.is_cargo.outputs.cargo_sbom == 'true'
+    if: needs.event_types.outputs.trusted == 'true' && ( needs.is_cargo.outputs.cargo == 'true' && needs.is_cargo.outputs.cargo_sbom == 'true' )
 
     <<: *customWorkingDirectory
 
@@ -4483,11 +4544,14 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cargo
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_cargo.outputs.cargo == 'true'
+      )
 
     <<: *customWorkingDirectory
 
@@ -4572,6 +4636,7 @@ jobs:
     runs-on: ${{ matrix.os || fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - npm_test
       - custom_test
@@ -4581,9 +4646,11 @@ jobs:
       - versioned_source
     # allow some dependencies to be skipped
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       github.event.pull_request.state == 'open' &&
       needs.is_custom.outputs.custom_publish == 'true'
+      )
 
     # The permissions for custom actions are set by the calling workflow
     # and should not be overridden by Flowzone.
@@ -4630,11 +4697,14 @@ jobs:
     runs-on: ${{ matrix.os || fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_custom.outputs.custom_finalize == 'true'
+      )
 
     # The permissions for custom actions are set by the calling workflow
     # and should not be overridden by Flowzone.
@@ -4686,12 +4756,15 @@ jobs:
         os: ${{ fromJSON(inputs.custom_runs_on || format('[{0}]', inputs.runs_on)) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_custom
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       github.event.action == 'closed' &&
       github.event.pull_request.merged == false &&
       needs.is_custom.outputs.custom_clean == 'true'
+      )
 
     # The permissions for custom actions are set by the calling workflow
     # and should not be overridden by Flowzone.
@@ -4774,13 +4847,16 @@ jobs:
         include: ${{ fromJSON(needs.is_cloudformation.outputs.includes) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cloudformation
       - versioned_source
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       github.event.pull_request.state == 'open' &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'
+      )
 
     <<: *customWorkingDirectory
 
@@ -5036,12 +5112,15 @@ jobs:
         include: ${{ fromJSON(needs.is_cloudformation.outputs.includes) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cloudformation
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       (github.event.pull_request.merged == true || github.event_name == 'push') &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'
+      )
 
     env:
       # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html#cli-usage-retries-modes-adaptive
@@ -5172,13 +5251,16 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - all_jobs
     if: |
+      needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.all_jobs.result == 'success' &&
       github.event.pull_request.state == 'open' &&
       inputs.toggle_auto_merge == true &&
       github.event.pull_request.user.type != 'Bot'
+      )
 
     permissions: {}
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -52,7 +52,7 @@
     run: |
       package="$(poetry version --no-ansi | awk '{print $1}')"
       version="$(poetry version --no-ansi | awk '{print $2}')"
-      commit_sha="$(echo ${{ github.event.pull_request.head.sha }} | tr "a-z" "A-Z")"
+      commit_sha="$(echo ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | tr "a-z" "A-Z")"
       decimal_sha="$(echo "ibase=16; $commit_sha" | bc)"
       version_tag="${version}-dev${decimal_sha}"
 
@@ -424,8 +424,8 @@
         type=raw,value=latest
         type=raw,value=latest,prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
         type=raw,value=${{ github.base_ref || github.ref_name }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
-        type=raw,value=${{ github.event.pull_request.head.sha }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
-        type=raw,value=build-${{ github.event.pull_request.head.sha }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
+        type=raw,value=${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
+        type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
         type=raw,value=build-${{ github.event.pull_request.head.ref }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
       flavor: |
         latest=false
@@ -438,7 +438,7 @@
         ${{ matrix.image }}
       labels: *dockerMetaLabels
       tags: |
-        type=raw,value=build-${{ github.event.pull_request.head.sha }}
+        type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         type=raw,value=build-${{ github.event.pull_request.head.ref }}
       flavor: |
         latest=false
@@ -3072,8 +3072,8 @@ jobs:
           package="$(jq -r '.name' package.json)"
           version="$(jq -r '.version' package.json)"
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
+          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -3133,7 +3133,7 @@ jobs:
         if: needs.is_npm.outputs.npm_private != 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: npm-${{ github.event.pull_request.head.sha }}
+          name: npm-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}/npm-pack/*.tgz
           retention-days: 90
 
@@ -3151,7 +3151,7 @@ jobs:
         if: needs.is_npm.outputs.npm_docs == 'true' && needs.is_npm.outputs.max_node_version == matrix.node_version
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: docs-${{ github.event.pull_request.head.sha }}
+          name: docs-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
           path: ${{ runner.temp }}/docs.tar.zst
           retention-days: 90
 
@@ -3234,7 +3234,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}
-          name: npm-${{ github.event.pull_request.head.sha }}
+          name: npm-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
 
       - <<: *setupNode
         with:
@@ -3918,8 +3918,8 @@ jobs:
           package=$(grep '^name =' pyproject.toml | sed 's/name = "\(.*\)"/\1/')
           version=$(grep '^version =' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
+          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -4456,8 +4456,8 @@ jobs:
           packages="$(cargo metadata --no-deps --format-version 1 | jq -c '[.packages[] | .targets[] | select(.kind[] == "bin") | .name]')"
           version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo "${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha }}"
+          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
 
           {
             echo "packages=${packages}" ;

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -5110,7 +5110,13 @@ jobs:
       - *rejectCancelledJobs
 
   all_jobs:
-    name: All jobs
+    # Keep the required check context "All jobs" on the pull_request (and push) lanes so
+    # existing branch-protection rulesets keep matching. On pull_request_target emit a
+    # different, non-required context: defense-in-depth so that even if a caller misconfigures
+    # its routing and fires flowzone on both events for one PR, the (rejected) p_r_t run can
+    # neither block a valid PR nor satisfy the gate. The trusted pull_request lane is the sole
+    # producer of "All jobs".
+    name: All jobs${{ github.event_name == 'pull_request_target' && ' (pull_request_target)' || '' }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     permissions: {}

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -426,7 +426,7 @@
         type=raw,value=${{ github.base_ref || github.ref_name }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
         type=raw,value=${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
         type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
-        type=raw,value=build-${{ github.event.pull_request.head.ref }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
+        type=raw,value=build-${{ github.event.pull_request.head.ref || github.ref_name }},prefix=${{ steps.strings.outputs.prefix }},suffix=${{ steps.strings.outputs.suffix }}
       flavor: |
         latest=false
 
@@ -439,7 +439,7 @@
       labels: *dockerMetaLabels
       tags: |
         type=raw,value=build-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
-        type=raw,value=build-${{ github.event.pull_request.head.ref }}
+        type=raw,value=build-${{ github.event.pull_request.head.ref || github.ref_name }}
       flavor: |
         latest=false
         prefix=${{ steps.strings.outputs.prefix }}
@@ -3022,10 +3022,16 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_npm
       - versioned_source
+    # Runs on open PRs (build/test) and on the fork-merge push (rebuild from the merged
+    # commit, since the fork's no-secrets PR run produced no trusted artifact to promote).
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_npm.outputs.npm == 'true'
 
     <<: *customWorkingDirectory
@@ -3218,6 +3224,7 @@ jobs:
     if: |
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
+      github.event.pull_request.state == 'open' &&
       needs.npm_test.result == 'success' &&
       needs.is_npm.outputs.npm_private != 'true'
       )
@@ -3389,10 +3396,15 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_docker
       - versioned_source
+    # Runs on open PRs and on the fork-merge push (rebuild from the merged commit).
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_docker.outputs.docker_bake_json != ''
 
     <<: *customWorkingDirectory
@@ -4387,10 +4399,15 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ fromJSON(inputs.jobs_timeout_minutes) }}
     needs:
+      - event_types
       - is_cargo
       - versioned_source
+    # Runs on open PRs and on the fork-merge push (rebuild from the merged commit).
     if: |
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_cargo.outputs.cargo == 'true'
 
     <<: *customWorkingDirectory
@@ -4896,7 +4913,10 @@ jobs:
       - versioned_source
     if: |
       needs.event_types.outputs.trusted == 'true' && (
-      github.event.pull_request.state == 'open' &&
+      (
+        github.event.pull_request.state == 'open' ||
+        (github.event_name == 'push' && needs.event_types.outputs.fork_merge == 'true')
+      ) &&
       needs.is_cloudformation.outputs.cloudformation == 'true' &&
       needs.is_cloudformation.outputs.stacks != '' &&
       needs.is_cloudformation.outputs.stacks != '[]'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "node build",
     "test": "npm run build && git diff --exit-code ./.github/workflows/flowzone.yml ./README.md",
-    "lint": "docker run --rm -v $(pwd):/repo --workdir /repo rhysd/actionlint:1.7.1 -color -ignore=:info: -ignore=:style:",
+    "lint": "if command -v actionlint >/dev/null 2>&1; then actionlint -color -ignore=:info: -ignore=:style:; else echo 'actionlint not installed'; fi",
     "prepare": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "repository": {

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-if [ "${REPO_SECRET}" != "topsecret" ]
+# Fork PRs run with no secrets, so REPO_SECRET (from the COMPOSE_VARS secret) is empty.
+# Only assert its value when it was provided (i.e. the trusted lane); skip on forks.
+if [ -z "${REPO_SECRET}" ]
+then
+	echo "REPO_SECRET is empty (fork PR without secrets); skipping assertion"
+elif [ "${REPO_SECRET}" != "topsecret" ]
 then
 	echo "REPO_SECRET value is incorrect"
 	exit 1


### PR DESCRIPTION
Reworks how Flowzone handles external contributions so **fork PRs never run with secrets**, replacing the `pull_request_target` + review-gate "pwn request" pattern where untrusted fork code ran in the base repo's trusted context.

Design and rationale: [`docs/trust-boundary.md`](./docs/trust-boundary.md)

See: https://github.com/product-os/flowzone/issues/1855
See: https://balena.fibery.io/Work/Project/1398

## Manual testing

Validated the full fork lifecycle on a throwaway repo pinning this branch, forked to a personal account and driven through a real fork PR → merge:

- [x] **Fork PR (no secrets)**: builds and tests; publish/finalize jobs skip; `All jobs` is green. Forks never receive secrets and can't publish.
- [x] **Fork merge → Docker**: the push lane rebuilds from the merged commit and publishes to ghcr (`build-<sha>` + retag to the branch tag) — same-run rebuild, never the fork's uploaded artifact.
- [x] **Fork merge → versioning/release**: cuts the version tag + GitHub release, and the app token writes the versioned commit to the protected default branch as `vX.Y.Z [skip ci]`. Confirmed no recursive run fires for that commit — the `[skip ci]` guard holds.
- [x] **Fork PR footer validation**: a fork PR missing a `Change-type` footer now fails `versioned_source` at PR time ("No commits were annotated with a change type"), instead of only failing after merge. Writes stay trusted-only, so nothing is pushed from the fork.
- [x] **Direct push (no PR)**: quiet skip — no publish or finalize.
- [x] **Caller permissions**: a caller missing `pull-requests: read` / `packages: write` fails the reusable-workflow call at startup, confirming the usage snippet's permission block is required.

## Release Notes

### Model

- **Fork PRs** run on `pull_request` with no secrets — build and test only. No approval gate, no `pull_request_target`.
- **Fork publishing** moves to the `push` on the default branch after merge, rebuilt from the merged (trusted) commit — never the fork's uploaded bytes.
- **Internal PRs** are unchanged (secrets on `pull_request`, draft on open, finalize on merge).

The lane is decided in `event_types` and gated per job via `trusted` / `fork_merge` / `push_finalize` outputs. `pull_request_target` is rejected at the gate; its `all_jobs` uses a per-event, non-required check name so a misconfigured caller can't game the required check.

### Breaking changes

- **Fork testing** requires a caller change. The previous caller snippet routed fork PRs to
  `pull_request_target` with an `if:` condition, so a fork's `pull_request` invocation was
  filtered out. Flowzone no longer runs on `pull_request_target`, so callers must adopt the new
  [usage](../README.md#usage) snippet — removing the `pull_request_target` trigger and its
  routing `if:` — to send fork PRs to the no-secrets `pull_request` lane.
- **Fork publishing** additionally requires the `push` trigger on the default branch.
- **Internal PRs** are unchanged. A caller that keeps the old `pull_request` +
  `pull_request_target` wiring keeps working for internal PRs: the `pull_request_target`
  invocation is filtered out by the caller `if:` (and if it does run, Flowzone rejects it and
  its `all_jobs` is the non-required per-event context, so it never gates). Removing the dead
  trigger is otherwise a mechanical follow-up.
- **Caller permissions.** Most callers need no permission change. A caller that explicitly pins
  a restrictive `permissions:` block must include `pull-requests: read` — `event_types`
  declares it for the push-merge PR lookup, and a reusable-workflow call fails at startup if the
  caller granted less. Callers that do not pin the permission inherit enough by default.
