### PR TITLE
Skip balena_publish and website_publish on internal-merge pushes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -4020,7 +4020,8 @@ jobs:
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
-      (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
+      (github.event_name != 'push' || needs.event_types.outputs.fork_merge == 'true' || needs.event_types.outputs.merged_pr == '')
       )
     strategy:
       fail-fast: false
@@ -4677,7 +4678,8 @@ jobs:
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() && needs.versioned_source.result == 'success' &&
       inputs.cloudflare_website != '' &&
-      (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
+      (github.event_name != 'push' || needs.event_types.outputs.fork_merge == 'true' || needs.event_types.outputs.merged_pr == '')
       )
     permissions:
       contents: read

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -4040,11 +4040,15 @@ jobs:
       - versioned_source
       - release_notes
     # allow some dependencies to be skipped
+    # skip the internal-merge push (the pull_request lane already published). A tag
+    # push, a direct push, and a fork merge still publish, because balena_publish has
+    # no finalize job to catch those lanes.
     if: |
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() &&
       needs.is_balena.result == 'success' &&
-      (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
+      (github.event_name != 'push' || needs.event_types.outputs.fork_merge == 'true' || needs.event_types.outputs.merged_pr == '')
       )
 
     strategy:
@@ -4356,12 +4360,15 @@ jobs:
       - python_test
       - versioned_source
     # allow some dependencies to be skipped
-    # skip unmerged closed PRs, allow all other events
+    # skip unmerged closed PRs, and skip the internal-merge push (the pull_request
+    # lane already published). A tag push, a direct push, and a fork merge still
+    # publish, because website_publish has no finalize job to catch those lanes.
     if: |
       needs.event_types.outputs.trusted == 'true' && (
       !failure() && !cancelled() && needs.versioned_source.result == 'success' &&
       inputs.cloudflare_website != '' &&
-      (github.event.action != 'closed' || github.event.pull_request.merged == true)
+      (github.event.action != 'closed' || github.event.pull_request.merged == true) &&
+      (github.event_name != 'push' || needs.event_types.outputs.fork_merge == 'true' || needs.event_types.outputs.merged_pr == '')
       )
 
     permissions:


### PR DESCRIPTION
On an internal PR merge, GitHub fires both a `pull_request `closed event and a push to the default branch. `balena_publish` and `website_publish` had no push-lane gate, so they published once on each lane. That is the duplicate release.

Gate both on `merged_pr` so only the internal-merge push skips. A tag push and a direct push both have an empty `merged_pr`, and a fork merge sets fork_merge, so all three still publish. `balena_publish` and `website_publish` have no finalize job, so they must keep firing on those lanes (docs/trust-boundary.md line 28).

`docker_publish` already skips the internal-merge push through `docker_test`, so it needs no change. The version-commit self-retrigger stays handled by the `event_types` veto, this gate does not touch that.

Change-type: patch