### PR TITLE
Make .gitmodules check opt-in for balena-os

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -241,7 +241,7 @@ on:
         description: Require every .gitmodules submodule to declare a branch, and its pinned commit to be on it.
         type: boolean
         required: false
-        default: ${{ github.repository_owner == 'balena-os' }}
+        default: false
     outputs:
       cloudflare_deployment_url:
         description: Cloudflare Deployment URL

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ jobs:
       # it.
       # Type: boolean
       # Required: false
-      check_gitmodules_branches: ${{ github.repository_owner == 'balena-os' }}
+      check_gitmodules_branches: false
 
 
 ```

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -963,7 +963,7 @@ on:
         description: "Require every .gitmodules submodule to declare a branch, and its pinned commit to be on it."
         type: boolean
         required: false
-        default: "${{ github.repository_owner == 'balena-os' }}"
+        default: false
     outputs:
       cloudflare_deployment_url:
         description: "Cloudflare Deployment URL"


### PR DESCRIPTION
There are still too many submodules tracking default branches as intended that are not declared and have no requirement for this declaration to start enforcing it org-wide.

In the meantime, we can start opening PRs to declare all submodule branches without otherwise further blocking the pipelines.

Related-to: https://github.com/product-os/flowzone/pull/1905
Change-type: minor