### PR TITLE
Verify submodule commits are on their declared .gitmodules branch

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -237,6 +237,11 @@ on:
         type: boolean
         required: false
         default: true
+      check_gitmodules_branches:
+        description: Require every .gitmodules submodule to declare a branch, and its pinned commit to be on it.
+        type: boolean
+        required: false
+        default: ${{ github.repository_owner == 'balena-os' }}
     outputs:
       cloudflare_deployment_url:
         description: Cloudflare Deployment URL
@@ -488,6 +493,42 @@ jobs:
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
           token: ${{ steps.checkout_token.outputs.token || secrets.FLOWZONE_TOKEN || github.token }}
           persist-credentials: false
+      - name: Check submodule branches
+        if: inputs.check_gitmodules_branches == true && steps.has_submodules.outputs.result == 'true'
+        run: |
+          failures=0
+
+          # One "submodule.<name>.path <path>" line per submodule.
+          submodules="$(git config -f .gitmodules --get-regexp '\.path$' || true)"
+
+          echo "::group::Submodules declared in .gitmodules"
+          echo "${submodules}"
+          echo "::endgroup::"
+
+          while IFS=' ' read -r key path; do
+            [ -z "${key}" ] && continue
+            submodule="${key#submodule.}"
+            submodule="${submodule%.path}"
+            branch="$(git config -f .gitmodules --get "submodule.${submodule}.branch" || true)"
+
+            if [ -z "${branch}" ]; then
+              echo "::error file=.gitmodules::Submodule '${submodule}' (path: ${path}) does not declare a branch"
+              failures=$((failures + 1))
+            elif ! pinned_sha="$(git -C "${path}" rev-parse HEAD 2>/dev/null)"; then
+              echo "::error file=.gitmodules::Submodule '${submodule}' (path: ${path}) was not initialized, cannot verify branch '${branch}'"
+              failures=$((failures + 1))
+            elif ! git -C "${path}" merge-base --is-ancestor "${pinned_sha}" "refs/remotes/origin/${branch}" 2>/dev/null; then
+              echo "::error file=.gitmodules::Submodule '${submodule}' (path: ${path}) is pinned to ${pinned_sha}, which is not on branch '${branch}' (or that branch does not exist on its remote)"
+              failures=$((failures + 1))
+            fi
+          done <<< "${submodules}"
+
+          if [ "${failures}" -gt 0 ]; then
+            echo "::error::${failures} submodule(s) failed .gitmodules branch validation (see errors above)"
+            exit 1
+          fi
+
+          echo "All submodule commits are on their declared .gitmodules branch."
       - name: Describe git state
         id: git_describe
         run: |

--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ jobs:
       # Required: false
       generate_sbom: true
 
+      # Require every .gitmodules submodule to declare a branch, and its pinned commit to be on
+      # it.
+      # Type: boolean
+      # Required: false
+      check_gitmodules_branches: ${{ github.repository_owner == 'balena-os' }}
+
 
 ```
 <!-- end usage -->

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -959,6 +959,11 @@ on:
         type: boolean
         required: false
         default: true
+      check_gitmodules_branches:
+        description: "Require every .gitmodules submodule to declare a branch, and its pinned commit to be on it."
+        type: boolean
+        required: false
+        default: "${{ github.repository_owner == 'balena-os' }}"
     outputs:
       cloudflare_deployment_url:
         description: "Cloudflare Deployment URL"
@@ -1261,6 +1266,47 @@ jobs:
           # fallback to an invalid ref if the checkout ref is undefined
           ref: ${{ github.sha || '¯\_(ツ)_/¯' }}
           <<: *checkoutAuth
+
+      # Require every submodule to declare a branch, and its pinned commit to be on it.
+      # Tools like Renovate can only manage a submodule correctly when they know which
+      # branch it tracks; left undeclared, they fall back to guessing one.
+      # Submodules were already fetched with full history above, so no extra fetch is needed.
+      - name: Check submodule branches
+        if: inputs.check_gitmodules_branches == true && steps.has_submodules.outputs.result == 'true'
+        run: |
+          failures=0
+
+          # One "submodule.<name>.path <path>" line per submodule.
+          submodules="$(git config -f .gitmodules --get-regexp '\.path$' || true)"
+
+          echo "::group::Submodules declared in .gitmodules"
+          echo "${submodules}"
+          echo "::endgroup::"
+
+          while IFS=' ' read -r key path; do
+            [ -z "${key}" ] && continue
+            submodule="${key#submodule.}"
+            submodule="${submodule%.path}"
+            branch="$(git config -f .gitmodules --get "submodule.${submodule}.branch" || true)"
+
+            if [ -z "${branch}" ]; then
+              echo "::error file=.gitmodules::Submodule '${submodule}' (path: ${path}) does not declare a branch"
+              failures=$((failures + 1))
+            elif ! pinned_sha="$(git -C "${path}" rev-parse HEAD 2>/dev/null)"; then
+              echo "::error file=.gitmodules::Submodule '${submodule}' (path: ${path}) was not initialized, cannot verify branch '${branch}'"
+              failures=$((failures + 1))
+            elif ! git -C "${path}" merge-base --is-ancestor "${pinned_sha}" "refs/remotes/origin/${branch}" 2>/dev/null; then
+              echo "::error file=.gitmodules::Submodule '${submodule}' (path: ${path}) is pinned to ${pinned_sha}, which is not on branch '${branch}' (or that branch does not exist on its remote)"
+              failures=$((failures + 1))
+            fi
+          done <<< "${submodules}"
+
+          if [ "${failures}" -gt 0 ]; then
+            echo "::error::${failures} submodule(s) failed .gitmodules branch validation (see errors above)"
+            exit 1
+          fi
+
+          echo "All submodule commits are on their declared .gitmodules branch."
 
       # The current commit sha is needed as the parent sha for the versioned commit
       # and/or as default tag & semver if versioning is disabled.


### PR DESCRIPTION
Some device repositories don't declare a branch in .gitmodules. When it's missing, Renovate doesn't know which branch we actually meant to track, and ends up following the submodule's default branch instead rather than the branch it's actually pinned to. So Renovate opens PR updates to latest default instead of the intended branch.

Add an opt-in check_gitmodules_branches input that fails if a submodule has no declared branch, or its pinned commit isn't on it. Lives inside versioned_source, right after the submodule checkout it already does.

Change-type: minor