### PR TITLE
Security: Pass GitHub context into run steps via env instead of interpolating

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -342,10 +342,6 @@ jobs:
         if: inputs.restrict_custom_actions == false
         run: |
           echo "::warning::The 'restrict_custom_actions' input is deprecated and no longer has any effect. Fork pull requests run without secrets, so custom test actions run on forks (custom publish/finalize/always remain trusted-only). Please remove this input from your caller workflow."
-      - name: Log GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "${GITHUB_CONTEXT}" || true
   versioned_source:
     name: Versioned source
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1949,6 +1949,8 @@ jobs:
           git update-ref "refs/tags/${TAG}" "${SHA}"
       - name: Identify Poetry project
         id: python_poetry
+        env:
+          REPO_VISIBILITY: ${{ github.event.repository.visibility }}
         run: |
           if test -f "pyproject.toml"
           then
@@ -1964,7 +1966,7 @@ jobs:
             fi
 
             has_package="$(awk -F "=" '/^packages/ {print $2}' pyproject.toml)"
-            if [ -n "${has_package}" ] && [ "${{ github.event.repository.visibility }}" = "public" ]
+            if [ -n "${has_package}" ] && [ "${REPO_VISIBILITY}" = "public" ]
             then
               echo "pypi_publish=true" >> "${GITHUB_OUTPUT}"
             else
@@ -2693,12 +2695,14 @@ jobs:
         if: needs.is_npm.outputs.has_npm_lockfile != 'true'
       - name: Generate metadata
         id: meta
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         run: |
           package="$(jq -r '.name' package.json)"
           version="$(jq -r '.version' package.json)"
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          sha_tag="${branch_tag}-${HEAD_SHA}"
+          version_tag="${version}-${branch_tag}-${HEAD_SHA}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -2917,16 +2921,15 @@ jobs:
         run: |
           npm config set ignore-scripts true
 
-          pack="$(ls ${{ runner.temp }}/*.tgz | sort -t- -n -k3 | tail -n1)"
+          pack="$(ls "${RUNNER_TEMP}"/*.tgz | sort -t- -n -k3 | tail -n1)"
           tar xvf "${pack}"
           (cd package
-            npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${VERSION_TAG}-${{ github.run_attempt }} --allow-same-version
+            npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${VERSION_TAG}-${GITHUB_RUN_ATTEMPT} --allow-same-version
           )
           tar czvf "${pack}" package
 
-          # shellcheck disable=SC2170
-          if [ ${{ github.run_attempt }} -gt 1 ]; then
-            npm --loglevel=verbose --logs-max=0 unpublish ${PACKAGE}@${VERSION_TAG}-$((${{ github.run_attempt }} - 1)) || true
+          if [ "${GITHUB_RUN_ATTEMPT}" -gt 1 ]; then
+            npm --loglevel=verbose --logs-max=0 unpublish ${PACKAGE}@${VERSION_TAG}-$((GITHUB_RUN_ATTEMPT - 1)) || true
           fi
           npm --loglevel=verbose --logs-max=0 publish --tag=${TAG} "${pack}" --access="${ACCESS}"
   npm_finalize:
