### PR TITLE
Add a job that warns when the caller workflow needs migrating

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1188,6 +1188,145 @@ jobs:
               ref: context.ref,
               sarif: zippedSarif,
             });
+  check_config:
+    name: Check config
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: 5
+    needs:
+      - event_types
+    if: |
+      needs.event_types.outputs.trusted == 'true' &&
+      github.event.action != 'closed' &&
+      !startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+    env:
+      LISTING_NAME: flowzonify-list.txt
+      REPORT_NAME: flowzonify-report.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        env:
+          NODE_VERSION: 24.19.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Check the caller workflow
+        continue-on-error: true
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+        env:
+          FLOWZONIFY_VERSION: 0.3.4
+        run: |
+          spec="flowzonify@${FLOWZONIFY_VERSION}"
+          npm exec --yes -- "${spec}" --list > "${RUNNER_TEMP}/${LISTING_NAME}"
+          npm exec --yes -- "${spec}" --json > "${RUNNER_TEMP}/${REPORT_NAME}"
+      - name: Report outstanding migrations
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const read = (name) =>
+              fs.readFileSync(path.join(process.env.RUNNER_TEMP, name), "utf8");
+
+            // `--list` prints each migration as its id followed by an indented description.
+            // The report names only ids, so the two are joined to make each warning readable
+            // on its own. Never fatal: without a listing the warnings fall back to bare ids.
+            let described = new Map();
+            try {
+              described = new Map(
+                [...read(process.env.LISTING_NAME).matchAll(/^(\S+)\n\s+(.+)$/gm)].map(
+                  ([, id, description]) => [id, description],
+                ),
+              );
+            } catch {
+              // No listing.
+            }
+
+            let report;
+            try {
+              report = JSON.parse(read(process.env.REPORT_NAME));
+            } catch (error) {
+              // Staying quiet here would be indistinguishable from a caller needing nothing.
+              core.warning(
+                `Could not check this repository's Flowzone caller workflow: ${error.message}`,
+              );
+              return;
+            }
+
+            // `files` is not optional in flowzonify's output. Defaulting it to empty would
+            // report a malformed run as a clean caller, which is the one thing this job must
+            // never do.
+            if (!Array.isArray(report.files)) {
+              core.warning(
+                "Could not check this repository's Flowzone caller workflow: the report listed no files.",
+              );
+              return;
+            }
+
+            // Annotations render as a flat list interleaved with other jobs', so each warning
+            // repeats the fix rather than relying on a summary to carry it.
+            const FIX = "Run `npx flowzonify` to apply it.";
+
+            for (const file of report.files) {
+              // Not a Flowzone caller.
+              if (file.status === "skipped") {
+                continue;
+              }
+
+              // `file=` has to be relative to the repository, or GitHub attaches the
+              // annotation to nothing.
+              const where = { file: path.relative(process.env.GITHUB_WORKSPACE, file.path) };
+
+              // The one status where silence would lie: the migrations could not be evaluated,
+              // so "nothing outstanding" is unknown rather than false. Covers both an
+              // unreadable caller workflow and a gate that turned the migrated result down,
+              // which differ in who has to act, so the detail is passed through.
+              if (file.status === "error") {
+                core.warning(
+                  "Could not determine outstanding Flowzone config migrations: " +
+                    (file.error || "no detail was reported"),
+                  where,
+                );
+                continue;
+              }
+
+              // Same reasoning one level down: a file with outstanding migrations and no
+              // `report` would produce no warnings at all.
+              if (!Array.isArray(file.report)) {
+                core.warning(
+                  "Could not determine outstanding Flowzone config migrations: the report named no migrations.",
+                  where,
+                );
+                continue;
+              }
+
+              for (const unit of file.report) {
+                // The transform ran and a gate declined this unit: it needs a human.
+                if (unit.status === "blocked") {
+                  core.warning(
+                    `${unit.id} needs a manual migration: ${unit.note || "no detail was reported"}`,
+                    where,
+                  );
+                  continue;
+                }
+                if (unit.status === "skip" || !file.changed) {
+                  continue;
+                }
+                // `note` is set for an advisory, and is more specific than the description.
+                const why = unit.note || described.get(unit.id);
+                core.warning(
+                  why ? `${unit.id}: ${why} ${FIX}` : `${unit.id} is outstanding. ${FIX}`,
+                  where,
+                );
+              }
+            }
   file_list:
     name: File list
     runs-on: ${{ fromJSON(inputs.runs_on) }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Reusable, opinionated, zero-conf workflows for GitHub actions
 - [Getting Started](#getting-started)
 - [Usage](#usage)
   - [Merging](#merging)
+  - [Config Migrations](#config-migrations)
   - [External Contributions](#external-contributions)
   - [Commit Message](#commit-message)
     - [Skipping Workflow Runs](#skipping-workflow-runs)
@@ -348,6 +349,20 @@ Avoid using **Squash and merge** or **Rebase and merge** as these methods will r
 This would prevent Flowzone from finding and finalizing existing draft artifacts.
 
 You can read more about the available merge methods [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github).
+
+### Config Migrations
+
+Flowzone's caller contract changes over time. A caller workflow that has drifted from it gets no other signal — nothing fails, and features quietly stop applying — so the `Check config` job reports the drift as warnings on every run.
+
+The job reports what [flowzonify](https://github.com/product-os/flowzonify) would change in your `.github/workflows/flowzone.yml`. It holds no token, cannot write to your repository, and is not part of the `All jobs` check, so it never gates a merge.
+
+To act on a warning, migrate your caller workflow yourself and review the diff:
+
+```console
+npx flowzonify
+```
+
+Some workflows cannot be migrated automatically — a customised `if:` on the Flowzone job, for instance. Those are reported as needing a manual migration, with the reason.
 
 ### External Contributions
 

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -1929,6 +1929,178 @@ jobs:
               sarif: zippedSarif,
             });
 
+  # Report, but never fix, outstanding migrations to this repository's own Flowzone caller
+  # workflow. The caller contract changes over time, and a caller that has drifted gets no
+  # other signal: nothing fails, features quietly stop applying.
+  #
+  # Deliberately absent from `all_jobs` needs: a drifted caller workflow is not a reason to
+  # block the change under review.
+  check_config:
+    name: Check config
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    timeout-minutes: 5
+    needs:
+      - event_types
+
+    # Trusted lanes only. Not for secrecy -- there is no secret here -- but because the step
+    # below resolves an npm dependency tree inside the checked-out working copy, which is
+    # attacker-controlled on a fork pull request. Nothing is lost: a fork contributor does not
+    # own the caller workflow and cannot act on the warning.
+    #
+    # Closed pull requests are skipped because nobody acts on that report, and tag pushes
+    # because they duplicate the default-branch push that produced the tag.
+    if: |
+      needs.event_types.outputs.trusted == 'true' &&
+      github.event.action != 'closed' &&
+      !startsWith(github.ref, 'refs/tags/')
+
+    # Only what actions/checkout needs to clone a private caller. Nothing here writes.
+    permissions:
+      contents: read
+
+    # Named here so the step that writes them and the step that reads them share one owner.
+    # `runner.temp` is not available to a job-level `env`, so the directory is joined at use.
+    env:
+      LISTING_NAME: flowzonify-list.txt
+      REPORT_NAME: flowzonify-report.json
+
+    steps:
+      # Deliberately no `<<: *checkoutAuth`, unlike every other checkout in this workflow:
+      # that anchor injects FLOWZONE_TOKEN, and this job holds no credential by design.
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      - *setupNode
+
+      # https://github.com/product-os/flowzonify
+      # Runs the real transform and throws the result away: `changed` is what says whether
+      # anything was outstanding, and `report[]` names each unit. The workspace is a throwaway
+      # checkout, so the write costs nothing and nothing downstream reads the file.
+      #
+      # continue-on-error absorbs the exit code: flowzonify exits non-zero for `blocked` and
+      # `error`, both of which are things to report rather than fail on, and it prints the
+      # report either way.
+      - name: Check the caller workflow
+        continue-on-error: true
+        shell: bash --noprofile --norc -eo pipefail -x {0}
+        env:
+          # renovate: datasource=npm depName=flowzonify
+          FLOWZONIFY_VERSION: 0.3.4
+        run: |
+          spec="flowzonify@${FLOWZONIFY_VERSION}"
+          npm exec --yes -- "${spec}" --list > "${RUNNER_TEMP}/${LISTING_NAME}"
+          npm exec --yes -- "${spec}" --json > "${RUNNER_TEMP}/${REPORT_NAME}"
+
+      # Annotations come from core.warning() rather than an echoed `::warning::` string,
+      # because core.warning escapes the message: a note containing a newline or a colon
+      # would otherwise truncate or corrupt the annotation.
+      - name: Report outstanding migrations
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            const read = (name) =>
+              fs.readFileSync(path.join(process.env.RUNNER_TEMP, name), "utf8");
+
+            // `--list` prints each migration as its id followed by an indented description.
+            // The report names only ids, so the two are joined to make each warning readable
+            // on its own. Never fatal: without a listing the warnings fall back to bare ids.
+            let described = new Map();
+            try {
+              described = new Map(
+                [...read(process.env.LISTING_NAME).matchAll(/^(\S+)\n\s+(.+)$/gm)].map(
+                  ([, id, description]) => [id, description],
+                ),
+              );
+            } catch {
+              // No listing.
+            }
+
+            let report;
+            try {
+              report = JSON.parse(read(process.env.REPORT_NAME));
+            } catch (error) {
+              // Staying quiet here would be indistinguishable from a caller needing nothing.
+              core.warning(
+                `Could not check this repository's Flowzone caller workflow: ${error.message}`,
+              );
+              return;
+            }
+
+            // `files` is not optional in flowzonify's output. Defaulting it to empty would
+            // report a malformed run as a clean caller, which is the one thing this job must
+            // never do.
+            if (!Array.isArray(report.files)) {
+              core.warning(
+                "Could not check this repository's Flowzone caller workflow: the report listed no files.",
+              );
+              return;
+            }
+
+            // Annotations render as a flat list interleaved with other jobs', so each warning
+            // repeats the fix rather than relying on a summary to carry it.
+            const FIX = "Run `npx flowzonify` to apply it.";
+
+            for (const file of report.files) {
+              // Not a Flowzone caller.
+              if (file.status === "skipped") {
+                continue;
+              }
+
+              // `file=` has to be relative to the repository, or GitHub attaches the
+              // annotation to nothing.
+              const where = { file: path.relative(process.env.GITHUB_WORKSPACE, file.path) };
+
+              // The one status where silence would lie: the migrations could not be evaluated,
+              // so "nothing outstanding" is unknown rather than false. Covers both an
+              // unreadable caller workflow and a gate that turned the migrated result down,
+              // which differ in who has to act, so the detail is passed through.
+              if (file.status === "error") {
+                core.warning(
+                  "Could not determine outstanding Flowzone config migrations: " +
+                    (file.error || "no detail was reported"),
+                  where,
+                );
+                continue;
+              }
+
+              // Same reasoning one level down: a file with outstanding migrations and no
+              // `report` would produce no warnings at all.
+              if (!Array.isArray(file.report)) {
+                core.warning(
+                  "Could not determine outstanding Flowzone config migrations: the report named no migrations.",
+                  where,
+                );
+                continue;
+              }
+
+              for (const unit of file.report) {
+                // The transform ran and a gate declined this unit: it needs a human.
+                if (unit.status === "blocked") {
+                  core.warning(
+                    `${unit.id} needs a manual migration: ${unit.note || "no detail was reported"}`,
+                    where,
+                  );
+                  continue;
+                }
+                if (unit.status === "skip" || !file.changed) {
+                  continue;
+                }
+                // `note` is set for an advisory, and is more specific than the description.
+                const why = unit.note || described.get(unit.id);
+                core.warning(
+                  why ? `${unit.id}: ${why} ${FIX}` : `${unit.id} is outstanding. ${FIX}`,
+                  where,
+                );
+              }
+            }
   # This job should be used as a universal and safe method of checking
   # which project files exist in order to skip other jobs entirely.
   # Eventually it should replace a bunch of the steps in the is_blah-type jobs.


### PR DESCRIPTION
Flowzone's caller contract changes over time, and a drifted caller gets no
signal today: nothing fails, features quietly stop applying. check_config runs
flowzonify against the caller's own flowzone.yml and warns per outstanding
migration. It holds no token, never gates a merge, and fixing it stays the
maintainer's move.

See: https://balena.fibery.io/Work/Improvement/Migration-PRs-open-themselves-4663

e.g.
<img width="1340" height="290" alt="image" src="https://github.com/user-attachments/assets/8aac5feb-5e42-4148-b95e-d35d560c8df7" />


