### PR TITLE
harden: using variable interpolation `${{ in flowzone.yml...

### DIFF
--- a/flowzone.yml
+++ b/flowzone.yml
@@ -2400,6 +2400,7 @@ jobs:
           BAKE_JSON: "${{ steps.docker_bake.outputs.result }}"
           RUNS_ON: "${{ inputs.runs_on }}"
           DOCKER_RUNS_ON: "${{ inputs.docker_runs_on }}"
+          INVERT_TAGS: "${{ inputs.docker_invert_tags }}"
         with:
           result-encoding: json
           script: |
@@ -2427,7 +2428,7 @@ jobs:
             };
 
             // Add tag prefix/suffix based on docker_invert_tags
-            const invertTags = ${{ inputs.docker_invert_tags }};
+            const invertTags = process.env.INVERT_TAGS === 'true';
             matrix.include = matrix.include.map(item => {
               if (item.target !== 'default') {
                 if (invertTags) {
@@ -4436,9 +4437,9 @@ jobs:
               --draft=false
 
             if [[ ${{ inputs.github_prerelease }} =~ false ]]; then
-                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/${{ needs.versioned_source.outputs.tag }}" \
+                release_id="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${{ needs.versioned_source.outputs.tag }}" \
                   -H 'Accept: application/vnd.github+json' | jq -r .id)"
-                gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
+                gh api --method PATCH "/repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
                   -H 'Accept: application/vnd.github+json' \
                   -F make_latest=true
             fi


### PR DESCRIPTION
## Summary
Harden input handling in `flowzone.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.github-script-injection.github-script-injection |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.github-script-injection.github-script-injection` |
| **File** | `flowzone.yml:2405` |
| **Assessment** | Defensive hardening |

**Description**: Using variable interpolation `${{...}}` with `github` context data in a `actions/github-script`'s `script:` step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:` to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `flowzone.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
