### PR TITLE
Stop describing the push trigger as optional

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -609,7 +609,10 @@ jobs:
         if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_commit
         env:
-          MESSAGE: ${{ steps.versionist.outputs.tag }} [skip ci]
+          MESSAGE: |-
+            ${{ steps.versionist.outputs.tag }}
+
+            [skip ci]
           TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3

--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ on:
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  # Fork contributions publish on the push to the default branch after merge, rebuilt from the
-  # merged commit (see "External Contributions" in the README). Drop this trigger to keep fork
-  # support test-only. Internal PRs do not need it.
+  # Fork contributions are rebuilt and published from the push to the default
+  # branch after merge.
   push:
     branches: [main, master]
 

--- a/build.js
+++ b/build.js
@@ -41,9 +41,8 @@ on:
   pull_request:
     types: [opened, synchronize, closed]
     branches: [main, master]
-  # Fork contributions publish on the push to the default branch after merge, rebuilt from the
-  # merged commit (see "External Contributions" in the README). Drop this trigger to keep fork
-  # support test-only. Internal PRs do not need it.
+  # Fork contributions are rebuilt and published from the push to the default
+  # branch after merge.
   push:
     branches: [main, master]
 

--- a/docs/trust-boundary.md
+++ b/docs/trust-boundary.md
@@ -92,7 +92,8 @@ consume its `custom_publish` output (the action bodies are caller-defined).
 - Fork PRs cannot run steps that need secrets (private submodules, `COMPOSE_VARS`-backed compose
   tests) during review; the trusted merge lane rebuilds them with credentials.
 - Fork publish-path bugs surface at merge, not during review, because forks cannot draft-publish.
-- Repos that never add the `push` trigger get fork test-only.
+- A repo without the `push` trigger gets fork test-only, and will need it once internal
+  branches move onto the push lane.
 - `push`-merge runs share the default-branch concurrency group with `cancel-in-progress: false`;
   GitHub keeps one pending run per group, so stacked merges can drop a pending publish. Re-run the
   workflow for the affected merge commit.

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1391,7 +1391,9 @@ jobs:
           # (unlike github.token) does re-trigger workflows. GitHub skips a push run whose HEAD
           # commit message contains a skip directive, so the redundant run never starts. This
           # does not affect the current run's publish/finalize (those run from the merge commit).
-          MESSAGE: ${{ steps.versionist.outputs.tag }} [skip ci]
+          # The blank line keeps it out of the commit subject: git folds the whole first
+          # paragraph into %s, so a single newline would still show up in `git log --oneline`.
+          MESSAGE: "${{ steps.versionist.outputs.tag }}\n\n[skip ci]"
           TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9


### PR DESCRIPTION
Replaced with a description of what the trigger is for, and nothing about whether it's needed:

```yaml
  # Fork contributions are rebuilt and published from the push to the default
  # branch after merge.
  push:
    branches: [main, master]
```

The matching "Accepted limitations" bullet in `docs/trust-boundary.md` now notes the trigger will be needed, rather than framing its absence as a settled choice.

---

Also keep 'skip ci' out of the version commit subject