### PR TITLE
Stop suppressing every workflow on the version commit

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -270,7 +270,9 @@ jobs:
         github.event_name == 'push' && (
           startsWith(github.ref, 'refs/tags/') ||
           github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        )
+        ) &&
+        github.event.sender.login != 'flowzone-app[bot]' &&
+        !contains(github.event.head_commit.message, 'Flowzone-version-commit:')
       )
     strategy:
       fail-fast: true
@@ -612,7 +614,7 @@ jobs:
           MESSAGE: |-
             ${{ steps.versionist.outputs.tag }}
 
-            [skip ci]
+            Flowzone-version-commit: true
           TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3

--- a/docs/trust-boundary.md
+++ b/docs/trust-boundary.md
@@ -25,6 +25,7 @@ event, not by review.
 | `push` | default branch, **fork merge** | **Rebuild + publish + finalize** from the merged (trusted) commit. Where fork contributions publish. |
 | `push` | default branch, internal merge | Quiet skip — already finalized on the internal PR's `pull_request` lane. |
 | `push` | tags / direct | Trusted release path. **Unchanged.** |
+| `push` | **Flowzone itself** | **Vetoed** at the event gate — see [Not re-triggering itself](#not-re-triggering-itself). |
 | `pull_request_target` | any | **Rejected** at the event gate. |
 
 The lane is decided in the `event_types` job and exported as outputs the rest of the workflow
@@ -37,6 +38,36 @@ gates on:
   (`GET /repos/{}/commits/{sha}/pulls`).
 - `push_finalize` — `true` for tag pushes and fork merges; gates the finalize path on `push`.
   Internal merges and direct pushes are `false` (no double-publish).
+
+## Not re-triggering itself
+
+Adding the `push` trigger means Flowzone reacts to pushes it makes itself. `versioned_source`
+pushes the versioned commit with the GitHub App token, and unlike `github.token`, an App token
+**does** re-trigger workflows — so the versioned commit re-enters the pipeline.
+
+That run cannot loop: it merged no PR, so `fork_merge` and `push_finalize` are both `false`, the
+test jobs skip, and no git ref is written again. It is not harmless, though. The jobs whose `if:`
+carries no push-lane gate beyond `trusted == 'true'` — `balena_publish`, `website_publish`, and a
+caller's `custom_always` — would run a second time, so a release that already published would
+push another balena release and redeploy the Cloudflare Pages site. `versioned_source` would also
+re-run versionist and leave orphan commit and tag objects behind.
+
+The `event_types` job's `if:` vetoes it. Every other job has `event_types` in its `needs`
+(directly or transitively), so skipping there skips the whole workflow — one place to veto a run.
+Two independent signals, because either can be absent:
+
+- `github.event.sender.login != 'flowzone-app[bot]'` — any push made by the App, including
+  auto-merge. Does not cover the legacy `FLOWZONE_TOKEN` (PAT) path, where the pusher is a human
+  account whose login Flowzone cannot know.
+- `!contains(github.event.head_commit.message, 'Flowzone-version-commit:')` — the trailer
+  `versioned_source` writes into the versioned commit, so the veto holds whichever credential
+  pushed it.
+
+This is deliberately **not** a `[skip ci]` commit directive. GitHub honours skip directives for
+every workflow in the repository, not just Flowzone, so vetoing that way also suppressed
+downstream pipelines that key deployments off pushes to the default branch (balena-os). A private
+trailer that only Flowzone reads keeps the veto scoped to Flowzone and leaves other consumers of
+the push running.
 
 ## Why a fork merge rebuilds
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1011,6 +1011,19 @@ jobs:
       merged_pr: ${{ steps.push_class.outputs.merged_pr }}
       fork_merge: ${{ steps.push_class.outputs.fork_merge == 'true' }}
       push_finalize: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || steps.push_class.outputs.fork_merge == 'true' }}