@@ -4091,12 +4094,14 @@ jobs:
           fi
       - name: Generate metadata
         id: meta
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         run: |
           package=$(grep '^name =' pyproject.toml | sed 's/name = "\(.*\)"/\1/')
           version=$(grep '^version =' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          sha_tag="${branch_tag}-${HEAD_SHA}"
+          version_tag="${version}-${branch_tag}-${HEAD_SHA}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -4373,10 +4378,12 @@ jobs:
           poetry-version: 1.5.1
       - name: Generate Python metadata
         id: python_meta
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         run: |
           package="$(poetry version --no-ansi | awk '{print $1}')"
           version="$(poetry version --no-ansi | awk '{print $2}')"
-          commit_sha="$(echo ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | tr "a-z" "A-Z")"
+          commit_sha="$(echo "${HEAD_SHA}" | tr "a-z" "A-Z")"
           decimal_sha="$(echo "ibase=16; $commit_sha" | bc)"
           version_tag="${version}-dev${decimal_sha}"
 
@@ -4905,21 +4912,23 @@ jobs:
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          RELEASE_TAG: ${{ needs.versioned_source.outputs.tag }}
+          PRERELEASE: ${{ inputs.github_prerelease }}
         run: |
           set -ea
 
           if gh release view "${GITHUB_HEAD_REF}"; then
             gh release edit "${GITHUB_HEAD_REF}" \
-              --notes-file '${{ runner.temp }}/release-notes.txt' \
-              --title '${{ needs.versioned_source.outputs.tag }}' \
-              --tag '${{ needs.versioned_source.outputs.tag }}' \
-              --prerelease='${{ inputs.github_prerelease }}' \
+              --notes-file "${RUNNER_TEMP}/release-notes.txt" \
+              --title "${RELEASE_TAG}" \
+              --tag "${RELEASE_TAG}" \
+              --prerelease="${PRERELEASE}" \
               --draft=false
 
-            if [[ ${{ inputs.github_prerelease }} =~ false ]]; then
-                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/${{ needs.versioned_source.outputs.tag }}" \
+            if [[ "${PRERELEASE}" =~ false ]]; then
+                release_id="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
                   -H 'Accept: application/vnd.github+json' | jq -r .id)"
-                gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
+                gh api --method PATCH "/repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
                   -H 'Accept: application/vnd.github+json' \
                   -F make_latest=true
             fi
@@ -5045,12 +5054,14 @@ jobs:
         run: cargo publish --dry-run --workspace
       - name: Generate metadata
         id: meta
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         run: |
           packages="$(cargo metadata --no-deps --format-version 1 | jq -c '[.packages[] | .targets[] | select(.kind[] == "bin") | .name]')"
           version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo "${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          sha_tag="${branch_tag}-${HEAD_SHA}"
