### PR TITLE
Do not require pull-requests: read from callers

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -278,8 +278,6 @@ jobs:
         include:
           - event_name: ${{ github.event_name }}
             event_action: ${{ github.event.action }}
-    permissions:
-      pull-requests: read
     steps:
       - name: Reject pull_request_target events
         if: github.event_name == 'pull_request_target'
@@ -296,16 +294,38 @@ jobs:
             false
           fi
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Decode private key
+        if: inputs.app_id && github.event_name == 'push'
+        id: decode
+        uses: product-os/decode-private-key@e51369845773d30f258072c37a0086b3b46c0b4f
+        with:
+          secret: ${{ secrets.FLOWZONE_APP_PRIVATE_KEY || secrets.GH_APP_PRIVATE_KEY }}
+      - name: Generate GitHub App installation token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        if: inputs.app_id && github.event_name == 'push'
+        id: gh_app_token
+        with:
+          client-id: ${{ inputs.app_id }}
+          private-key: ${{ steps.decode.outputs.private-key }}
+          permission-metadata: read
+          permission-pull-requests: read
       - name: Classify push merge
         id: push_class
         if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           script: |
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              ...context.repo,
-              commit_sha: context.sha,
-            });
+            let prs;
+            try {
+              ({ data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                ...context.repo,
+                commit_sha: context.sha,
+              }));
+            } catch (e) {
+              core.warning(`Could not look up the PR for this push (needs 'pull-requests: read'): ${e.message}. Fork-merge publishing will be skipped.`);
+              return;
+            }
             const merged = prs.find((pr) => pr.merged_at != null);
             if (!merged) return;
             core.setOutput("merged_pr", merged.number);

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,10 @@ permissions:
   # packages: read
   packages: write # Allow Flowzone to publish to ghcr.io
   pages: none
-  # Flowzone's event_types classifies the PR a push merged ("Classify push merge"); the
-  # reusable workflow declares pull-requests: read, so the caller must grant it or the call
-  # fails at startup.
-  pull-requests: read
+  # Deliberately none: on the push lane flowzone mints an ephemeral app token for the fork-merge
+  # PR lookup, so the caller's GITHUB_TOKEN does not need pull-requests. Keeping this at none
+  # exercises that path — proving callers need not grant pull-requests: read.
+  pull-requests: none
   repository-projects: none
   security-events: none
   statuses: none

--- a/docs/trust-boundary.md
+++ b/docs/trust-boundary.md
@@ -73,10 +73,14 @@ consume its `custom_publish` output (the action bodies are caller-defined).
   invocation is filtered out by the caller `if:` (and if it does run, Flowzone rejects it and
   its `all_jobs` is the non-required per-event context, so it never gates). Removing the dead
   trigger is otherwise a mechanical follow-up.
-- **Caller permissions.** Most callers need no permission change. A caller that explicitly pins
-  a restrictive `permissions:` block must include `pull-requests: read` — `event_types`
-  declares it for the push-merge PR lookup, and a reusable-workflow call fails at startup if the
-  caller granted less. Callers that do not pin the permission inherit enough by default.
+- **Caller permissions.** No permission change is required. Flowzone declares no `GITHUB_TOKEN`
+  permissions the caller must grant, so it never fails the reusable-workflow permissions subset
+  check at startup. The push-lane `Classify push merge` lookup needs `pull-requests: read`, but
+  it mints an ephemeral Flowzone **app token** for it (scoped `pull-requests: read`) when
+  `app_id` is configured — so fork publishing works without the caller granting anything. If the
+  app is not configured it falls back to `FLOWZONE_TOKEN`, then `github.token`; if that last
+  fallback lacks the scope, fork-merge detection is skipped (a warning is logged) and everything
+  else is unaffected.
 - **`restrict_custom_actions` is deprecated.** It only existed to keep fork custom code out of
   the trusted `pull_request_target` context; forks now run without secrets, so it has no effect.
   `custom_test` runs on forks; `custom_publish`/`custom_finalize`/`custom_always` are

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1035,10 +1035,10 @@ jobs:
           - event_name: ${{ github.event_name }}
             event_action: ${{ github.event.action }}
 
-    permissions:
-      # Read-only PR lookup for `Classify push merge` below (uses github.token on the push lane).
-      pull-requests: read
-
+    # No job-level permissions block: declaring pull-requests: read here made the reusable
+    # workflow require it of every caller, and callers whose org default omits it fail the
+    # permissions subset check at startup. event_types instead inherits the caller's token; the
+    # push-lane PR lookup below tolerates the scope being absent.
     steps:
       - *rejectPullRequestTarget
       # Fork pull_request runs receive no secrets by design, so only require them on
@@ -1048,6 +1048,19 @@ jobs:
           github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository
 
+      # The push-lane PR lookup below needs pull-requests: read. Rather than require that of the
+      # caller's GITHUB_TOKEN (which broke callers whose org default omits it), mint an ephemeral
+      # app token here — a push is trusted, so app_id and the app key are available. When app_id
+      # is unset the lookup falls back to FLOWZONE_TOKEN then github.token; when app_id is set a
+      # token-generation failure fails the job loudly (it is a real app-config error).
+      - <<: *decodePrivateKey
+        if: inputs.app_id && github.event_name == 'push'
+      - <<: *getGitHubAppToken
+        if: inputs.app_id && github.event_name == 'push'
+        with:
+          <<: *getGitHubAppTokenWith
+          permission-pull-requests: read
+
       # On a push to the default branch, find the PR (if any) this commit merged so downstream
       # jobs can distinguish a fork merge (publish here) from an internal merge (already
       # finalized on its pull_request lane) or a direct push (no PR -> skip).
@@ -1056,11 +1069,21 @@ jobs:
         if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
+          # Prefer the ephemeral app token (carries pull-requests: read regardless of the caller
+          # default); a denied lookup is tolerated below so a missing scope skips fork-merge
+          # detection rather than failing the run.
+          github-token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           script: |
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              ...context.repo,
-              commit_sha: context.sha,
-            });
+            let prs;
+            try {
+              ({ data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                ...context.repo,
+                commit_sha: context.sha,
+              }));
+            } catch (e) {
+              core.warning(`Could not look up the PR for this push (needs 'pull-requests: read'): ${e.message}. Fork-merge publishing will be skipped.`);
+              return;
+            }
             const merged = prs.find((pr) => pr.merged_at != null);
             if (!merged) return;
             core.setOutput("merged_pr", merged.number);


### PR DESCRIPTION
`event_types` declared a job-level permissions block with `pull-requests: read`, which made the reusable workflow require that scope of every caller. Callers whose org default GITHUB_TOKEN omits pull-requests fail the permissions subset check at startup, breaking all of their Flowzone runs.

Drop the permissions block so event_types inherits the caller's token. The push-lane fork-merge PR lookup still needs pull-requests: read, so mint an ephemeral Flowzone app token scoped to it.
A push is trusted, so `app_id` and the app key are available.

Change-type: patch