+    # Every other job has event_types in its needs (directly or transitively), so skipping here
+    # skips the whole workflow. That makes this the single place to veto a run.
+    #
+    # The push lane excludes Flowzone's own pushes. The versioned commit is pushed with the app
+    # token, which (unlike github.token) does re-trigger workflows, so it re-enters the pipeline.
+    # That run cannot loop (no merged PR -> fork_merge and push_finalize are false), but the jobs
+    # with no push-lane gate beyond `trusted` (balena_publish, website_publish, custom_always)
+    # would publish a second time. Two independent signals, because either can be absent:
+    #   - sender.login  — catches any push made by the app (versioned commit, auto-merge), but
+    #                     not the legacy FLOWZONE_TOKEN (PAT) path, where the pusher is a human.
+    #   - commit trailer — catches the versioned commit regardless of which credential pushed it.
+    # Vetoing here (rather than with a `[skip ci]` commit directive) keeps the veto scoped to
+    # Flowzone, so pipelines that deploy on pushes to the default branch still fire.
     if: |
       (
         (
@@ -1025,7 +1038,9 @@ jobs:
         github.event_name == 'push' && (
           startsWith(github.ref, 'refs/tags/') ||
           github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        )
+        ) &&
+        github.event.sender.login != 'flowzone-app[bot]' &&
+        !contains(github.event.head_commit.message, 'Flowzone-version-commit:')
       )
 
     strategy:
@@ -1386,14 +1401,19 @@ jobs:
         if: inputs.disable_versioning != true && needs.event_types.outputs.trusted == 'true'
         id: create_commit
         env:
-          # [skip ci] avoids recursion: this versioned commit becomes the default-branch HEAD
-          # when updateGitReference pushes it, and that push is made with the app token, which
-          # (unlike github.token) does re-trigger workflows. GitHub skips a push run whose HEAD
-          # commit message contains a skip directive, so the redundant run never starts. This
-          # does not affect the current run's publish/finalize (those run from the merge commit).
+          # This versioned commit becomes the default-branch HEAD when updateGitReference pushes
+          # it, and that push is made with the app token, which (unlike github.token) does
+          # re-trigger workflows. The `Flowzone-version-commit` trailer marks the commit so that
+          # Flowzone's own event gate can skip the redundant push run (see event_types).
+          #
+          # Deliberately NOT a GitHub `[skip ci]` directive: a skip directive suppresses *every*
+          # workflow for that push, not just Flowzone, which broke downstream pipelines that key
+          # deployments off pushes to the default branch (balena-os). A private trailer that only
+          # Flowzone reads leaves other consumers of the push untouched.
+          #
           # The blank line keeps it out of the commit subject: git folds the whole first
           # paragraph into %s, so a single newline would still show up in `git log --oneline`.
-          MESSAGE: "${{ steps.versionist.outputs.tag }}\n\n[skip ci]"
+          MESSAGE: "${{ steps.versionist.outputs.tag }}\n\nFlowzone-version-commit: true"
           TREE_SHA: ${{ steps.create_tree.outputs.sha }}
           PARENT_COMMIT_SHA: ${{ steps.git_describe.outputs.sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9


### PR DESCRIPTION
The version commit that versioned_source pushes carried [skip ci]. GitHub applies skip directives repository-wide rather than per-workflow, so it also silenced downstream pipelines that key deployments off pushes to the default branch (balena-os).

Replace the directive with a Flowzone-version-commit trailer and veto the re-entrant run inside Flowzone instead, so only Flowzone skips. Every job lists event_types in its needs, directly or transitively, which makes that job's if: the single point able to veto a whole run. Two independent signals, because either can be absent: the app's sender login covers any push the app makes, and the trailer covers the legacy FLOWZONE_TOKEN path where the pusher is a human account.

The veto is required rather than a cost saving. balena_publish, website_publish and custom_always gate only on `trusted`, which is true for any push, so a self-triggered run would push a second balena release and redeploy the Cloudflare Pages site.

Change-type: patch