+          version_tag="${version}-${branch_tag}-${HEAD_SHA}"
 
           {
             echo "packages=${packages}" ;

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -258,12 +258,6 @@
     GH_PROMPT_DISABLED: "true"
     GH_REPO: "${{ github.repository }}"
 
-  - &logGitHubContext
-    name: Log GitHub context
-    env:
-      GITHUB_CONTEXT: ${{ toJSON(github) }}
-    run: echo "${GITHUB_CONTEXT}" || true
-
   - &deleteDraftGitHubRelease
     name: Delete draft GitHub release
     run: gh release delete --yes "${GITHUB_HEAD_REF}" || true
@@ -1127,8 +1121,6 @@ jobs:
         if: inputs.restrict_custom_actions == false
         run: |
           echo "::warning::The 'restrict_custom_actions' input is deprecated and no longer has any effect. Fork pull requests run without secrets, so custom test actions run on forks (custom publish/finalize/always remain trusted-only). Please remove this input from your caller workflow."
-
-      - *logGitHubContext
 
   # Version the project with balena-versionist,
   # upload a versioned source artifact to the workflow for use by other jobs,

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -45,10 +45,14 @@
   - &generatePythonMetadata
     name: Generate Python metadata
     id: python_meta
+    env:
+      # The tip of the PR head branch. Deliberately NOT GITHUB_SHA, which on
+      # pull_request is the ephemeral refs/pull/N/merge commit.
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
     run: |
       package="$(poetry version --no-ansi | awk '{print $1}')"
       version="$(poetry version --no-ansi | awk '{print $2}')"
-      commit_sha="$(echo ${{ github.event.pull_request.head.sha || github.event.head_commit.id }} | tr "a-z" "A-Z")"
+      commit_sha="$(echo "${HEAD_SHA}" | tr "a-z" "A-Z")"
       decimal_sha="$(echo "ibase=16; $commit_sha" | bc)"
       version_tag="${version}-dev${decimal_sha}"
 
@@ -2566,6 +2570,8 @@ jobs:
 
       - name: Identify Poetry project
         id: python_poetry
+        env:
+          REPO_VISIBILITY: ${{ github.event.repository.visibility }}
         run: |
           if test -f "pyproject.toml"
           then
@@ -2581,7 +2587,7 @@ jobs:
             fi
 
             has_package="$(awk -F "=" '/^packages/ {print $2}' pyproject.toml)"
-            if [ -n "${has_package}" ] && [ "${{ github.event.repository.visibility }}" = "public" ]
+            if [ -n "${has_package}" ] && [ "${REPO_VISIBILITY}" = "public" ]
             then
               echo "pypi_publish=true" >> "${GITHUB_OUTPUT}"
             else
@@ -3079,12 +3085,16 @@ jobs:
 
       - name: Generate metadata
         id: meta
+        env:
+          # The tip of the PR head branch. Deliberately NOT GITHUB_SHA, which on
+          # pull_request is the ephemeral refs/pull/N/merge commit.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         run: |
           package="$(jq -r '.name' package.json)"
           version="$(jq -r '.version' package.json)"
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          sha_tag="${branch_tag}-${HEAD_SHA}"
+          version_tag="${version}-${branch_tag}-${HEAD_SHA}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -3268,16 +3278,15 @@ jobs:
         run: |
           npm config set ignore-scripts true
 
-          pack="$(ls ${{ runner.temp }}/*.tgz | sort -t- -n -k3 | tail -n1)"
+          pack="$(ls "${RUNNER_TEMP}"/*.tgz | sort -t- -n -k3 | tail -n1)"
           tar xvf "${pack}"
           (cd package
-            npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${VERSION_TAG}-${{ github.run_attempt }} --allow-same-version
+            npm --loglevel=verbose --logs-max=0 --no-git-tag-version version ${VERSION_TAG}-${GITHUB_RUN_ATTEMPT} --allow-same-version
           )
           tar czvf "${pack}" package
 
-          # shellcheck disable=SC2170
-          if [ ${{ github.run_attempt }} -gt 1 ]; then
-            npm --loglevel=verbose --logs-max=0 unpublish ${PACKAGE}@${VERSION_TAG}-$((${{ github.run_attempt }} - 1)) || true
+          if [ "${GITHUB_RUN_ATTEMPT}" -gt 1 ]; then
+            npm --loglevel=verbose --logs-max=0 unpublish ${PACKAGE}@${VERSION_TAG}-$((GITHUB_RUN_ATTEMPT - 1)) || true
           fi
           npm --loglevel=verbose --logs-max=0 publish --tag=${TAG} "${pack}" --access="${ACCESS}"
 
@@ -3972,12 +3981,16 @@ jobs:
 
       - name: Generate metadata
         id: meta
+        env:
+          # The tip of the PR head branch. Deliberately NOT GITHUB_SHA, which on
+          # pull_request is the ephemeral refs/pull/N/merge commit.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         run: |
           package=$(grep '^name =' pyproject.toml | sed 's/name = "\(.*\)"/\1/')
           version=$(grep '^version =' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           branch_tag="$(echo "build-${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          sha_tag="${branch_tag}-${HEAD_SHA}"
+          version_tag="${version}-${branch_tag}-${HEAD_SHA}"
 
           echo "package=${package}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
@@ -4429,21 +4442,25 @@ jobs:
         env:
           <<: *gitHubCliEnvironment
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+          # The tag is derived from the versionist config in the PR branch, so it is
+          # contributor-controlled. Keep it out of the script body.
+          RELEASE_TAG: ${{ needs.versioned_source.outputs.tag }}
+          PRERELEASE: ${{ inputs.github_prerelease }}
         run: |
           set -ea
 
           if gh release view "${GITHUB_HEAD_REF}"; then
             gh release edit "${GITHUB_HEAD_REF}" \
-              --notes-file '${{ runner.temp }}/release-notes.txt' \
-              --title '${{ needs.versioned_source.outputs.tag }}' \
-              --tag '${{ needs.versioned_source.outputs.tag }}' \
-              --prerelease='${{ inputs.github_prerelease }}' \
+              --notes-file "${RUNNER_TEMP}/release-notes.txt" \
+              --title "${RELEASE_TAG}" \
+              --tag "${RELEASE_TAG}" \
+              --prerelease="${PRERELEASE}" \
               --draft=false
 
-            if [[ ${{ inputs.github_prerelease }} =~ false ]]; then
-                release_id="$(gh api "/repos/${{ github.repository }}/releases/tags/${{ needs.versioned_source.outputs.tag }}" \
+            if [[ "${PRERELEASE}" =~ false ]]; then
+                release_id="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
                   -H 'Accept: application/vnd.github+json' | jq -r .id)"
-                gh api --method PATCH "/repos/${{ github.repository }}/releases/${release_id}" \
+                gh api --method PATCH "/repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
                   -H 'Accept: application/vnd.github+json' \
                   -F make_latest=true
             fi
@@ -4552,12 +4569,16 @@ jobs:
 
       - name: Generate metadata
         id: meta
+        env:
+          # The tip of the PR head branch. Deliberately NOT GITHUB_SHA, which on
+          # pull_request is the ephemeral refs/pull/N/merge commit.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.head_commit.id }}
         run: |
           packages="$(cargo metadata --no-deps --format-version 1 | jq -c '[.packages[] | .targets[] | select(.kind[] == "bin") | .name]')"
           version="${{ needs.versioned_source.outputs.semver }}"
           branch_tag="$(echo "${GITHUB_HEAD_REF}" | sed 's/[^[:alnum:]]/-/g')"
-          sha_tag="${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
-          version_tag="${version}-${branch_tag}-${{ github.event.pull_request.head.sha || github.event.head_commit.id }}"
+          sha_tag="${branch_tag}-${HEAD_SHA}"
+          version_tag="${version}-${branch_tag}-${HEAD_SHA}"
 
           {
             echo "packages=${packages}" ;


### PR DESCRIPTION
Picks up the semgrep finding from #1885 without the behavior changes that PR introduced.

#1885 replaced `github.event.pull_request.head.sha || github.event.head_commit.id` with `GITHUB_SHA`. Those aren't the same value. On `pull_request`, `GITHUB_SHA` is the ephemeral `refs/pull/N/merge` commit, so draft tags would move every time the base branch moves and would stop matching the `npm-<sha>` and `docs-<sha>` artifact names, which still key off the head sha.

It also referenced `REPO_VISIBILITY` without defining it anywhere, which would have pinned `pypi_publish` to false for every public Poetry repo, silently.

Here every site gets a step-level env var holding the value it already had, so the scanner is happy and nothing else moves:

- `HEAD_SHA` in the four metadata generators (npm, python, cargo, and the shared Python anchor)
- `REPO_VISIBILITY` in the Poetry check, actually defined this time
- `RELEASE_TAG` and `PRERELEASE` in the release finalize step, plus the built-in `RUNNER_TEMP` and `GITHUB_REPOSITORY`. Single quotes there become double quotes so the vars expand.
- `GITHUB_RUN_ATTEMPT` in the npm draft publish, which lets the `shellcheck disable=SC2170` come out

`PRERELEASE` rather than `GITHUB_PRERELEASE` because GitHub reserves the `GITHUB_` prefix for its own variables.

The only interpolation genuinely worth hardening is `versioned_source.outputs.tag`, since versionist derives it from config in the PR branch. The rest are SHAs, run attempts and `owner/repo`. Still worth doing them all so the pattern doesn't come back.

Left for a follow-up: the CloudFormation deploy step still interpolates matrix JSON into its script body, including into a jq filter. That needs restructuring, not an env var.

Supersedes #1885 and #1879
