### PR TITLE
patch: Update cfn-lint version to 1.55.1 and Renovate

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -6166,7 +6166,9 @@ jobs:
       - name: Install cfn-lint
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cfn-lint==1.35.3
+          python -m pip install "cfn-lint==${CFN_LINT_VERSION}"
+        env:
+          CFN_LINT_VERSION: 1.55.1
       - name: Lint template
         run: |
           ignore_from_meta="$(cat <"${TEMPLATE_FILE}" | yq e .Metadata.cfn-lint.config.ignore_checks[] -)"

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -5302,7 +5302,10 @@ jobs:
       - name: Install cfn-lint
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cfn-lint==1.35.3
+          python -m pip install "cfn-lint==${CFN_LINT_VERSION}"
+        env:
+          # renovate: datasource=github-releases depName=aws-cloudformation/cfn-lint
+          CFN_LINT_VERSION: 1.55.1
 
       - name: Lint template
         run: |


### PR DESCRIPTION
> unblock https://github.com/balena-io/environment-production/pull/6905 as v1.35.x is too [old](https://github.com/balena-io/environment-production/actions/runs/32427005925/job/96614737860?pr=6905#step:19:26). 

https://balena.fibery.io/Work/Project/Capture-data-to-build-the-balena-reliability-pipeline-1422